### PR TITLE
Fixes #28912: Add a configurable target for root node policies directory

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PathComputer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PathComputer.scala
@@ -41,6 +41,7 @@ import com.normation.errors.*
 import com.normation.inventory.domain.AgentType
 import com.normation.inventory.domain.AgentType.CfeCommunity
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FilenameUtils
@@ -172,7 +173,7 @@ class PathComputerImpl(
                 s"Can not find the parent node with id '${pid.value}' of node '${toNode.fqdn}' (${toNodeId.value}) when trying to build the policies files for node ${fromNodeId.value}"
               )
           result <- parent match {
-                      case root if root.id == NodeId("root") =>
+                      case root if root.id == Constants.ROOT_POLICY_SERVER_ID =>
                         // root is a specific case, it is the root of everything
                         recurseComputePath(fromNodeId, root.id, path, allNodeConfig, root.id :: chain)
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PromiseWriteDataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PromiseWriteDataStructures.scala
@@ -122,11 +122,9 @@ final case class AgentNodeWritableConfiguration(
  * A back-up folder is also provided to save a copy.
  */
 final case class NodePoliciesPaths(
-    nodeId:     NodeId,
-    baseFolder: String, // /var/rudder/share/xxxx-xxxxx-xxxx/rules/cfengine-community
-
-    newFolder: String, // /var/rudder/share/xxxx-xxxxx-xxxx/rules.new/cfengine-community
-
+    nodeId:       NodeId,
+    baseFolder:   String, // /var/rudder/share/xxxx-xxxxx-xxxx/rules/cfengine-community
+    newFolder:    String, // /var/rudder/share/xxxx-xxxxx-xxxx/rules.new/cfengine-community
     backupFolder: Option[String]
 )
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -919,6 +919,17 @@ object RudderParsedProperties {
         "rudder-policy-reader"
     }
   }
+  val RUDDER_GENERATED_POLICIES_ROOT_PATH:    String   = {
+    try {
+      config.getString("rudder.generated.policies.rootserver.path")
+    } catch {
+      case ex: Exception =>
+        ApplicationLogger.info(
+          s"Property 'rudder.generated.policies.rootserver.path' is absent or empty in rudder.configFile. Default to '${Constants.CFENGINE_COMMUNITY_PROMISES_PATH}'."
+        )
+        Constants.CFENGINE_COMMUNITY_PROMISES_PATH
+    }
+  }
 
   val RUDDER_RELAY_API: String = config.getString("rudder.server.relay.api")
 
@@ -2579,7 +2590,7 @@ object RudderConfigInit {
       Constants.NODE_PROMISES_PARENT_DIR_BASE,
       Constants.NODE_PROMISES_PARENT_DIR,
       RUDDER_DIR_BACKUP,
-      Constants.CFENGINE_COMMUNITY_PROMISES_PATH
+      RUDDER_GENERATED_POLICIES_ROOT_PATH
     )
 
     /*


### PR DESCRIPTION
https://issues.rudder.io/issues/28912

Make root node policies directory configurable. Half the PR is format consistancy cleaning. The PR is literally "just get the config value it properties file and use that in place of the default one". 

Everything seems to work as intented - of course, not at all with current set-up, since we miss a `/opt/rudder/etc/hooks.d/policy-generation-node-finished/` hook or whatever that would move the files in the correct place with the correct rights. 
