### PR TITLE
Fixes #20614: VMmemory attribute should be an integer, not a string

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/resources/ldap/inventory.schema
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/resources/ldap/inventory.schema
@@ -523,9 +523,9 @@ attributetype ( InventoryAttributes:400.15
 attributetype ( InventoryAttributes:400.16
   NAME 'vmMemory'
   DESC 'process virtual memory'
-  EQUALITY caseIgnoreMatch
-  SUBSTR caseIgnoreSubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
 
 
 #

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/resources/ldap-data/schema/099-0-inventory.ldif
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/resources/ldap-data/schema/099-0-inventory.ldif
@@ -426,9 +426,9 @@ attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.15
 attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.16
   NAME 'vmMemory'
   DESC 'process virtual memory'
-  EQUALITY caseIgnoreMatch
-  SUBSTR caseIgnoreSubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
 #
 # A machine can have some complex "physicale" elements:
 # * bios

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-0-inventory.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-0-inventory.ldif
@@ -426,9 +426,9 @@ attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.15
 attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.16
   NAME 'vmMemory'
   DESC 'process virtual memory'
-  EQUALITY caseIgnoreMatch
-  SUBSTR caseIgnoreSubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
 #
 # A machine can have some complex "physicale" elements:
 # * bios

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-0-inventory.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-0-inventory.ldif
@@ -432,9 +432,9 @@ attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.15
 attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.16
   NAME 'vmMemory'
   DESC 'process virtual memory'
-  EQUALITY caseIgnoreMatch
-  SUBSTR caseIgnoreSubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
 #
 # A machine can have some complex "physicale" elements:
 # * bios


### PR DESCRIPTION
https://issues.rudder.io/issues/20614

So just changing the schema seems to be enought. I didn't switch to "memory" type, because it was already switched to a "long" comparator, and so the change remains minimal. 