### PR TITLE
Fixes #28874: Migrate to java-time offset and zoned date time 

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
@@ -6,8 +6,8 @@ import com.normation.inventory.services.core.ReadOnlySoftwareDAO
 import com.normation.inventory.services.core.WriteOnlySoftwareDAO
 import com.normation.utils.DateFormaterService
 import com.normation.zio.*
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import zio.*
 import zio.syntax.*
 
@@ -63,7 +63,7 @@ class SoftwareServiceImpl(
                                            dir.createDirectories()
                                            File(
                                              dir,
-                                             s"${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}-unreferenced-software-dns.txt"
+                                             s"${DateFormaterService.serializeOffsetDateTime(OffsetDateTime.now(ZoneOffset.UTC))}-unreferenced-software-dns.txt"
                                            )
                                          }
                                     _ <- IOResult.attempt {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AbstractScheduler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AbstractScheduler.scala
@@ -39,13 +39,16 @@ package com.normation.rudder.batch
 
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.domain.logger.ScheduledJobLogger
+import com.normation.utils.DateFormaterService.toJodaDateTime
+import java.time.Duration
+import java.time.OffsetDateTime
 import net.liftweb.actor.LAPinger
 import net.liftweb.actor.SpecializedLiftActor
 import net.liftweb.common.*
-import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.DurationInt
+import scala.jdk.DurationConverters.JavaDurationOps
+import scala.math.Ordered.orderingToOrdered
+import zio.durationInt
 
 // -----------------------------------------------------
 // Constants and private objects and classes
@@ -53,15 +56,16 @@ import scala.concurrent.duration.DurationInt
 
 sealed trait AbstractActorUpdateMessage
 object AbstractActorUpdateMessage {
-  case object StartUpdate                                                                    extends AbstractActorUpdateMessage
-  final case class UpdateResult[T](id: Long, start: DateTime, end: DateTime, result: Box[T]) extends AbstractActorUpdateMessage
+  case object StartUpdate extends AbstractActorUpdateMessage
+  final case class UpdateResult[T](id: Long, start: OffsetDateTime, end: OffsetDateTime, result: Box[T])
+      extends AbstractActorUpdateMessage
 }
 
 sealed trait UpdaterStates //states into wich the updater process can be
 //the process is idle
-case object IdleUpdater                                       extends UpdaterStates
+case object IdleUpdater                                             extends UpdaterStates
 //an update is currently running for the given nodes
-final case class StartProcessing(id: Long, started: DateTime) extends UpdaterStates
+final case class StartProcessing(id: Long, started: OffsetDateTime) extends UpdaterStates
 //the process gave a result
 
 /**
@@ -117,20 +121,23 @@ trait AbstractScheduler {
     private var updateId = 0L
     private var currentState: UpdaterStates = IdleUpdater
     private var onePending = false
+
+    extension (self: Duration) def display: String = self.toScala.toCoarsest.toString
+
     private val realUpdateInterval: Duration = {
       if (updateInterval < schedulerMinimumIntervalTime) {
         logger.warn(
-          s"Value '${updateInterval.toCoarsest}' for ${propertyName} is too small for [${displayName}] scheduler interval, using '${schedulerMinimumIntervalTime}'"
+          s"Value '${updateInterval.display}' for ${propertyName} is too small for [${displayName}] scheduler interval, using '${schedulerMinimumIntervalTime.display}'"
         )
         schedulerMinimumIntervalTime
       } else {
         if (updateInterval > schedulerMaximumIntervalTime) {
           logger.warn(
-            s"Value '${updateInterval.toCoarsest}' for ${propertyName} is too big for [${displayName}] scheduler interval, using '${schedulerMaximumIntervalTime}'"
+            s"Value '${updateInterval.display}' for ${propertyName} is too big for [${displayName}] scheduler interval, using '${schedulerMaximumIntervalTime.display}'"
           )
           schedulerMaximumIntervalTime
         } else {
-          logger.info(s"Starting [${displayName}] scheduler with a period of '${updateInterval.toCoarsest}'")
+          logger.info(s"Starting [${displayName}] scheduler with a period of '${updateInterval.display}'")
           updateInterval
         }
       }
@@ -146,7 +153,7 @@ trait AbstractScheduler {
           case IdleUpdater =>
             logger.debug(s"[${displayName}] Scheduled task starting")
             updateId = updateId + 1
-            TaskProcessor ! StartProcessing(updateId, new DateTime)
+            TaskProcessor ! StartProcessing(updateId, OffsetDateTime.now())
           case _: StartProcessing if (!onePending) =>
             logger.trace(s"Add a pending task for [${displayName}] scheduler")
             onePending = true
@@ -167,22 +174,24 @@ trait AbstractScheduler {
         LAPinger.schedule(this, AbstractActorUpdateMessage.StartUpdate, realUpdateInterval.toMillis)
 
         // log some information
-        val format = ISODateTimeFormat.dateTimeNoMillis()
+        val format         = ISODateTimeFormat.dateTimeNoMillis()
+        val startFormatted = start.toJodaDateTime.toString(format)
+        val endFormatted   = end.toJodaDateTime.toString(format)
 
         result match {
           case e: EmptyBox =>
             val error = {
-              (e ?~! s"Error when executing [${displayName}] scheduler task started at ${start.toString(format)}, ended at ${end
-                  .toString(format)}.")
+              (e ?~! s"Error when executing [${displayName}] scheduler task started at ${startFormatted}, ended at ${endFormatted}.")
             }
             logger.error(error.messageChain)
           case Full(x) =>
-            val executionTimeInMs = end.getMillis() - start.getMillis()
-            logger.debug(s"[${displayName}] Scheduled task finished in ${executionTimeInMs} ms (started at ${start
-                .toString(format)}, finished at ${end.toString(format)})")
-            if (executionTimeInMs >= updateInterval.toMillis) {
+            val executionTime = java.time.Duration.between(start, end)
+            logger.debug(
+              s"[${displayName}] Scheduled task finished in ${executionTime.toMillis} ms (started at ${startFormatted}, finished at ${endFormatted})"
+            )
+            if (executionTime >= updateInterval) {
               ApplicationLogger.warn(
-                s"[${displayName}] Task frequency is set too low! Last task took ${executionTimeInMs} ms but tasks are scheduled every ${updateInterval.toMillis} ms. Adjust ${propertyName} if this problem persists."
+                s"[${displayName}] Task frequency is set too low! Last task took ${executionTime.toMillis} ms but tasks are scheduled every ${updateInterval.toMillis} ms. Adjust ${propertyName} if this problem persists."
               )
             }
         }
@@ -200,9 +209,14 @@ trait AbstractScheduler {
           try {
             val result = executeTask(processId)
 
-            if (updateManager != null)
-              updateManager ! AbstractActorUpdateMessage.UpdateResult(processId, startTime, new DateTime, result)
-            else this ! StartProcessing(processId, startTime)
+            if (updateManager != null) {
+              updateManager ! AbstractActorUpdateMessage.UpdateResult(
+                id = processId,
+                start = startTime,
+                end = OffsetDateTime.now(),
+                result = result
+              )
+            } else this ! StartProcessing(id = processId, started = startTime)
           } catch {
             case e: Throwable =>
               e match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
@@ -45,8 +45,7 @@ import com.normation.utils.CronParser.*
 import com.normation.utils.DateFormaterService
 import com.normation.zio.*
 import cron4s.CronExpr
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import java.time.Duration
 import zio.*
 
 /**
@@ -85,17 +84,16 @@ class CleanupUsers(
    *
    */
   val cleanup: UIO[Unit] = for {
-    t0   <- currentTimeMillis
-    d     = new DateTime(t0, DateTimeZone.UTC)
-    trace = EventTrace(RudderEventActor, d, _)
-    _    <-
+    start <- currentOffsetDateTimeUTC
+    trace  = EventTrace(RudderEventActor, start, _)
+    _     <-
       // disable current users known not to be admin
       getNonAdminUserIds
         .flatMap(userIds => {
           userRepository
             .disable(
               userIds = userIds,
-              notLoggedSince = Some(d.minus(disableInactive.toMillis)),
+              notLoggedSince = Some(start.minus(disableInactive)),
               excludeFromOrigin = Nil,
               trace = trace(s"User was inactive since last '${disableInactive.render}'")
             )
@@ -113,55 +111,54 @@ class CleanupUsers(
               .unit
           }
         )
-    _    <- userRepository
-              .delete(
-                userIds = Nil,
-                notLoggedSince = Some(d.minus(deleteInactive.toMillis)),
-                excludeFromOrigin = localBackends,
-                initialStatus = Some(UserStatus.Disabled),
-                trace = trace(s"User was inactive since last '${deleteInactive.render}")
-              )
-              .foldZIO(
-                err => logger.error(s"Error when deleting user accounts inactive since '${deleteInactive.render}': ${err.fullMsg}"),
-                deletedUsers => {
-                  ZIO
-                    .unless(deletedUsers.isEmpty)(
-                      logger.info(s"Following users status changed from 'disabled' to 'deleted': '${deletedUsers.mkString("', '")}'")
-                    )
-                    .unit
-                }
-              )
-    _    <- userRepository
-              .purge(
-                userIds = Nil,
-                deletedSince = Some(d.minus(purgeDeleted.toMillis)),
-                excludeFromOrigin = Nil,
-                trace = trace(s"User is purged definitively '${purgeDeleted.render}' after being deleted")
-              )
-              .foldZIO(
-                err => logger.error(s"Error when purging user accounts deleted since '${purgeDeleted.render}': ${err.fullMsg}"),
-                purgedUsers => {
-                  ZIO
-                    .unless(purgedUsers.isEmpty)(
-                      logger.info(
-                        s"Users were purged from the database because they were configured to be purged ${purgeDeleted.render} after deletion. Users list is : '${purgedUsers
-                            .mkString("', '")}'"
-                      )
-                    )
-                    .unit
-                }
-              )
-    dos   = d.minus(purgeSessions.toMillis)
-    _    <-
+    _     <- userRepository
+               .delete(
+                 userIds = Nil,
+                 notLoggedSince = Some(start.minus(deleteInactive)),
+                 excludeFromOrigin = localBackends,
+                 initialStatus = Some(UserStatus.Disabled),
+                 trace = trace(s"User was inactive since last '${deleteInactive.render}")
+               )
+               .foldZIO(
+                 err => logger.error(s"Error when deleting user accounts inactive since '${deleteInactive.render}': ${err.fullMsg}"),
+                 deletedUsers => {
+                   ZIO
+                     .unless(deletedUsers.isEmpty)(
+                       logger.info(s"Following users status changed from 'disabled' to 'deleted': '${deletedUsers.mkString("', '")}'")
+                     )
+                     .unit
+                 }
+               )
+    _     <- userRepository
+               .purge(
+                 userIds = Nil,
+                 deletedSince = Some(start.minus(purgeDeleted)),
+                 excludeFromOrigin = Nil,
+                 trace = trace(s"User is purged definitively '${purgeDeleted.render}' after being deleted")
+               )
+               .foldZIO(
+                 err => logger.error(s"Error when purging user accounts deleted since '${purgeDeleted.render}': ${err.fullMsg}"),
+                 purgedUsers => {
+                   ZIO
+                     .unless(purgedUsers.isEmpty)(
+                       logger.info(
+                         s"Users were purged from the database because they were configured to be purged ${purgeDeleted.render} after deletion. Users list is : '${purgedUsers
+                             .mkString("', '")}'"
+                       )
+                     )
+                     .unit
+                 }
+               )
+    _     <-
       userRepository
-        .deleteOldSessions(olderThan = dos) // success is already logged
+        .deleteOldSessions(olderThan = start.minus(purgeSessions)) // success is already logged
         .catchAll(err => {
           logger.error(
-            s"Error when purging user sessions older than '${DateFormaterService.serialize(d)}': ${err.fullMsg}"
+            s"Error when purging user sessions older than '${DateFormaterService.serializeOffsetDateTime(start)}': ${err.fullMsg}"
           )
         })
-    t1   <- currentTimeMillis
-    _    <- logger.info(s"Cleaning user accounts and sessions performed in ${Duration.fromMillis(t1 - t0).render}")
+    end   <- Clock.instant
+    _     <- logger.info(s"Cleaning user accounts and sessions performed in ${Duration.between(start, end).render}")
   } yield ()
 
   // Must not fail.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/FetchNodeExecutions.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/FetchNodeExecutions.scala
@@ -38,9 +38,9 @@
 package com.normation.rudder.batch
 
 import com.normation.rudder.reports.execution.ReportsExecutionService
+import java.time.Duration
 import net.liftweb.common.Box
 import net.liftweb.util.Helpers.tryo
-import scala.concurrent.duration.Duration
 
 /**
  * That batch scheduler periodically store Nodes executions.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignDateScheduler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignDateScheduler.scala
@@ -40,7 +40,16 @@ package com.normation.rudder.campaigns
 import cats.implicits.*
 import com.normation.errors.*
 import com.normation.utils.DateFormaterService
-import org.joda.time.*
+import com.normation.utils.DateFormaterService.JavaTimeToJoda
+import com.normation.utils.DateFormaterService.toOffsetDateTime
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
+import java.time.temporal.TemporalAdjusters.dayOfWeekInMonth
+import org.joda.time.DateTime
+import scala.math.Ordered.orderingToOrdered
 
 /*
  * This object contains the logic to compute campaign event dates.
@@ -48,31 +57,40 @@ import org.joda.time.*
  */
 object CampaignDateScheduler {
 
-  implicit class DateTimeTzOps(date: DateTime) {
-    def adjustScheduleTimeZone(optTimeZone: Option[ScheduleTimeZone])(implicit defaultTz: DateTimeZone): DateTime = {
-      optTimeZone.flatMap(_.toDateTimeZone) match {
+  extension (date: OffsetDateTime) {
+    def adjustScheduleTimeZone(optTimeZone: Option[ScheduleTimeZone])(implicit defaultTz: ZoneId): ZonedDateTime = {
+      optTimeZone.flatMap(_.toZoneId) match {
         // no schedule time zone (or invalid one) means the default one should be used
-        case None             => date.withZone(defaultTz)
-        case Some(scheduleTz) => date.withZone(scheduleTz)
+        case None             => date.atZoneSameInstant(defaultTz)
+        case Some(scheduleTz) => date.atZoneSameInstant(scheduleTz)
       }
     }
   }
 
-  private def nextDateFromDayTime(date: DateTime, start: DayTime): DateTime = {
-    (if (
-       date.getDayOfWeek > start.day.value
-       || (date.getDayOfWeek == start.day.value && date.getHourOfDay > start.realHour)
-       || (date.getDayOfWeek == start.day.value && date.getHourOfDay == start.realHour && date.getMinuteOfHour > start.realMinute)
-     ) {
-       date.plusWeeks(1)
-     } else {
-       date
-     })
-      .withDayOfWeek(start.day.value)
-      .withHourOfDay(start.realHour)
-      .withMinuteOfHour(start.realMinute)
-      .withSecondOfMinute(0)
-      .withMillisOfSecond(0)
+  extension (self: ZonedDateTime)
+    def withTime(time: Time): ZonedDateTime = {
+      self
+        .withHour(time.realHour)
+        .withMinute(time.realMinute)
+        .truncatedTo(ChronoUnit.MINUTES)
+    }
+
+  private def nextDateFromDayTime(date: ZonedDateTime, start: DayTime): ZonedDateTime = {
+    if (
+      date.getDayOfWeek > start.day.toJavaTime
+      || (date.getDayOfWeek == start.day.toJavaTime && date.getHour > start.realHour)
+      || (date.getDayOfWeek == start.day.toJavaTime && date.getHour == start.realHour && date.getMinute > start.realMinute)
+    ) {
+      date
+        .plusWeeks(1)
+        .`with`(TemporalAdjusters.previousOrSame(start.day.toJavaTime))
+        .withTime(start.asTime)
+    } else {
+      date
+        .`with`(TemporalAdjusters.nextOrSame(start.day.toJavaTime))
+        .withTime(start.asTime)
+    }
+
   }
 
   def nextCampaignDate(
@@ -80,7 +98,7 @@ object CampaignDateScheduler {
       date:     DateTime
   ): PureResult[Option[(DateTime, DateTime)]] = {
     // Schedule needs to be adjusted to current server timezone, not to the one from the base schedule date
-    implicit val currentTz: DateTimeZone = DateTimeZone.getDefault()
+    given currentTz: ZoneId = ZoneId.systemDefault()
     schedule match {
       case OneShot(start, end) =>
         if (start.isBefore(end)) {
@@ -90,98 +108,63 @@ object CampaignDateScheduler {
             None.asRight
           }
         } else {
-
           Inconsistency(s"Cannot schedule a one shot event if end (${DateFormaterService
               .getDisplayDate(end)}) date is before start date (${DateFormaterService.getDisplayDate(start)})").asLeft
         }
 
       case Daily(start, end, tz) =>
-        val scheduleInitialDate = date.adjustScheduleTimeZone(tz)
+        val scheduleInitialDate = date.toOffsetDateTime.adjustScheduleTimeZone(tz)
         val startDate           = {
-          (if (
-             scheduleInitialDate
-               .getHourOfDay() > start.realHour || (scheduleInitialDate.getHourOfDay() == start.realHour && scheduleInitialDate
-               .getMinuteOfHour() > start.realMinute)
-           ) {
-             scheduleInitialDate.plusDays(1)
-           } else {
-             scheduleInitialDate
-           })
-            .withHourOfDay(start.realHour)
-            .withMinuteOfHour(start.realMinute)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0)
+          if (
+            scheduleInitialDate.getHour > start.realHour ||
+            (scheduleInitialDate.getHour == start.realHour && scheduleInitialDate.getMinute > start.realMinute)
+          ) {
+            scheduleInitialDate.plusDays(1).withTime(start)
+          } else {
+            scheduleInitialDate.withTime(start)
+          }
         }
 
         val endDate = {
-          (if (end.realHour < start.realHour || (end.realHour == start.realHour && end.realMinute < start.realMinute)) {
-             startDate.plusDays(1)
-           } else {
-             startDate
-           }).withHourOfDay(end.realHour).withMinuteOfHour(end.realMinute).withSecondOfMinute(0).withMillisOfSecond(0)
+          if (end.realHour < start.realHour || (end.realHour == start.realHour && end.realMinute < start.realMinute)) {
+            startDate.plusDays(1).withTime(end)
+          } else {
+            startDate.withTime(end)
+          }
         }
 
-        Some((startDate, endDate)).asRight
+        Some((startDate.toJoda, endDate.toJoda)).asRight
 
       case WeeklySchedule(start, end, tz) =>
-        val scheduleInitialDate = date.adjustScheduleTimeZone(tz)
+        val scheduleInitialDate = date.toOffsetDateTime.adjustScheduleTimeZone(tz)
         val startDate           = nextDateFromDayTime(scheduleInitialDate, start)
         val endDate             = nextDateFromDayTime(startDate, end)
 
-        Some((startDate, endDate)).asRight
+        Some((startDate.toJoda, endDate.toJoda)).asRight
 
       case MonthlySchedule(position, start, end, tz) =>
-        val scheduleInitialDate  = date.adjustScheduleTimeZone(tz)
-        val realHour             = start.realHour
-        val realMinutes          = start.realMinute
-        val day                  = start.day
-        def base(date: DateTime) = (position match {
-          case First      =>
-            val t = date.withDayOfMonth(1).withDayOfWeek(day.value)
-            if ((t.getYear == date.getYear && t.getMonthOfYear < date.getMonthOfYear) || t.getYear + 1 == date.getYear) {
-              t.plusWeeks(1)
-            } else {
-              t
-            }
-          case Second     =>
-            val t = date.withDayOfMonth(1).withDayOfWeek(day.value)
-            if ((t.getYear == date.getYear && t.getMonthOfYear < date.getMonthOfYear) || t.getYear + 1 == date.getYear) {
-              t.plusWeeks(2)
-            } else {
-              t.plusWeeks(1)
-            }
-          case Third      =>
-            val t = date.withDayOfMonth(1).withDayOfWeek(day.value)
-            if ((t.getYear == date.getYear && t.getMonthOfYear < date.getMonthOfYear) || t.getYear + 1 == date.getYear) {
-              t.plusWeeks(3)
-            } else {
-              t.plusWeeks(2)
-            }
-          case Last       =>
-            val t = date.plusMonths(1).withDayOfMonth(1).withDayOfWeek(day.value)
-            if ((t.getYear == date.getYear && t.getMonthOfYear > date.getMonthOfYear) || t.getYear == date.getYear + 1) {
-              t.minusWeeks(1)
-            } else {
-              t
-            }
-          case SecondLast =>
-            val t = date.plusMonths(1).withDayOfMonth(1).withDayOfWeek(day.value)
-            if ((t.getYear == date.getYear && t.getMonthOfYear > date.getMonthOfYear) || t.getYear == date.getYear + 1) {
-              t.minusWeeks(2)
-            } else {
-              t.minusWeeks(1)
-            }
-        }).withHourOfDay(realHour).withMinuteOfHour(realMinutes).withSecondOfMinute(0).withMillisOfSecond(0)
-        val currentMonthStart    = base(scheduleInitialDate)
-        val startDate            = {
-          if (scheduleInitialDate.isAfter(currentMonthStart)) {
-            base(scheduleInitialDate.plusMonths(1))
-          } else {
-            currentMonthStart
-          }
+        val scheduleInitialDate = date.toOffsetDateTime.adjustScheduleTimeZone(tz)
+
+        val ordinalForDayOfWeekInMonth = position match {
+          case First      => 1
+          case Second     => 2
+          case Third      => 3
+          case Last       => -1
+          case SecondLast => -2
         }
-        val endDate              = nextDateFromDayTime(startDate, end)
-        Some((startDate, endDate)).asRight
+
+        def computeMonthStart(date: ZonedDateTime) = date
+          .`with`(dayOfWeekInMonth(ordinalForDayOfWeekInMonth, start.day.toJavaTime))
+          .withTime(start.asTime)
+
+        val currentMonthStart = computeMonthStart(scheduleInitialDate)
+        val startDate         = if (scheduleInitialDate.isAfter(currentMonthStart)) {
+          computeMonthStart(scheduleInitialDate.plusMonths(1))
+        } else {
+          currentMonthStart
+        }
+        val endDate           = nextDateFromDayTime(startDate, end)
+        Some((startDate.toJoda, endDate.toJoda)).asRight
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/DataTypes.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/DataTypes.scala
@@ -47,6 +47,7 @@ import java.time.Instant
 import java.time.ZoneId
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
+import scala.util.Try
 import zio.json.*
 import zio.json.enumeratum.*
 
@@ -202,6 +203,19 @@ case object Sunday extends DayOfWeek {
   val value = 7
 }
 
+extension (self: DayOfWeek)
+  def toJavaTime: java.time.DayOfWeek = {
+    self match {
+      case Monday    => java.time.DayOfWeek.MONDAY
+      case Tuesday   => java.time.DayOfWeek.TUESDAY
+      case Wednesday => java.time.DayOfWeek.WEDNESDAY
+      case Thursday  => java.time.DayOfWeek.THURSDAY
+      case Friday    => java.time.DayOfWeek.FRIDAY
+      case Saturday  => java.time.DayOfWeek.SATURDAY
+      case Sunday    => java.time.DayOfWeek.SUNDAY
+    }
+  }
+
 case class Time(hour: Int, minute: Int) {
   val realHour:   Int = hour   % 24
   val realMinute: Int = minute % 60
@@ -212,8 +226,9 @@ case class DayTime(
     hour:   Int,
     minute: Int
 ) {
-  val realHour:   Int = hour   % 24
-  val realMinute: Int = minute % 60
+  val realHour:   Int  = hour   % 24
+  val realMinute: Int  = minute % 60
+  def asTime:     Time = Time(hour, minute)
 }
 
 case class ScheduleTimeZone(
@@ -223,6 +238,7 @@ case class ScheduleTimeZone(
     try { Option(DateTimeZone.forID(id)) }
     catch { case _: Throwable => None }
   }
+  def toZoneId:       Option[ZoneId]       = Try(ZoneId.of(id)).toOption
 }
 object ScheduleTimeZone                 {
   def parse(s: String): Either[String, ScheduleTimeZone] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
@@ -107,7 +107,7 @@ class CampaignSerializer {
 
 object CampaignSerializer {
   implicit val idEncoder:               JsonEncoder[CampaignId]              = JsonEncoder[String].contramap(_.value)
-  implicit val dateTime:                JsonEncoder[DateTime]                = JsonEncoder[String].contramap(DateFormaterService.serialize)
+  implicit val dateTime:                JsonEncoder[DateTime]                = DateFormaterService.json.encoderDateTime
   implicit val dayOfWeek:               JsonEncoder[DayOfWeek]               = JsonEncoder[Int].contramap(_.value)
   implicit val monthlySchedulePosition: JsonEncoder[MonthlySchedulePosition] = JsonEncoder[Int].contramap(s => {
     s match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -63,8 +63,8 @@ import com.normation.zio.*
 import java.io.InputStream
 import java.nio.file.NoSuchFileException
 import java.security.PublicKey as JavaSecPubKey
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import org.joda.time.Duration
 import org.joda.time.format.PeriodFormat
 import scala.annotation.nowarn
@@ -442,7 +442,7 @@ class InventoryMover(
    */
   def writeErrorLogFile(failedInventoryPath: File, result: InventoryProcessStatus): UIO[Unit] = {
     import com.normation.rudder.inventory.StatusLog.*
-    val date       = DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))
+    val date       = DateFormaterService.serializeOffsetDateTime(OffsetDateTime.now(ZoneOffset.UTC))
     val rejectPath = failedInventoryPath.pathAsString + s".reject-${date}.log"
 
     // this must never lead to a bubbling failure

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
@@ -48,6 +48,7 @@ import com.normation.utils.DateFormaterService
 import enumeratum.*
 import io.scalaland.chimney.Transformer
 import java.security.SecureRandom
+import java.time.OffsetDateTime
 import org.joda.time.DateTime
 import zio.json.*
 import zio.json.ast.Json
@@ -229,7 +230,7 @@ object UserStatus extends Enum[UserStatus] {
   }
 }
 
-final case class EventTrace(actor: EventActor, actionDate: DateTime, reason: String = "")
+final case class EventTrace(actor: EventActor, actionDate: OffsetDateTime, reason: String = "")
 
 /*
  * Track changes in Status.
@@ -243,12 +244,12 @@ final case class StatusHistory(status: UserStatus, trace: EventTrace)
  */
 case class UserInfo(
     id:            String,
-    creationDate:  DateTime,
+    creationDate:  OffsetDateTime,
     status:        UserStatus,
     managedBy:     String,
     name:          Option[String],
     email:         Option[String],
-    lastLogin:     Option[DateTime],
+    lastLogin:     Option[OffsetDateTime],
     statusHistory: List[StatusHistory],
     otherInfo:     Json.Obj
 )
@@ -265,12 +266,12 @@ final case class SessionId(value: String)
 case class UserSession(
     userId:       String,
     sessionId:    SessionId,
-    creationDate: DateTime,
+    creationDate: OffsetDateTime,
     authMethod:   String,
     permissions:  List[String],
     authz:        List[String],
     tenants:      Option[String],
-    endDate:      Option[DateTime],
+    endDate:      Option[OffsetDateTime],
     endCause:     Option[String]
 ) {
   def isOpen: Boolean = endDate.isEmpty

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -51,7 +51,7 @@ import doobie.free.connection.unit as connectionUnit
 import doobie.implicits.*
 import doobie.postgres.implicits.*
 import doobie.util.invariant.UnexpectedContinuation
-import org.joda.time.DateTime
+import java.time.OffsetDateTime
 import zio.*
 import zio.interop.catz.*
 import zio.json.ast.*
@@ -74,15 +74,15 @@ trait UserRepository {
       tenants:           String, // this is the serialisation of tenants (ie nodePerms.value)
       sessionId:         SessionId,
       authenticatorName: String,
-      date:              DateTime
+      date:              OffsetDateTime
   ): IOResult[Unit]
 
-  def logCloseSession(userId: String, date: DateTime, cause: String): IOResult[Unit]
+  def logCloseSession(userId: String, date: OffsetDateTime, cause: String): IOResult[Unit]
 
   /*
    * Close all opened sessions (typically for when rudder restart)
    */
-  def closeAllOpenSession(endDate: DateTime, endCause: String): IOResult[Unit]
+  def closeAllOpenSession(endDate: OffsetDateTime, endCause: String): IOResult[Unit]
 
   /*
    * Get the last previous session for user
@@ -93,7 +93,7 @@ trait UserRepository {
   /*
    * Delete session that are older than the given date
    */
-  def deleteOldSessions(olderThan: DateTime): IOResult[Unit]
+  def deleteOldSessions(olderThan: OffsetDateTime): IOResult[Unit]
 
   /*
    * Get users created by the given authenticator
@@ -147,7 +147,7 @@ trait UserRepository {
    */
   def disable(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       trace:             EventTrace
   ): IOResult[List[String]]
@@ -175,7 +175,7 @@ trait UserRepository {
    */
   def delete(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       initialStatus:     Option[UserStatus],
       trace:             EventTrace
@@ -200,7 +200,7 @@ trait UserRepository {
    */
   def purge(
       userIds:           List[String],
-      deletedSince:      Option[DateTime],
+      deletedSince:      Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       trace:             EventTrace
   ): IOResult[List[String]]
@@ -339,23 +339,33 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
       tenants:           String,
       sessionId:         SessionId,
       authenticatorName: String,
-      date:              DateTime
+      date:              OffsetDateTime
   ): IOResult[Unit] = {
     sessionBase.update(
-      UserSession(userId, sessionId, date, authenticatorName, permissions.sorted, authz.sorted, Some(tenants), None, None) :: _
+      UserSession(
+        userId = userId,
+        sessionId = sessionId,
+        creationDate = date,
+        authMethod = authenticatorName,
+        permissions = permissions.sorted,
+        authz = authz.sorted,
+        tenants = Some(tenants),
+        endDate = None,
+        endCause = None
+      ) :: _
     ) *>
     userBase.update(_.map { case (k, v) => if (k == userId) (k, v.modify(_.lastLogin).setTo(Some(date))) else (k, v) })
   }
 
-  private def closeSession(userSession: UserSession, endDate: DateTime, endCause: String): UserSession = {
+  private def closeSession(userSession: UserSession, endDate: OffsetDateTime, endCause: String): UserSession = {
     userSession.modify(_.endDate).setTo(Some(endDate)).modify(_.endCause).setTo(Some(endCause))
   }
 
-  override def closeAllOpenSession(endDate: DateTime, endCause: String): IOResult[Unit] = {
+  override def closeAllOpenSession(endDate: OffsetDateTime, endCause: String): IOResult[Unit] = {
     sessionBase.update(_.map(s => if (s.endDate.isEmpty) closeSession(s, endDate, endCause) else s))
   }
 
-  override def logCloseSession(userId: String, date: DateTime, cause: String): IOResult[Unit] = {
+  override def logCloseSession(userId: String, date: OffsetDateTime, cause: String): IOResult[Unit] = {
     sessionBase.update(_.map(s => if (s.userId == userId) closeSession(s, date, cause) else s))
   }
 
@@ -364,7 +374,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
     sessionBase.get.map(_.find(s => s.userId == userId && (!closedSessionsOnly || s.endDate.isDefined)))
   }
 
-  override def deleteOldSessions(olderThan: DateTime): IOResult[Unit] = {
+  override def deleteOldSessions(olderThan: OffsetDateTime): IOResult[Unit] = {
     sessionBase.update(_.collect { case session if (session.creationDate.isAfter(olderThan)) => session })
   }
 
@@ -420,7 +430,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
   // predicates to purge user, ie return true if the user is to be purged
   private def predicateUser(u: UserInfo, ids: List[String]) = ids.contains(u.id)
 
-  private def predicateLogDate(u: UserInfo, date: Option[DateTime]) = {
+  private def predicateLogDate(u: UserInfo, date: Option[OffsetDateTime]) = {
     (date, u.lastLogin) match {
       case (None, _)                 => false
       case (Some(limit), None)       => u.creationDate.isBefore(limit)
@@ -428,7 +438,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
     }
   }
 
-  private def predicateDeletedSince(u: UserInfo, date: Option[DateTime]) = {
+  private def predicateDeletedSince(u: UserInfo, date: Option[OffsetDateTime]) = {
     u.statusHistory match { // only deleted get purged with that filter
       case StatusHistory(UserStatus.Deleted, EventTrace(_, d, _)) :: _ =>
         date match {
@@ -452,7 +462,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
 
   override def disable(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       trace:             EventTrace
   ): IOResult[List[String]] = {
@@ -461,10 +471,8 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
       val m          = users.map {
         case (k, u) =>
           if (
-            (predicateUser(u, userIds) || predicateLogDate(
-              u,
-              notLoggedSince
-            )) && u.status == UserStatus.Active && predicateNotOrigin(u, excludeFromOrigin)
+            (predicateUser(u, userIds) || predicateLogDate(u, notLoggedSince)) &&
+            u.status == UserStatus.Active && predicateNotOrigin(u, excludeFromOrigin)
           ) {
             modUserIds = k :: modUserIds
             (
@@ -484,7 +492,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
 
   override def delete(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       initialStatus:     Option[UserStatus],
       trace:             EventTrace
@@ -494,10 +502,8 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
       val m          = users.map {
         case (k, u) =>
           if (
-            (predicateUser(u, userIds) || predicateLogDate(
-              u,
-              notLoggedSince
-            )) && predicateInitialStatus(u, initialStatus) && predicateNotOrigin(u, excludeFromOrigin)
+            (predicateUser(u, userIds) || predicateLogDate(u, notLoggedSince)) &&
+            predicateInitialStatus(u, initialStatus) && predicateNotOrigin(u, excludeFromOrigin)
           ) {
             modUserIds = k :: modUserIds
             (
@@ -517,7 +523,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
 
   override def purge(
       userIds:           List[String],
-      deletedSince:      Option[DateTime],
+      deletedSince:      Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       trace:             EventTrace
   ): IOResult[List[String]] = {
@@ -611,7 +617,6 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
  *   endCause     text
  */
 class JdbcUserRepository(doobie: Doobie) extends UserRepository {
-  import com.normation.rudder.db.Doobie.*
   import com.normation.rudder.db.json.implicits.*
   import com.normation.rudder.users.UserSerialization.*
   import doobie.*
@@ -621,43 +626,49 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
 
   implicit val userWrite: Write[UserInfo] = {
     Write[
-      (String, DateTime, String, String, Option[String], Option[String], Option[DateTime], List[StatusHistory], Json.Obj)
-    ].contramap {
-      case u =>
-        (u.id, u.creationDate, u.status.value, u.managedBy, u.name, u.email, u.lastLogin, u.statusHistory, u.otherInfo)
-    }
+      (
+          String,
+          OffsetDateTime,
+          String,
+          String,
+          Option[String],
+          Option[String],
+          Option[OffsetDateTime],
+          List[StatusHistory],
+          Json.Obj
+      )
+    ].contramap(u =>
+      (u.id, u.creationDate, u.status.value, u.managedBy, u.name, u.email, u.lastLogin, u.statusHistory, u.otherInfo)
+    )
   }
 
   implicit val userStatusMeta: Meta[UserStatus] = Meta[String].tiemap(UserStatus.parse(_))(_.value)
 
   implicit val userRead: Read[UserInfo] = {
     Read[
-      (String, DateTime, String, String, Option[String], Option[String], Option[DateTime], List[StatusHistory], Json.Obj)
-    ].map {
-      (u: (
-          (
-              String,
-              DateTime,
-              String,
-              String,
-              Option[String],
-              Option[String],
-              Option[DateTime],
-              List[StatusHistory],
-              Json.Obj
-          )
-      )) =>
-        UserInfo(
-          u._1,
-          u._2,
-          UserStatus.parse(u._3).toOption.getOrElse(UserStatus.Disabled),
-          u._4,
-          u._5,
-          u._6,
-          u._7,
-          u._8,
-          u._9
-        )
+      (
+          String,
+          OffsetDateTime,
+          String,
+          String,
+          Option[String],
+          Option[String],
+          Option[OffsetDateTime],
+          List[StatusHistory],
+          Json.Obj
+      )
+    ].map { u =>
+      UserInfo(
+        id = u._1,
+        creationDate = u._2,
+        status = UserStatus.parse(u._3).toOption.getOrElse(UserStatus.Disabled),
+        managedBy = u._4,
+        name = u._5,
+        email = u._6,
+        lastLogin = u._7,
+        statusHistory = u._8,
+        otherInfo = u._9
+      )
     }
   }
 
@@ -671,7 +682,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
       tenants:           String,
       sessionId:         SessionId,
       authenticatorName: String,
-      date:              DateTime
+      date:              OffsetDateTime
   ): IOResult[Unit] = {
     transactIOResult(s"Error when saving session '${sessionId.value}' info for user '${userId}'")(xa => {
       (for {
@@ -686,13 +697,13 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
     }).catchSome { case SystemError(_, ex: IllegalArgumentException) => Inconsistency(ex.getMessage).fail }
   }
 
-  override def logCloseSession(userId: String, endDate: DateTime, endCause: String): IOResult[Unit] = {
+  override def logCloseSession(userId: String, endDate: OffsetDateTime, endCause: String): IOResult[Unit] = {
     val sql =
       sql"""update usersessions set enddate = ${endDate}, endcause = ${endCause} where enddate is null and userid = ${userId}"""
     transactIOResult(s"Error when closing opened session for user '${userId}'")(xa => sql.update.run.transact(xa)).unit
   }
 
-  override def closeAllOpenSession(endDate: DateTime, endCause: String): IOResult[Unit] = {
+  override def closeAllOpenSession(endDate: OffsetDateTime, endCause: String): IOResult[Unit] = {
     val sql = sql"""update usersessions set enddate = ${endDate}, endcause = ${endCause} where enddate is null returning userid"""
     transactIOResult(s"Error when closing opened user session")(xa => sql.query[String].to[List].transact(xa)).flatMap(users =>
       logger.info(s"Close open sessions with reason '${endCause}' for users '${users.mkString("', '")}'")
@@ -717,15 +728,15 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
     )
   }
 
-  override def deleteOldSessions(olderThan: DateTime): IOResult[Unit] = {
+  override def deleteOldSessions(olderThan: OffsetDateTime): IOResult[Unit] = {
     val sql = sql"""delete from usersessions where creationdate < ${olderThan}"""
 
-    transactIOResult(s"Error when purging user sessions older then: ${DateFormaterService.serialize(olderThan)}")(xa =>
-      sql.update.run.transact(xa)
+    transactIOResult(s"Error when purging user sessions older then: ${DateFormaterService.serializeOffsetDateTime(olderThan)}")(
+      xa => sql.update.run.transact(xa)
     ).tapSome {
       case deletedSessionCount if deletedSessionCount > 0 =>
         logger.info(
-          s"${deletedSessionCount} user sessions older than ${DateFormaterService.serialize(olderThan)} were deleted"
+          s"${deletedSessionCount} user sessions older than ${DateFormaterService.serializeOffsetDateTime(olderThan)} were deleted"
         )
     }.unit
   }
@@ -848,7 +859,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
       tenants:           String,
       sessionId:         SessionId,
       authenticatorName: String,
-      date:              DateTime
+      date:              OffsetDateTime
   ): ConnectionIO[Int] = {
     sql"""insert into usersessions (sessionid, userid, creationdate, authmethod, permissions, authz, tenants)
         values (${sessionId}, ${userId}, ${date}, ${authenticatorName}, ${permissions.sorted}, ${authz.sorted}, ${tenants})""".update.run
@@ -856,7 +867,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
 
   private[users] def lastLoginUpdate(
       userId: String,
-      date:   DateTime
+      date:   OffsetDateTime
   ): ConnectionIO[Int] = {
     sql"""update users set lastlogin = ${date} where id = ${userId}""".update.run
   }
@@ -867,7 +878,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
     case h :: t => Some(Fragments.in(fr"id", NonEmptyList.of(h, t*)))
   }
 
-  private[users] def predicateLogDate(lastLogin: Option[DateTime]): Option[Fragment] = lastLogin match {
+  private[users] def predicateLogDate(lastLogin: Option[OffsetDateTime]): Option[Fragment] = lastLogin match {
     case None        => None
     case Some(limit) => // look for lastlogin and if null (coalesce) creationdate
       Some(fr"COALESCE(lastlogin, creationdate) < ${limit}")
@@ -883,7 +894,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
   // if both userIds and notLoggedSince are empty/None, select all or none depending of defaultToNone value
   private[users] def select(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       defaultToNone:     Boolean,         // if both userIds = Nil and notLoggedSince = None, if true return no user else all matching other params
       excludeFromOrigin: List[String],
       andSelectFragment: Option[Fragment] // refined selection
@@ -906,7 +917,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
   // change status of an user
   private[users] def changeStatus(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       trace:             EventTrace,
       targetStatus:      UserStatus,
@@ -931,8 +942,8 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
         (
           for {
             selected <- select(
-                          userIds,
-                          notLoggedSince,
+                          userIds = userIds,
+                          notLoggedSince = notLoggedSince,
                           defaultToNone = true,
                           excludeFromOrigin = excludeFromOrigin,
                           andSelectFragment = andSelectFragment
@@ -956,7 +967,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
 
   override def delete(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       initialStatus:     Option[UserStatus],
       trace:             EventTrace
@@ -975,7 +986,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
 
   override def disable(
       userIds:           List[String],
-      notLoggedSince:    Option[DateTime],
+      notLoggedSince:    Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       trace:             EventTrace
   ): IOResult[List[String]] = {
@@ -991,14 +1002,14 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
 
   override def purge(
       userIds:           List[String],
-      deletedSince:      Option[DateTime],
+      deletedSince:      Option[OffsetDateTime],
       excludeFromOrigin: List[String],
       trace:             EventTrace
   ): IOResult[List[String]] = {
 
     transactIOResult(
       s"Error when purging users with condition: [ids in: ${userIds.mkString(", ")} ; " +
-      s"deleted since: ${deletedSince.map(DateFormaterService.serialize(_)).getOrElse("ignored")} ; " +
+      s"deleted since: ${deletedSince.map(DateFormaterService.serializeOffsetDateTime).getOrElse("ignored")} ; " +
       s"exclude backends: ${excludeFromOrigin.mkString(", ")} "
     )(xa => {
       (for {
@@ -1015,7 +1026,8 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
                       case None        => selected.map(_._1)
                       case Some(limit) =>
                         selected.collect {
-                          case (id, StatusHistory(UserStatus.Deleted, trace) :: t) if (trace.actionDate.isBefore(limit)) => id
+                          case (id, StatusHistory(UserStatus.Deleted, trace) :: t) if (trace.actionDate.isBefore(limit)) =>
+                            id
                         }
                     }
         _        <- Update[String]("delete from users where id = ?").updateMany(toDelete)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/batch/AbstractSchedulerSpec.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/batch/AbstractSchedulerSpec.scala
@@ -40,15 +40,17 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
+import java.time.Duration
 import net.liftweb.common.Box
 import net.liftweb.common.Full
 import org.junit.runner.RunWith
 import org.slf4j.LoggerFactory
-import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import zio.Scope
 import zio.UIO
 import zio.ZIO
+import zio.durationInt
+import zio.durationLong
 import zio.test.*
 import zio.test.Assertion.*
 import zio.test.junit.ZTestJUnitRunner
@@ -91,7 +93,7 @@ class AbstractSchedulerSpec extends ZIOSpecDefault {
     test("should log scheduling period when instantiated with a value in the right range") {
       for {
         capture  <- captureLogger("scheduled.job", Level.INFO)
-        scheduler = TestScheduler(interval = Duration.apply("5 seconds"))
+        scheduler = TestScheduler(interval = 5.seconds)
       } yield {
         assert(capture.logs)(contains("[INFO] Starting [test scheduler] scheduler with a period of '5 seconds'"))
       }
@@ -99,7 +101,7 @@ class AbstractSchedulerSpec extends ZIOSpecDefault {
     test("should log simplified scheduling period when instantiated with a value in the right range") {
       for {
         capture  <- captureLogger("scheduled.job", Level.INFO)
-        scheduler = TestScheduler(interval = Duration.apply("5000000000 nanoseconds"))
+        scheduler = TestScheduler(interval = 5000000000L.nanoseconds)
       } yield {
         assert(capture.logs)(contains("[INFO] Starting [test scheduler] scheduler with a period of '5 seconds'"))
       }
@@ -107,7 +109,7 @@ class AbstractSchedulerSpec extends ZIOSpecDefault {
     test("should log period is too high when instantiated with an out of range value") {
       for {
         capture  <- captureLogger("scheduled.job", Level.INFO)
-        scheduler = TestScheduler(interval = Duration.apply("10 minutes"))
+        scheduler = TestScheduler(interval = 10.minutes)
       } yield {
         assert(capture.logs)(
           contains("[WARN] Value '10 minutes' for prop is too big for [test scheduler] scheduler interval, using '5 minutes'")
@@ -117,7 +119,7 @@ class AbstractSchedulerSpec extends ZIOSpecDefault {
     test("should log simplified scheduling period when instantiated with an out of range value") {
       for {
         capture  <- captureLogger("scheduled.job", Level.INFO)
-        scheduler = TestScheduler(interval = Duration.apply("600 seconds"))
+        scheduler = TestScheduler(interval = 600.seconds)
       } yield {
         assert(capture.logs)(
           contains("[WARN] Value '10 minutes' for prop is too big for [test scheduler] scheduler interval, using '5 minutes'")
@@ -127,7 +129,7 @@ class AbstractSchedulerSpec extends ZIOSpecDefault {
     test("should log period is too low when instantiated with an out of range value") {
       for {
         capture  <- captureLogger("scheduled.job", Level.INFO)
-        scheduler = TestScheduler(interval = Duration.apply("100 ms"))
+        scheduler = TestScheduler(interval = 100.milliseconds)
       } yield {
         assert(capture.logs)(
           contains(
@@ -139,7 +141,7 @@ class AbstractSchedulerSpec extends ZIOSpecDefault {
     test("should log simplified scheduling period when instantiated with an low out of range value") {
       for {
         capture  <- captureLogger("scheduled.job", Level.INFO)
-        scheduler = TestScheduler(interval = Duration.apply("100000000 nanoseconds"))
+        scheduler = TestScheduler(interval = 100000000L.nanoseconds)
       } yield {
         assert(capture.logs)(
           contains(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
@@ -46,9 +46,9 @@ import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import net.liftweb.common.Loggable
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -61,8 +61,8 @@ class UserRepositoryUtilsTest extends Specification {
 
   "UserRepositoryTest computeUpdatedUserList" should {
     val actor    = EventActor("test")
-    val dateInit = DateTime.parse("2023-09-01T01:01:01Z")
-    val date2    = DateTime.parse("2023-09-02T02:02:02Z")
+    val dateInit = OffsetDateTime.parse("2023-09-01T01:01:01Z")
+    val date2    = OffsetDateTime.parse("2023-09-02T02:02:02Z")
 
     val users = List("alice", "bob", "charlie", "mallory")
 
@@ -291,7 +291,8 @@ class JdbcUserRepositoryTest extends UserRepositoryTest with DBCommon {
       // lastLogin of user2 being after other dates allows filtering inactive users : user1
       val lastLogin        = dateInit.plusMonths(1)
       transactRunEither(
-        (repo.lastLoginUpdate("user2", lastLogin) *> repo.select(users, Some(notLoggedInSince), defaultToNone = true, Nil, None))
+        (repo.lastLoginUpdate("user2", lastLogin) *> repo
+          .select(users, Some(notLoggedInSince), defaultToNone = true, Nil, None))
           .transact(_)
       ).map(_.map(_._1)) must beRight(
         containTheSameElementsAs(List("user1"))
@@ -335,11 +336,11 @@ trait UserRepositoryTest extends Specification with Loggable {
   implicit class ForceTimeUTC(users: List[UserInfo]) {
     def toUTC: List[UserInfo] = users.map(u => {
       u.modify(_.creationDate)
-        .using(_.toDateTime(DateTimeZone.UTC))
+        .using(_.withOffsetSameInstant(ZoneOffset.UTC))
         .modify(_.statusHistory)
-        .using(hs => hs.map(h => h.modify(_.trace.actionDate).using(_.toDateTime(DateTimeZone.UTC))))
+        .using(hs => hs.map(h => h.modify(_.trace.actionDate).using(_.withOffsetSameInstant(ZoneOffset.UTC))))
         .modify(_.lastLogin)
-        .using(_.map(_.toDateTime(DateTimeZone.UTC)))
+        .using(_.map(_.withOffsetSameInstant(ZoneOffset.UTC)))
     })
   }
 
@@ -351,8 +352,8 @@ trait UserRepositoryTest extends Specification with Loggable {
 
   def repo: UserRepository
 
-  val actor:    EventActor = EventActor("test")
-  val dateInit: DateTime   = DateTime.parse("2023-09-01T01:01:01Z")
+  val actor:    EventActor     = EventActor("test")
+  val dateInit: OffsetDateTime = OffsetDateTime.parse("2023-09-01T01:01:01Z")
 
   "basic sequential operations with users" >> {
     val users = List("alice", "bob", "charlie", "mallory")
@@ -370,15 +371,15 @@ trait UserRepositoryTest extends Specification with Loggable {
        */
       users.map(u => {
         UserInfo(
-          u,
-          dateInit,
-          UserStatus.Active,
-          AUTH_PLUGIN_NAME_LOCAL,
-          None,
-          None,
-          None,
-          historyInit,
-          Json.Obj()
+          id = u,
+          creationDate = dateInit,
+          status = UserStatus.Active,
+          managedBy = AUTH_PLUGIN_NAME_LOCAL,
+          name = None,
+          email = None,
+          lastLogin = None,
+          statusHistory = historyInit,
+          otherInfo = Json.Obj()
         )
       })
     }
@@ -437,7 +438,7 @@ trait UserRepositoryTest extends Specification with Loggable {
 
     // BOB REMOVED
     val userFileBobRemoved  = users.filterNot(_ == "bob")
-    val dateBobRemoved      = DateTime.parse("2023-09-02T02:02:02Z")
+    val dateBobRemoved      = OffsetDateTime.parse("2023-09-02T02:02:02Z")
     val traceBobRemoved     = EventTrace(actor, dateBobRemoved)
     val userInfosBobRemoved = {
       /*
@@ -462,7 +463,7 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // BOB is added again to the active users and is 'active'
-    val dateBobReactivated      = DateTime.parse("2023-09-02T02:03:03Z")
+    val dateBobReactivated      = OffsetDateTime.parse("2023-09-02T02:03:03Z")
     val traceBobReactivated     = EventTrace(actor, dateBobReactivated)
     val userInfosBobReactivated = {
       /*
@@ -488,7 +489,7 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // BOB is kept removed after setting the users again without BOB
-    val dateBobRemovedIdempotent      = DateTime.parse("2023-09-02T02:03:04Z")
+    val dateBobRemovedIdempotent      = OffsetDateTime.parse("2023-09-02T02:03:04Z")
     val traceBobRemovedIdempotent     = EventTrace(actor, dateBobRemovedIdempotent)
     val userInfosBobRemovedIdempotent = {
       /*
@@ -515,9 +516,9 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // BOB added back from OIDC
-    val dateBobOidc      = DateTime.parse("2023-09-03T03:03:03Z")
+    val dateBobOidc      = OffsetDateTime.parse("2023-09-03T03:03:03Z")
     val traceBobOidc     = EventTrace(actor, dateBobOidc)
-    val dateReload       = DateTime.parse("2023-09-04T04:04:04Z")
+    val dateReload       = OffsetDateTime.parse("2023-09-04T04:04:04Z")
     val traceReload      = EventTrace(actor, dateReload)
     val userInfosBobOidc = {
       /*
@@ -546,19 +547,19 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // William is added from OIDC
-    val dateWilliamOidc      = DateTime.parse("2023-09-05T05:05:05Z")
+    val dateWilliamOidc      = OffsetDateTime.parse("2023-09-05T05:05:05Z")
     val traceWilliamOidc     = EventTrace(actor, dateWilliamOidc)
     val userInfosWilliamOidc = {
       userInfosBobOidc :+ UserInfo(
-        "william",
-        dateWilliamOidc,
-        UserStatus.Active,
-        AUTH_PLUGIN_NAME_REMOTE,
-        None,
-        None,
-        None,
-        StatusHistory(UserStatus.Active, traceWilliamOidc) :: Nil,
-        Json.Obj()
+        id = "william",
+        creationDate = dateWilliamOidc,
+        status = UserStatus.Active,
+        managedBy = AUTH_PLUGIN_NAME_REMOTE,
+        name = None,
+        email = None,
+        lastLogin = None,
+        statusHistory = StatusHistory(UserStatus.Active, traceWilliamOidc) :: Nil,
+        otherInfo = Json.Obj()
       )
     }
 
@@ -568,7 +569,7 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // Bob is disabled
-    val dateBobDisabled      = DateTime.parse("2023-09-06T06:06:06Z")
+    val dateBobDisabled      = OffsetDateTime.parse("2023-09-06T06:06:06Z")
     val traceBobDisabled     = EventTrace(actor, dateBobDisabled)
     val userInfosBobDisabled = {
       userInfosWilliamOidc.map {
@@ -590,19 +591,19 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // Xavier is added from OIDC
-    val dateXavierOidc      = DateTime.parse("2023-09-07T07:07:07Z")
+    val dateXavierOidc      = OffsetDateTime.parse("2023-09-07T07:07:07Z")
     val traceXavierOidc     = EventTrace(actor, dateXavierOidc)
     val userInfosXavierOidc = {
       userInfosBobDisabled :+ UserInfo(
-        "xavier",
-        dateXavierOidc,
-        UserStatus.Active,
-        AUTH_PLUGIN_NAME_REMOTE,
-        None,
-        None,
-        None,
-        StatusHistory(UserStatus.Active, traceXavierOidc) :: Nil,
-        Json.Obj()
+        id = "xavier",
+        creationDate = dateXavierOidc,
+        status = UserStatus.Active,
+        managedBy = AUTH_PLUGIN_NAME_REMOTE,
+        name = None,
+        email = None,
+        lastLogin = None,
+        statusHistory = StatusHistory(UserStatus.Active, traceXavierOidc) :: Nil,
+        otherInfo = Json.Obj()
       )
     }
 
@@ -613,7 +614,7 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // All OIDC users deleted
-    val dateOidcDeleted      = DateTime.parse("2023-09-09T08:08:08Z")
+    val dateOidcDeleted      = OffsetDateTime.parse("2023-09-09T08:08:08Z")
     val traceOidcDeleted     = EventTrace(actor, dateOidcDeleted)
     val userInfosOidcDeleted = {
       userInfosXavierOidc.map {
@@ -633,7 +634,7 @@ trait UserRepositoryTest extends Specification with Loggable {
     }
 
     // BOB deleted, then purged and added back in OIDC
-    val dateBobPurged      = DateTime.parse("2023-09-08T08:08:08Z")
+    val dateBobPurged      = OffsetDateTime.parse("2023-09-08T08:08:08Z")
     val traceBobPurged     = EventTrace(actor, dateBobPurged)
     val userInfosBobPurged = {
       /*
@@ -645,15 +646,15 @@ trait UserRepositoryTest extends Specification with Loggable {
       userInfosOidcDeleted.map {
         case u if (u.id == "bob") =>
           UserInfo(
-            u.id,
-            dateBobPurged,
-            UserStatus.Active,
-            AUTH_PLUGIN_NAME_REMOTE,
-            None,
-            None,
-            None,
-            StatusHistory(UserStatus.Active, traceBobPurged) :: Nil,
-            Json.Obj()
+            id = u.id,
+            creationDate = dateBobPurged,
+            status = UserStatus.Active,
+            managedBy = AUTH_PLUGIN_NAME_REMOTE,
+            name = None,
+            email = None,
+            lastLogin = None,
+            statusHistory = StatusHistory(UserStatus.Active, traceBobPurged) :: Nil,
+            otherInfo = Json.Obj()
           )
 
         case u => u
@@ -673,39 +674,50 @@ trait UserRepositoryTest extends Specification with Loggable {
 
   "testing purge" >> {
 
-    val date1 = DateTime.parse("2021-01-01T01:01:01Z")
-    val date2 = DateTime.parse("2022-02-02T02:02:02Z")
-    val date3 = DateTime.parse("2023-03-03T03:03:03Z")
-    val date4 = DateTime.parse("2024-04-04T04:04:04Z")
-    val date5 = DateTime.parse("2025-05-05T05:05:05Z")
-    val date6 = DateTime.parse("2023-09-06T06:06:06Z")
+    val date1 = OffsetDateTime.parse("2021-01-01T01:01:01Z")
+    val date2 = OffsetDateTime.parse("2022-02-02T02:02:02Z")
+    val date3 = OffsetDateTime.parse("2023-03-03T03:03:03Z")
+    val date4 = OffsetDateTime.parse("2024-04-04T04:04:04Z")
+    val date5 = OffsetDateTime.parse("2025-05-05T05:05:05Z")
+    val date6 = OffsetDateTime.parse("2023-09-06T06:06:06Z")
 
     val trace1          = EventTrace(actor, date1)
     val traceAllDeleted = EventTrace(actor, date6)
 
     val userInfosAllDeleted = List(
       UserInfo(
-        "david",
-        date1,
-        UserStatus.Deleted,
-        AUTH_PLUGIN_NAME_LOCAL,
-        None,
-        None,
-        Some(date4),
-        List(StatusHistory(UserStatus.Deleted, traceAllDeleted), StatusHistory(UserStatus.Active, trace1)),
-        Json.Obj()
+        id = "david",
+        creationDate = date1,
+        status = UserStatus.Deleted,
+        managedBy = AUTH_PLUGIN_NAME_LOCAL,
+        name = None,
+        email = None,
+        lastLogin = Some(date4),
+        statusHistory = List(StatusHistory(UserStatus.Deleted, traceAllDeleted), StatusHistory(UserStatus.Active, trace1)),
+        otherInfo = Json.Obj()
       )
     )
 
     "deleting+purging all users not logged in since a date in the future should remove all users" >> {
       // set delete trace event to "dateInit" to make it simpler to know when the "deleted before" must be set to
       repo
-        .delete(Nil, Some(dateInit.plusYears(1)), Nil, None, EventTrace(actor, dateInit))
+        .delete(
+          userIds = Nil,
+          notLoggedSince = Some(dateInit.plusYears(1)),
+          excludeFromOrigin = Nil,
+          initialStatus = None,
+          trace = EventTrace(actor, dateInit)
+        )
         .tap(users => errors.effectUioUnit(logger.debug(s"Users were marked deleted: ${users}")))
         .runNow must containTheSameElementsAs(List("alice", "charlie", "mallory", "bob")) // william is already deleted
 
       repo
-        .purge(Nil, Some(dateInit.plusYears(1)), Nil, EventTrace(actor, DateTime.now(DateTimeZone.UTC)))
+        .purge(
+          userIds = Nil,
+          deletedSince = Some(dateInit.plusYears(1)),
+          excludeFromOrigin = Nil,
+          trace = EventTrace(actor, dateInit)
+        )
         .tap(users => errors.effectUioUnit(logger.debug(s"Users were purged: ${users}")))
         .runNow must containTheSameElementsAs(List("alice", "charlie", "mallory", "bob", "william", "xavier"))
 
@@ -716,14 +728,30 @@ trait UserRepositoryTest extends Specification with Loggable {
       (
         // Alice logged but not since date2
         repo.setExistingUsers(AUTH_PLUGIN_NAME_LOCAL, List("alice"), EventTrace(actor, date1)) *>
-        repo.logStartSession("alice", List("role1"), List.empty, "", SessionId("sessionAlice1"), AUTH_PLUGIN_NAME_LOCAL, date2) *>
+        repo.logStartSession(
+          "alice",
+          List("role1"),
+          List.empty,
+          "",
+          SessionId("sessionAlice1"),
+          AUTH_PLUGIN_NAME_LOCAL,
+          date2
+        ) *>
         // Bob created at date1 but never logged since
         repo.setExistingUsers(AUTH_PLUGIN_NAME_LOCAL, List("alice", "bob"), EventTrace(actor, date1)) *>
         // same for Charlie from OIDC
         repo.setExistingUsers(AUTH_PLUGIN_NAME_REMOTE, List("charlie"), EventTrace(actor, date1)) *>
         // David created on date1 and logged recently
         repo.setExistingUsers(AUTH_PLUGIN_NAME_LOCAL, List("alice", "bob", "david"), EventTrace(actor, date1)) *>
-        repo.logStartSession("david", List("role1"), List.empty, "", SessionId("sessionDavid1"), AUTH_PLUGIN_NAME_LOCAL, date4)
+        repo.logStartSession(
+          "david",
+          List("role1"),
+          List.empty,
+          "",
+          SessionId("sessionDavid1"),
+          AUTH_PLUGIN_NAME_LOCAL,
+          date4
+        )
       ).runNow
 
       val users = repo.getAll().runNow

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
@@ -75,7 +75,7 @@ final case class RestEventLog(
 object RestEventLog {
 
   // We still have Joda DateTime because we map an event log field using chimney
-  implicit val datetimeEncoder:    JsonEncoder[DateTime]     = JsonEncoder[String].contramap(DateFormaterService.serialize)
+  implicit val datetimeEncoder:    JsonEncoder[DateTime]     = DateFormaterService.json.encoderDateTime
   implicit val eventActorEncoder:  JsonEncoder[EventActor]   = JsonEncoder[String].contramap(_.name)
   implicit val descriptionEncoder: JsonEncoder[NodeSeq]      = JsonEncoder[String].contramap(_.toString())
   implicit val encoder:            JsonEncoder[RestEventLog] = DeriveJsonEncoder.gen[RestEventLog]

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -80,13 +80,14 @@ import com.normation.rudder.users.UserManagementService
 import com.normation.rudder.users.UserRepository
 import com.normation.rudder.users.UserSession
 import com.normation.rudder.users.UserStatus
+import com.normation.utils.DateFormaterService.toJodaDateTime
+import com.normation.zio.currentOffsetDateTimeUTC
 import enumeratum.*
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.syntax.*
+import java.time.OffsetDateTime
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import sourcecode.Line
 import zio.ZIO
 import zio.syntax.*
@@ -269,7 +270,7 @@ class UserManagementApiImpl(
                 }
                 .map {
                   case (lastClosedSession, lastSession) =>
-                    implicit val previousLogin: Option[DateTime] = lastClosedSession.map(_.creationDate)
+                    implicit val previousLogin: Option[OffsetDateTime] = lastClosedSession.map(_.creationDate)
 
                     // depending on provider property configuration, we should merge or override roles
                     val mainProviderRoleExtension = getProviderRoleExtensions().get(u.managedBy)
@@ -501,13 +502,14 @@ class UserManagementApiImpl(
       UserManagementIO
         .inUserFileSemaphore(for {
           user       <- userRepo.get(id).notOptional(s"User '$id' does not exist therefore cannot be activated")
+          now        <- currentOffsetDateTimeUTC
           jsonStatus <- user.status match {
                           case UserStatus.Active   => JsonStatus(UserStatus.Active).succeed
                           case UserStatus.Disabled => {
                             val eventTrace = EventTrace(
-                              authzToken.qc.actor,
-                              DateTime.now(DateTimeZone.UTC),
-                              "User current disabled status set to 'active' by user management API"
+                              actor = authzToken.qc.actor,
+                              actionDate = now,
+                              reason = "User current disabled status set to 'active' by user management API"
                             )
                             (userRepo.setActive(List(user.id), eventTrace) *> userService.reloadPure())
                               .as(JsonStatus(UserStatus.Active))
@@ -537,13 +539,14 @@ class UserManagementApiImpl(
       UserManagementIO
         .inUserFileSemaphore(for {
           user       <- userRepo.get(id).notOptional(s"User '$id' does not exist therefore cannot be disabled")
+          now        <- currentOffsetDateTimeUTC
           jsonStatus <- user.status match {
                           case UserStatus.Disabled => JsonStatus(UserStatus.Disabled).succeed
                           case UserStatus.Active   => {
                             val eventTrace = EventTrace(
-                              authzToken.qc.actor,
-                              DateTime.now(DateTimeZone.UTC),
-                              "User current active status set to 'disabled' by user management API"
+                              actor = authzToken.qc.actor,
+                              actionDate = now,
+                              reason = "User current active status set to 'disabled' by user management API"
                             )
                             (userRepo.disable(List(user.id), None, List.empty, eventTrace) *> userService.reloadPure())
                               .as(JsonStatus(UserStatus.Disabled))
@@ -607,8 +610,8 @@ class UserManagementApiImpl(
       authz:         Rights,
       info:          UserInfo,
       providersInfo: Map[String, JsonProviderInfo],
-      lastLogin:     Option[DateTime]
-  )(implicit previousLogin: Option[DateTime]): JsonUser = {
+      lastLogin:     Option[OffsetDateTime]
+  )(implicit previousLogin: Option[OffsetDateTime]): JsonUser = {
     // NoRights and AnyRights directly map to known user permissions. AnyRights takes precedence over NoRights.
     if (authz.authorizationTypes.contains(AuthorizationType.AnyRights)) {
       JsonUser.anyRights(
@@ -619,8 +622,8 @@ class UserManagementApiImpl(
         status,
         providersInfo,
         getDisplayTenants(nodePerms),
-        lastLogin = lastLogin,
-        previousLogin = previousLogin
+        lastLogin = lastLogin.map(_.toJodaDateTime),
+        previousLogin = previousLogin.map(_.toJodaDateTime)
       )
     } else if (authz.authorizationTypes.isEmpty || authz.authorizationTypes.contains(AuthorizationType.NoRights)) {
       JsonUser.noRights(
@@ -631,8 +634,8 @@ class UserManagementApiImpl(
         status,
         providersInfo,
         getDisplayTenants(nodePerms),
-        lastLogin = lastLogin,
-        previousLogin = previousLogin
+        lastLogin = lastLogin.map(_.toJodaDateTime),
+        previousLogin = previousLogin.map(_.toJodaDateTime)
       )
     } else {
       JsonUser(
@@ -643,8 +646,8 @@ class UserManagementApiImpl(
         status,
         providersInfo,
         getDisplayTenants(nodePerms),
-        lastLogin = lastLogin,
-        previousLogin = previousLogin
+        lastLogin = lastLogin.map(_.toJodaDateTime),
+        previousLogin = previousLogin.map(_.toJodaDateTime)
       )
     }
   }
@@ -652,7 +655,7 @@ class UserManagementApiImpl(
   implicit def transformDbUserToJsonUser(implicit
       userInfo:      UserInfo,
       nodePerms:     TenantAccessGrant,
-      previousLogin: Option[DateTime]
+      previousLogin: Option[OffsetDateTime]
   ): Transformer[UserSession, JsonUser] = {
     def getDisplayPermissions(userSession: UserSession): JsonRoles = {
       JsonRoles(userSession.permissions.flatMap {
@@ -686,9 +689,9 @@ class UserManagementApiImpl(
           )
         }
       )
-      .withFieldComputed(_.lastLogin, s => Some(s.creationDate))
+      .withFieldComputed(_.lastLogin, s => Some(s.creationDate.toJodaDateTime))
       .withFieldConst(_.tenants, getDisplayTenants(nodePerms))
-      .withFieldConst(_.previousLogin, previousLogin)
+      .withFieldConst(_.previousLogin, previousLogin.map(_.toJodaDateTime))
       .withFieldConst(_.customRights, JsonRights.empty)
       .buildTransformer
   }
@@ -702,7 +705,7 @@ class UserManagementApiImpl(
    */
   private def transformProvidedUser(userInfo: UserInfo, nodePerms: TenantAccessGrant, lastSession: Option[UserSession])(implicit
       allRoles:      Set[Role],
-      previousLogin: Option[DateTime]
+      previousLogin: Option[OffsetDateTime]
   ): JsonUser = {
     lastSession match {
       case None              => {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -88,7 +88,7 @@ final case class UpdateUserInfo(
 
 object Serialisation {
 
-  implicit val dateTime:                     JsonEncoder[DateTime]              = JsonEncoder[String].contramap(DateFormaterService.serialize)
+  implicit val dateTime:                     JsonEncoder[DateTime]              = DateFormaterService.json.encoderDateTime
   implicit val userStatusEncoder:            JsonEncoder[UserStatus]            = JsonEncoder[String].contramap(_.value)
   implicit val providerRoleExtensionEncoder: JsonEncoder[ProviderRoleExtension] =
     JsonEncoder[String].contramap(_.name)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -105,6 +105,7 @@ import io.scalaland.chimney.syntax.*
 import java.io.InputStream
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+import java.time.OffsetDateTime
 import org.apache.commons.io.IOUtils
 import org.joda.time.DateTime
 import scala.collection.MapView
@@ -816,18 +817,18 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
         tenants:           String,
         sessionId:         SessionId,
         authenticatorName: String,
-        date:              DateTime
+        date:              OffsetDateTime
     ): IOResult[Unit] = ???
 
-    override def logCloseSession(userId: String, date: DateTime, cause: String): IOResult[Unit] = ???
+    override def logCloseSession(userId: String, date: OffsetDateTime, cause: String): IOResult[Unit] = ???
 
-    override def closeAllOpenSession(endDate: DateTime, endCause: String): IOResult[Unit] = ???
+    override def closeAllOpenSession(endDate: OffsetDateTime, endCause: String): IOResult[Unit] = ???
 
     override def getLastPreviousLogin(userId: String, closedSessionsOnly: Boolean): IOResult[Option[UserSession]] = {
       userSessions.find(us => us.userId == userId && (!closedSessionsOnly || !us.isOpen)).succeed
     }
 
-    override def deleteOldSessions(olderThan: DateTime): IOResult[Unit] = ???
+    override def deleteOldSessions(olderThan: OffsetDateTime): IOResult[Unit] = ???
 
     override def setExistingUsers(
         origin:          String,
@@ -845,7 +846,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
 
     override def disable(
         userIds:           List[String],
-        notLoggedSince:    Option[DateTime],
+        notLoggedSince:    Option[OffsetDateTime],
         excludeFromOrigin: List[String],
         trace:             EventTrace
     ): IOResult[List[String]] = {
@@ -854,7 +855,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
 
     override def delete(
         userIds:           List[String],
-        notLoggedSince:    Option[DateTime],
+        notLoggedSince:    Option[OffsetDateTime],
         excludeFromOrigin: List[String],
         initialStatus:     Option[UserStatus],
         trace:             EventTrace
@@ -864,7 +865,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
 
     override def purge(
         userIds:           List[String],
-        deletedSince:      Option[DateTime],
+        deletedSince:      Option[OffsetDateTime],
         excludeFromOrigin: List[String],
         trace:             EventTrace
     ): IOResult[List[String]] = ???
@@ -937,7 +938,7 @@ object MockUserManagement {
     List(
       UserInfo( // user3 not in the file will get empty permissions and authz
         "user3",
-        DateTime.parse("2024-02-01T01:01:01Z"),
+        OffsetDateTime.parse("2024-02-01T01:01:01Z"),
         UserStatus.Disabled,
         "manager",
         Some("User 3"),
@@ -948,7 +949,7 @@ object MockUserManagement {
       ),
       UserInfo(
         "user2",
-        DateTime.parse("2024-02-01T01:01:01Z"),
+        OffsetDateTime.parse("2024-02-01T01:01:01Z"),
         UserStatus.Active,
         "file",
         None,
@@ -959,7 +960,7 @@ object MockUserManagement {
       ),
       UserInfo(
         "user1",
-        DateTime.parse("2024-02-01T01:01:01Z"),
+        OffsetDateTime.parse("2024-02-01T01:01:01Z"),
         UserStatus.Active,
         "file",
         None,
@@ -975,7 +976,7 @@ object MockUserManagement {
       UserSession(
         "user2",
         SessionId("s2-2"),
-        DateTime.parse("2024-02-29T00:00:00Z"),
+        OffsetDateTime.parse("2024-02-29T00:00:00Z"),
         "file",
         List.empty,
         List.empty,
@@ -986,12 +987,12 @@ object MockUserManagement {
       UserSession(
         "user2",
         SessionId("s2-1"),
-        DateTime.parse("2024-02-28T12:34:00Z"),
+        OffsetDateTime.parse("2024-02-28T12:34:00Z"),
         "file",
         List.empty,
         List.empty,
         Some("a-previous-tenant-zone"),
-        Some(DateTime.parse("2024-02-28T12:34:00Z")),
+        Some(OffsetDateTime.parse("2024-02-28T12:34:00Z")),
         None
       )
     )

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -78,14 +78,14 @@ import com.normation.utils.DateFormaterService
 import com.normation.zio.*
 import io.scalaland.chimney.syntax.*
 import java.io.FileOutputStream
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.zip.ZipFile
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import net.liftweb.http.OutputStreamResponse
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.revwalk.RevWalk
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -107,7 +107,9 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
   val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
   val mockDirectives = new MockDirectives(mockTechniques)
 
-  val testDir: File = File(s"/tmp/test-rudder-response-content-${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}")
+  val testDir: File = File(
+    s"/tmp/test-rudder-response-content-${DateFormaterService.serializeOffsetDateTime(OffsetDateTime.now(ZoneOffset.UTC))}"
+  )
   testDir.createDirectoryIfNotExists(true)
 
   override def afterAll(): Unit = {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -47,10 +47,11 @@ import com.normation.rudder.rest.RudderJsonResponse.JsonRudderApiResponseError
 import com.normation.rudder.rest.RudderJsonResponse.LiftJsonResponse
 import com.normation.utils.DateFormaterService
 import com.normation.zio.*
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
-import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -71,7 +72,9 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
   ZioRuntime.unsafeRun(MainCampaignService.start(restTestSetUp.mockCampaign.mainCampaignService))
   val restTest      = new RestTest(restTestSetUp.liftRules)
 
-  val testDir: File = File(s"/tmp/test-rudder-campaign-${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}")
+  val testDir: File = File(
+    s"/tmp/test-rudder-campaign-${DateFormaterService.serializeOffsetDateTime(OffsetDateTime.now(ZoneOffset.UTC))}"
+  )
   testDir.createDirectoryIfNotExists(true)
 
   override def afterAll(): Unit = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -64,7 +64,6 @@ import jakarta.servlet.http.HttpServletResponse
 import java.time.Instant
 import java.util.Collection
 import net.liftweb.common.*
-import org.joda.time.DateTime
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -394,11 +393,12 @@ class AppConfigAuth extends ApplicationContextAware {
       override def authConfig: UserList = SingleUserList(encoder, admin)
     }
     (for {
+      now                 <- currentOffsetDateTimeUTC
       rootAccountUserRepo <- InMemoryUserRepository.make()
       _                   <- rootAccountUserRepo.setExistingUsers(
                                "root-account",
                                admin.map(_.getUsername).toList,
-                               EventTrace(com.normation.rudder.domain.eventlog.RudderEventActor, DateTime.now())
+                               EventTrace(com.normation.rudder.domain.eventlog.RudderEventActor, now)
                              )
     } yield {
       val provider = new DaoAuthenticationProvider(new RudderInMemoryUserDetailsService(authConfigProvider, rootAccountUserRepo))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -91,8 +91,6 @@ import net.liftweb.sitemap.Loc.*
 import net.liftweb.util.TimeHelpers.*
 import net.liftweb.util.Vendor
 import org.apache.commons.text.StringEscapeUtils
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.reflections.Reflections
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
@@ -356,37 +354,37 @@ object UserLogout {
       case auth =>
         auth.getPrincipal() match {
           case u: RudderUserDetail =>
-            val redirects: IterableOnce[Option[URI]] = {
-              (RudderConfig.userRepository.logCloseSession(u.getUsername, DateTime.now(DateTimeZone.UTC), endCause) *>
-              RudderConfig.eventLogRepository
-                .saveEventLog(
-                  ModificationId(RudderConfig.stringUuidGenerator.newUuid),
-                  LogoutEventLog(
-                    EventLogDetails(
-                      modificationId = None,
-                      principal = EventActor(u.getUsername),
-                      details = EventLog.emptyDetails,
-                      reason = None
-                    )
-                  )
-                ) *>
-              logoutActions.get.flatMap(actions => {
-                ZIO.foreach(actions)(a => {
-                  a.exec(auth)
-                    .catchAll(err => {
-                      ApplicationLoggerPure.error(
-                        s"Error when performing logout action '${a.id}': ${err.fullMsg}"
-                      ) *> None.succeed
-                    })
-                })
-              }))
-                .catchAll(err =>
-                  ApplicationLoggerPure.error(s"Error when saving user login event log result: ${err.fullMsg}") *> None.succeed
-                )
-                .runNow
-            }
-
-            redirects.iterator.toSeq.headOption.flatten
+            (
+              for {
+                now       <- currentOffsetDateTimeUTC
+                _         <- RudderConfig.userRepository.logCloseSession(u.getUsername, now, endCause)
+                _         <- RudderConfig.eventLogRepository.saveEventLog(
+                               ModificationId(RudderConfig.stringUuidGenerator.newUuid),
+                               LogoutEventLog(
+                                 EventLogDetails(
+                                   modificationId = None,
+                                   principal = EventActor(u.getUsername),
+                                   details = EventLog.emptyDetails,
+                                   reason = None
+                                 )
+                               )
+                             )
+                actions   <- logoutActions.get
+                redirects <- ZIO.foreach(actions) { action =>
+                               action
+                                 .exec(auth)
+                                 .catchAll { err =>
+                                   ApplicationLoggerPure.error(
+                                     s"Error when performing logout action '${action.id}': ${err.fullMsg}"
+                                   ) *> None.succeed
+                                 }
+                             }
+              } yield redirects.headOption.flatten
+            )
+              .catchAll(err =>
+                ApplicationLoggerPure.error(s"Error when saving user login event log result: ${err.fullMsg}") *> None.succeed
+              )
+              .runNow
 
           case x => // impossible to know who is login out
             ApplicationLogger.debug(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderAuthorizationFileReloadCallback.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderAuthorizationFileReloadCallback.scala
@@ -39,8 +39,7 @@ package bootstrap.liftweb
 
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.users.*
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import com.normation.zio.currentOffsetDateTimeUTC
 
 /*
  * A callback that is in charge of updating the list of UserInfo managed by the file authenticator.
@@ -50,18 +49,16 @@ object UserRepositoryUpdateOnFileReload {
     RudderAuthorizationFileReloadCallback(
       "update-pg-users-on-xml-file-reload",
       userList => {
-        userRepository
-          .setExistingUsers(
-            DefaultAuthBackendProvider.FILE,
-            userList.users.keys.toList,
-            EventTrace(
-              RudderEventActor,
-              DateTime.now(DateTimeZone.UTC),
-              "Updating users because `rudder-users.xml` was reloaded"
-            ),
-            userList.isCaseSensitive
-          )
-          .unit
+        for {
+          now <- currentOffsetDateTimeUTC
+          _   <- userRepository
+                   .setExistingUsers(
+                     origin = DefaultAuthBackendProvider.FILE,
+                     userIds = userList.users.keys.toList,
+                     trace = EventTrace(RudderEventActor, now, "Updating users because `rudder-users.xml` was reloaded"),
+                     isCaseSensitive = userList.isCaseSensitive
+                   )
+        } yield ()
       }
     )
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -155,7 +155,6 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import scala.collection.mutable.Buffer
-import scala.concurrent.duration
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 import zio.{Scheduler as _, System as _, *}
@@ -776,8 +775,8 @@ object RudderParsedProperties {
   // THIS ONE IS STILL USED FOR USERS USING GIT REPLICATION
   val RUDDER_AUTOARCHIVEITEMS: Boolean = config.getBoolean("rudder.autoArchiveItems") // true
 
-  val RUDDER_REPORTS_EXECUTION_INTERVAL: duration.Duration =
-    config.getInt("rudder.batch.storeAgentRunTimes.updateInterval").seconds.asScala
+  val RUDDER_REPORTS_EXECUTION_INTERVAL: java.time.Duration =
+    config.getInt("rudder.batch.storeAgentRunTimes.updateInterval").seconds
 
   val HISTORY_INVENTORIES_ROOTDIR: String = config.getString("history.inventories.rootdir")
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManagerUtil.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManagerUtil.scala
@@ -7,9 +7,9 @@ import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.users.SessionId
 import com.normation.rudder.users.UserRepository
 import com.normation.zio.UnsafeRun
-import org.joda.time.DateTime
 import org.springframework.web.context.request.RequestAttributes
 import org.springframework.web.context.request.ServletRequestAttributes
+import zio.Clock
 import zio.syntax.*
 
 /**
@@ -23,35 +23,41 @@ object RudderProviderManagerUtil {
       provider:          String,
       requestAttributes: RequestAttributes
   ): Unit = {
-    (userRepository
-      .logStartSession(
-        details.getUsername,
-        com.normation.rudder.Role.toDisplayNames(details.roles),
-        com.normation.rudder.Rights
-          .combineAll(details.roles.toList.map(_.rights))
-          .authorizationTypes
-          .toList
-          .map(_.id),
-        details.accessGrant.value,
-        sessionId,
-        provider,
-        DateTime.now
-      )
-      .catchSome {
-        case Inconsistency(msg) =>
-          requestAttributes match {
-            case requestAttrs: ServletRequestAttributes =>
-              IOResult.attempt(requestAttrs.getRequest().getSession(false).invalidate())
-            case _ =>
-              // There is nothing we can do to change the user session programmatically, user will have to change session id manually
-              ApplicationLoggerPure.warn(
-                "Rudder does not know how to handle the current authentication request using " + requestAttributes.getClass.getName + ". Please retry to log in after clearing the browser cache."
-              ) *>
-              Inconsistency("Refused authentication: " + msg).fail
-          }
-      } *> // user session is started with known rights and password, we need to update users sessions cache to invalidate any change in user access
-    LiftSpringApplicationContext.springContext
-      .getBean(classOf[UserSessionInvalidationFilter])
-      .updateUser(details)).runNow
+
+    (for {
+      now <- Clock.currentDateTime
+      _   <- userRepository
+               .logStartSession(
+                 details.getUsername,
+                 com.normation.rudder.Role.toDisplayNames(details.roles),
+                 com.normation.rudder.Rights
+                   .combineAll(details.roles.toList.map(_.rights))
+                   .authorizationTypes
+                   .toList
+                   .map(_.id),
+                 details.accessGrant.value,
+                 sessionId,
+                 provider,
+                 now
+               )
+               .catchSome {
+                 case Inconsistency(msg) =>
+                   requestAttributes match {
+                     case requestAttrs: ServletRequestAttributes =>
+                       IOResult.attempt(requestAttrs.getRequest().getSession(false).invalidate())
+                     case _ =>
+                       // There is nothing we can do to change the user session programmatically, user will have to change session id manually
+                       ApplicationLoggerPure.warn(
+                         "Rudder does not know how to handle the current authentication request using " + requestAttributes.getClass.getName + ". Please retry to log in after clearing the browser cache."
+                       ) *>
+                       Inconsistency("Refused authentication: " + msg).fail
+                   }
+               }
+      _   <-
+        // user session is started with known rights and password, we need to update users sessions cache to invalidate any change in user access
+        LiftSpringApplicationContext.springContext
+          .getBean(classOf[UserSessionInvalidationFilter])
+          .updateUser(details)
+    } yield ()).runNow
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -45,13 +45,12 @@ import com.normation.rudder.users.UserRepository
 import com.normation.rudder.users.UserStatus
 import com.normation.rudder.users.ValidatedUserList
 import com.normation.zio.UnsafeRun
+import com.normation.zio.currentOffsetDateTimeUTC
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import java.io.IOException
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 import zio.*
@@ -120,14 +119,12 @@ class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailLi
                             .fail
                       },
                       _ => {
-                        userRepository.logCloseSession(
-                          user.getUsername,
-                          DateTime.now(DateTimeZone.UTC),
-                          endSessionReason
-                        ) *>
-                        ApplicationLoggerPure.info(
-                          s"User session for user '${username}' is invalidated because : ${reason}"
-                        )
+                        for {
+                          now <- currentOffsetDateTimeUTC
+                          _   <- userRepository.logCloseSession(user.getUsername, now, endSessionReason)
+                          _   <-
+                            ApplicationLoggerPure.info(s"User session for user '${username}' is invalidated because : ${reason}")
+                        } yield ()
                       }
                     )
                 case _                 =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CloseOpenUserSessions.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CloseOpenUserSessions.scala
@@ -42,8 +42,6 @@ import bootstrap.liftweb.BootstrapLogger
 import com.normation.rudder.users.*
 import com.normation.zio.*
 import jakarta.servlet.UnavailableException
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 
 /**
  * This class check that all user sessions are closed
@@ -56,8 +54,10 @@ class CloseOpenUserSessions(
 
   @throws(classOf[UnavailableException])
   override def checks(): Unit = {
-    userRepository
-      .closeAllOpenSession(DateTime.now(DateTimeZone.UTC), "sessions still opened while Rudder is starting")
+    (for {
+      now <- currentOffsetDateTimeUTC
+      _   <- userRepository.closeAllOpenSession(now, "sessions still opened while Rudder is starting")
+    } yield ())
       .catchAll(err => BootstrapLogger.error(s"Error when closing user sessions when Rudder restart: ${err.fullMsg}"))
       .runNow
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/FixedPathLoggerMigration.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/FixedPathLoggerMigration.scala
@@ -3,8 +3,8 @@ package bootstrap.liftweb.checks.endconfig.migration
 import bootstrap.liftweb.BootstrapChecks
 import bootstrap.liftweb.BootstrapLogger
 import com.normation.utils.DateFormaterService
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import org.springframework.core.io.ClassPathResource
 import scala.xml.Elem
 import scala.xml.Node as XmlNode
@@ -147,7 +147,8 @@ class FixedPathLoggerMigration extends BootstrapChecks {
 
     if (shouldMigrateLogback) {
       val newLogback = migrateLogback(xml)
-      val backPath   = logbackFile.parent / s"logback.xml-backup-${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}"
+      val backPath   =
+        logbackFile.parent / s"logback.xml-backup-${DateFormaterService.serializeOffsetDateTime(OffsetDateTime.now(ZoneOffset.UTC))}"
 
       // In case file already exists
       logbackFile.copyTo(backPath, overwrite = true)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
@@ -44,6 +44,7 @@ import com.normation.rudder.Role
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.users.CurrentUser
 import com.normation.utils.DateFormaterService
+import com.normation.utils.DateFormaterService.toJodaDateTime
 import com.normation.zio.*
 import net.liftweb.common.*
 import net.liftweb.http.*
@@ -74,7 +75,7 @@ class UserInformation extends DispatchSnippet with DefaultExtendableSnippet[User
         val lastSession = userRepo.getLastPreviousLogin(u.getUsername).runNow match {
           case None    => ""
           case Some(s) =>
-            s"Last login on '${DateFormaterService.getDisplayDate(s.creationDate)}' with '${s.authMethod}' authentication"
+            s"Last login on '${DateFormaterService.getDisplayDate(s.creationDate.toJodaDateTime)}' with '${s.authMethod}' authentication"
         }
 
         "#openerAccount" #> <span id="openerAccount" title={List(roles, lastSession).mkString("\n")}>{displayName}</span>

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -38,6 +38,8 @@ import com.normation.errors.SystemError
 import com.normation.errors.effectUioUnit
 import io.scalaland.chimney.cats.*
 import io.scalaland.chimney.partial.*
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 import net.liftweb.common.{Logger as _, *}
 import org.slf4j.*
@@ -440,6 +442,8 @@ object errors {
 }
 
 object zio {
+
+  val currentOffsetDateTimeUTC: UIO[OffsetDateTime] = Clock.instant.map(_.atOffset(ZoneOffset.UTC))
 
   val currentTimeMillis: ZIO[Any, Nothing, Long] = ZIO.clockWith(_.currentTime(TimeUnit.MILLISECONDS))
 //    ZIO.access[_root_.zio.clock.Clock](_.get.currentTime(TimeUnit.MILLISECONDS))

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -65,11 +65,26 @@ object DateFormaterService {
 
     // see https://stackoverflow.com/a/47753227 - read other solution and the comment in them, too
     def toZonedDateTime: ZonedDateTime = self.toJavaInstant.atZone(ZoneId.of(self.getZone.getID, ZoneId.SHORT_IDS))
+
+    def toOffsetDateTime: OffsetDateTime = {
+      OffsetDateTime.ofInstant(
+        self.toJavaInstant,
+        ZoneOffset.ofTotalSeconds(self.getZone.getOffset(self) / 2000)
+      )
+    }
   }
 
   extension (self: Instant) {
     def toJodaDateTime: DateTime = new DateTime(self.toEpochMilli, DateTimeZone.UTC)
   }
+
+  extension (self: OffsetDateTime)
+    def toJodaDateTime: DateTime = {
+      new DateTime(
+        self.toInstant.toEpochMilli,
+        DateTimeZone.forOffsetMillis(self.getOffset.getTotalSeconds * 1000)
+      )
+    }
 
   implicit class JavaTimeToJoda(x: ZonedDateTime) {
     // see https://stackoverflow.com/a/37335420 - read other solution and the comment in them, too

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/DateFormaterServiceSpec.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/DateFormaterServiceSpec.scala
@@ -1,6 +1,8 @@
 package com.normation.utils
 
 import com.normation.utils.DateFormaterService.JavaTimeToJoda
+import com.normation.utils.DateFormaterService.toJodaDateTime
+import com.normation.utils.DateFormaterService.toOffsetDateTime
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
@@ -50,6 +52,18 @@ class DateFormaterServiceSpec extends ZIOSpecDefault {
     .filterNot(_.getZone.toString.startsWith("SystemV")) // not supported by joda
 
   def spec = suite("DateFormaterService")(
+    suite("extension methods")(
+      test("toOffsetDateTime + toJodateDateTime should be idempotent") {
+        check(
+          Gen
+            .offsetDateTime(
+              min = Instant.EPOCH.atOffset(ZoneOffset.UTC),
+              max = Instant.parse("9999-01-01T00:00:00Z").atOffset(ZoneOffset.UTC)
+            )
+            .map(_.truncatedTo(ChronoUnit.MILLIS))
+        )(offsetDateTime => assert(offsetDateTime.toJodaDateTime.toOffsetDateTime)(equalTo(offsetDateTime)))
+      }
+    ),
     test("basicDateTimeFormatter should behave like jodatime ISODateTimeFormat.basicDateTime()") {
       check(Gen.instant(min = Instant.EPOCH, max = Instant.parse("9999-01-01T00:00:00Z"))) { input =>
         assert(DateFormaterService.formatAsBasicDateTime(input))(


### PR DESCRIPTION
https://issues.rudder.io/issues/28874

Several porting to java-time "offset datetime" serialisation, and some ZonedDateTime too.

For the history of commits, see the original PR from @mbaechler: https://github.com/Normation/rudder/pull/7132.

The next steps would be about removing the `DateFormaterService#serialize(dateTime: org.joda.datetime.DateTime)` method (which was "Deprecated" in the original PR, but still used for now, we would still need to check plugins too)