### PR TITLE
Fixes #28878: The export of archive is broken

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
@@ -97,6 +97,7 @@ object GitFindUtils extends NamedZioLogger {
       while (tw.next) {
         paths += tw.getPathString
       }
+      tw.close()
 
       paths.toSet
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
@@ -65,7 +65,6 @@ import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleTargetInfo
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.properties.GlobalParameter
-import com.normation.rudder.git.FileTreeFilter
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitFindUtils
 import com.normation.rudder.git.GitRepositoryProvider
@@ -87,7 +86,6 @@ import java.io.InputStream
 import java.nio.file.Paths
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Repository
-import org.eclipse.jgit.treewalk.TreeWalk
 import zio.*
 import zio.syntax.*
 
@@ -168,7 +166,7 @@ class GitParseRules(
     for {
       treeId <- GitFindUtils.findRevTreeFromRevString(repo.db, rev.value)
       // rules are just under "rules", but use list to check is one exists on that revtree
-      rules  <- GitFindUtils.listFiles(repo.db, treeId, List(rulesDirectory.directoryPath), uid.value + ".xml" :: Nil)
+      rules  <- GitFindUtils.listFiles(repo.db, treeId, List(rulesDirectory.directoryPath), s"/${uid.value}.xml" :: Nil)
       res    <- rules.toList match {
                   case Nil      => None.succeed
                   case h :: Nil =>
@@ -378,7 +376,7 @@ class GitParseGroupLibrary(
       // nodegroups are any where in the subtree with parent directory name == uuid of the group category.
       // So we need to find the group by name, and split path to get its category. Be careful, the name of root
       // category is not "groups" but "GroupRoot"
-      groups <- GitFindUtils.listFiles(repo.db, treeId, List(groupsDirectory.directoryPath), uid.value + ".xml" :: Nil)
+      groups <- GitFindUtils.listFiles(repo.db, treeId, List(groupsDirectory.directoryPath), s"/{uid.value}.xml" :: Nil)
       res    <- groups.toList match {
                   case Nil      => None.succeed
                   case h :: Nil =>
@@ -465,7 +463,7 @@ class GitParseTechniqueLibrary(
       _      <- ConfigurationLoggerPure.revision.debug(s"Looking for technique: ${id.debugString}")
       treeId <- GitFindUtils.findRevTreeFromRevString(repo.db, rev.value)
       _      <- ConfigurationLoggerPure.revision.trace(s"Git tree corresponding to revision: ${rev.value}: ${treeId.toString}")
-      paths  <- GitFindUtils.listFiles(repo.db, treeId, List(root), List(s"${id.withDefaultRev.serialize}/${techniqueMetadata}"))
+      paths  <- GitFindUtils.listFiles(repo.db, treeId, List(root), List(s"/${id.withDefaultRev.serialize}/${techniqueMetadata}"))
       _      <- ConfigurationLoggerPure.revision.trace(s"Found candidate paths: ${paths}")
       tuple  <- paths.size match {
                   case 0 =>
@@ -557,7 +555,7 @@ class GitParseTechniqueLibrary(
                    repo.db,
                    current,
                    List(root),
-                   List(s"${name.value}/${version.toVersionString}/${metadata}")
+                   List(s"/${name.value}/${version.toVersionString}/${metadata}")
                  ) // we are just looking for the path here
       path    <- optPath.toList match {
                    case Nil      => Inconsistency(s"Technique '${name.value}/${version.toVersionString}' not found f").fail
@@ -590,23 +588,19 @@ class GitParseTechniqueLibrary(
     /*
      * find the path of the technique version
      */
-    def getFilePath(db: Repository, revTreeId: ObjectId, techniqueId: TechniqueId) = {
-      IOResult.attempt {
-        // a first walk to find categories
-        val tw     = new TreeWalk(db)
-        // there is no directory in git, only files
-        val filter = new FileTreeFilter(List(root + "/"), List(techniqueId.withDefaultRev.serialize + "/" + techniqueMetadata))
-        tw.setFilter(filter)
-        tw.setRecursive(true)
-        tw.reset(revTreeId)
-
-        var path = Option.empty[String]
-        while (tw.next && path.isEmpty) {
-          path = Some(tw.getPathString)
-          tw.close()
+    def getFilePath(db: Repository, revTreeId: ObjectId, techniqueId: TechniqueId): IOResult[Option[String]] = {
+      GitFindUtils
+        .listFiles(db, revTreeId, List(root + "/"), List("/" + techniqueId.withDefaultRev.serialize + "/" + techniqueMetadata))
+        .flatMap { set =>
+          set.toList match {
+            case Nil         => None.succeed
+            case path :: Nil => Some(path.replaceAll("/" + techniqueMetadata, "")).succeed
+            case several     =>
+              Inconsistency(
+                s"Error when looking for technique '${techniqueId.serialize}', several paths match: '${several.mkString("', '")}'"
+              ).fail
+          }
         }
-        path.map(_.replaceAll("/" + techniqueMetadata, ""))
-      }
     }
 
     for {
@@ -680,7 +674,7 @@ class GitParseActiveTechniqueLibrary(
       _      <- ConfigurationLoggerPure.revision.debug(s"Looking for directive: ${DirectiveId(uid, rev).debugString}")
       treeId <- GitFindUtils.findRevTreeFromRevString(repo.db, rev.value)
       _      <- ConfigurationLoggerPure.revision.trace(s"Git tree corresponding to revision: ${rev.value}: ${treeId.toString}")
-      paths  <- GitFindUtils.listFiles(repo.db, treeId, List(root), List(s"${uid.value}.xml"))
+      paths  <- GitFindUtils.listFiles(repo.db, treeId, List(root), List(s"/${uid.value}.xml"))
       _      <- ConfigurationLoggerPure.revision.trace(s"Found candidate paths: ${paths}")
       pair   <- paths.size match {
                   case 0 =>
@@ -726,7 +720,7 @@ class GitParseActiveTechniqueLibrary(
       current <- revisionProvider.currentRevTreeId
       // find the file name, then look for revision for that path
       optPath <-
-        GitFindUtils.listFiles(repo.db, current, List(root), List(uid.serialize + ".xml")) // not sur about the version here
+        GitFindUtils.listFiles(repo.db, current, List(root), List(s"/${uid.serialize}.xml")) // not sur about the version here
       path    <- optPath.toList match {
                    case Nil      => Inconsistency(s"Directive with UID '${uid.value}' not found f").fail
                    case p :: Nil => p.succeed

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/category.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/category.xml
@@ -1,0 +1,22 @@
+<!--
+Copyright 2011 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, Version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<xml>
+    <name>Technique library root</name>
+    <description>
+        This is the root category for the Techniques library. It contains Techniques provided by Normation.
+    </description>
+</xml>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/Create_file/1.0/Create_file.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/Create_file/1.0/Create_file.ps1
@@ -1,0 +1,1 @@
+﻿# Placeholder file

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/Create_file/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/Create_file/1.0/metadata.xml
@@ -1,0 +1,26 @@
+<TECHNIQUE name="Create a file">
+  <POLICYGENERATION>separated-with-parameters</POLICYGENERATION>
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+  <USEMETHODREPORTING>true</USEMETHODREPORTING>
+  <DESCRIPTION>Create a file and a directory</DESCRIPTION>
+  <BUNDLES>
+    <NAME>Create_file</NAME>
+    <NAME agent="cfe">Create_file_rudder_reporting</NAME>
+  </BUNDLES>
+  <TMLS>
+    <TML name="rudder_reporting"/>
+  </TMLS>
+  <FILES>
+    <FILE name="RUDDER_CONFIGURATION_REPOSITORY/ncf/50_techniques/Create_file/Create_file.cf">
+      <INCLUDED>true</INCLUDED>
+    </FILE>
+  </FILES>
+
+  <SECTIONS>
+    <SECTION component="true" multivalued="true" name="Directory create">
+      <REPORTKEYS>
+        <VALUE><![CDATA[/tmp/foo]]></VALUE>
+      </REPORTKEYS>
+    </SECTION>
+  </SECTIONS>
+</TECHNIQUE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/Create_file/1.0/rudder_reporting.st
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/Create_file/1.0/rudder_reporting.st
@@ -1,0 +1,1 @@
+placeholder

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/category.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/ncf_techniques/category.xml
@@ -1,0 +1,6 @@
+<xml>
+  <name>Meta Techniques</name>
+  <description>
+    Meta Techniques created using the ncf framework.
+  </description>
+</xml>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/zz_last/category.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/zz_last/category.xml
@@ -1,0 +1,3 @@
+<xml>
+    <name>Last category</name>
+</xml>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/zz_last/file/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/zz_last/file/1.0/metadata.xml
@@ -1,0 +1,30 @@
+<TECHNIQUE name="Packages">
+  <DESCRIPTION>This technique operates on individual packages.
+
+  It will ensure that the defined packages are in the desired state using the appropriate package manager.</DESCRIPTION>
+
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+
+  <BUNDLES>
+    <NAME>package_management</NAME>
+  </BUNDLES>
+
+  <TMLS>
+    <TML name="packageManagement"/>
+  </TMLS>
+
+  <TRACKINGVARIABLE>
+    <SAMESIZEAS>PACKAGE_LIST</SAMESIZEAS>
+  </TRACKINGVARIABLE>
+
+  <SECTIONS>
+    <SECTION name="Package" multivalued="true" component="true" componentKey="PACKAGE_LIST">
+      <INPUT>
+        <NAME>PACKAGE_LIST</NAME>
+        <DESCRIPTION>Package name (or path)</DESCRIPTION>
+        <LONGDESCRIPTION>You can use a path to install a local package, when using the "present" state.</LONGDESCRIPTION>
+      </INPUT>
+      </SECTION>
+  </SECTIONS>
+</TECHNIQUE>
+

--- a/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/zz_last/file/1.0/packageManagement.st
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/same-end-technique-name/techniques/zz_last/file/1.0/packageManagement.st
@@ -1,0 +1,1 @@
+placeholder

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
@@ -240,7 +240,7 @@ class JGitRepositoryTest extends Specification with Loggable with AfterAll {
 
       }
 
-      "does nothing when the category already exsits" in {
+      "does nothing when the category already exists" in {
         techniqueArchive.saveTechniqueCategory(catPath, category, modId, EventActor("test"), s"test: commit again").runNow
         val lastCommitMsg = repo.git.log().setMaxCount(1).call().iterator().next().getFullMessage
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitParseRudderObjects.scala
@@ -1,0 +1,98 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.repository.xml
+
+import com.normation.GitVersion.Revision
+import com.normation.cfclerk.domain.TechniqueCategoryName
+import com.normation.cfclerk.domain.TechniqueId
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.domain.TechniqueVersion
+import com.normation.rudder.services.policies.TestTechniqueRepo
+import com.normation.utils.ParseVersion
+import com.normation.zio.*
+import net.liftweb.common.Loggable
+import org.apache.commons.io.FileUtils
+import org.junit.runner.RunWith
+import org.specs2.matcher.ContentMatchers
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+import zio.Chunk
+
+@RunWith(classOf[JUnitRunner])
+class TestGitParseRudderObjects extends Specification with Loggable with AfterAll with ContentMatchers {
+
+  ////////// set up / clean-up and utilities //////////
+
+  lazy val testRepo     = new TestTechniqueRepo("", "same-end-technique-name", None)
+  lazy val abstractRoot = testRepo.abstractRoot
+  lazy val parseObjects = new GitParseTechniqueLibrary(
+    testRepo.draftParser,
+    testRepo.repo,
+    testRepo.gitRevisionProvider,
+    "techniques",
+    "metadata.xml"
+  )
+
+  override def afterAll(): Unit = {
+    if (System.getProperty("tests.clean.tmp") != "false") {
+      logger.debug("Deleting directory " + abstractRoot.getAbsolutePath)
+      FileUtils.deleteDirectory(abstractRoot.getAbsoluteFile)
+    }
+  }
+
+  val v1_0 = ParseVersion.parse("1.0").getOrElse(throw new RuntimeException("Version 1.0"))
+
+  sequential
+
+  "looking for technique with the same end name" should {
+    "return the correct one" in {
+      val res = parseObjects.getTechnique(TechniqueName("file"), v1_0, Revision("master")).runNow
+
+      res.map(_._1) must (beSome((Chunk(TechniqueCategoryName("zz_last")))))
+      res.map(_._2.id.serialize) must (beSome("file/1.0+master"))
+    }
+
+    "give the correct resources" in {
+      val res = parseObjects.getTechniqueFileContents(TechniqueId(TechniqueName("file"), TechniqueVersion.V1_0)).runNow
+
+      // must not contain Create_file.ps1 etc
+      res.map(_.map(_._1).toSet) must (beSome(containTheSameElementsAs(List("metadata.xml", "packageManagement.st"))))
+    }
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/28878

So, we are using a filter that only matches the end of the path, and it stops on the first matches. If you happen to have two techniques with the same end, it never work correctly for the first one. 

The problem is all around `GitParseRudderObjects.scala` file, which was create to deal with technique at a certain revision point, and hopefuly that we don't use a lot. 

Moreover, in the specific case of getting technique resources, we rewrote the git filter logic, which we should really avoid to do, because it's not the kind of horror that we want to duplicate. 

So the whole correction is small: 
- replace the ad-hoc filtered tree traversal by `GitFindUtils.listFiles`
- add leading `/` in `listFiles` so that we disambiguate between `/blabla_something/foo/bar` and `/something/foo/bar`

Most of the other changes are related to the unit test and set-uping the repo with two techniques. 