### PR TITLE
Fixes #28903: file_from_shared_folder result condition is invalid because of invalid class_prefix

### DIFF
--- a/policies/lib/tree/30_generic_methods/file_from_shared_folder.cf
+++ b/policies/lib/tree/30_generic_methods/file_from_shared_folder.cf
@@ -39,7 +39,7 @@
 bundle agent file_from_shared_folder(source, path, hash_type)
 {
   vars:
-      "class_prefix" string => "file_from_shared_folder_${canonified_path}";
+      "class_prefix" string =>  canonify("file_from_shared_folder_${path}");
 
       "audit_arg"    string => "";
     (global_dry_run|dry_run)::


### PR DESCRIPTION
https://issues.rudder.io/issues/28903