### PR TITLE
Fixes #28885: Refactoring with opaque types 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -49,6 +49,8 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.ReportType.*
 import com.normation.rudder.reports.ComplianceModeName
+import com.normation.rudder.rest.data.CsvCompliance.*
+import com.normation.rudder.rest.data.CsvCompliance.CsvComplianceOpaqueTypes.*
 import com.normation.rudder.web.services.ComputePolicyMode.ComputedPolicyMode
 import com.normation.utils.Csv
 import enumeratum.*
@@ -59,6 +61,7 @@ import java.lang
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.QuoteMode
 import scala.collection.immutable
+import zio.json.JsonCodec
 import zio.json.JsonEncoder
 import zio.syntax.ToZio
 
@@ -125,7 +128,7 @@ final case class ByDirectiveByRuleCompliance(
 
 final case class ByDirectiveNodeCompliance(
     id:         NodeId,
-    name:       String,
+    name:       NodeName,
     policyMode: ComputedPolicyMode,
     compliance: ComplianceLevel,
     rules:      Seq[ByDirectiveByNodeRuleCompliance]
@@ -174,9 +177,17 @@ final case class ByNodeGroupByRuleDirectiveCompliance(
     components:     Seq[ByRuleComponentCompliance]
 )
 
+opaque type DirectiveName = String
+object DirectiveName extends CsvField[DirectiveName] {
+
+  given jsonCodec: JsonCodec[DirectiveName] = JsonCodec.string
+
+  def apply(name: String): DirectiveName = name
+}
+
 final case class ByRuleDirectiveCompliance(
     id:             DirectiveId,
-    name:           String,
+    name:           DirectiveName,
     compliance:     ComplianceLevel,
     skippedDetails: Option[SkippedDetails],
     policyMode:     ComputedPolicyMode,
@@ -184,26 +195,26 @@ final case class ByRuleDirectiveCompliance(
 )
 
 sealed trait ByRuleComponentCompliance extends ComponentComplianceByNode {
-  def name:       String
+  def name:       ComponentName
   def compliance: ComplianceLevel
 }
 
 final case class ByRuleBlockCompliance(
-    name:           String,
+    name:           BlockName,
     reportingLogic: ReportingLogic,
     subComponents:  Seq[ByRuleComponentCompliance]
 ) extends ByRuleComponentCompliance with BlockComplianceByNode[ByRuleComponentCompliance] {
   override def subs: List[ByRuleComponentCompliance & ComponentCompliance] = subComponents.toList
 
-  override def componentName: String = name
+  override def componentName: String = name.value
 }
 
 final case class ByRuleValueCompliance(
-    name:       String,
+    name:       ValueName,
     compliance: ComplianceLevel,
     nodes:      List[ByRuleNodeCompliance]
 ) extends ByRuleComponentCompliance {
-  override def componentName: String = name
+  override def componentName: String = name.value
 
   override def allReports: List[ReportType] = reportsByNode.values.flatten.toList
 
@@ -213,7 +224,7 @@ final case class ByRuleValueCompliance(
 
 final case class ByRuleNodeCompliance(
     id:         NodeId,
-    name:       String,
+    name:       NodeName,
     policyMode: ComputedPolicyMode,
     compliance: ComplianceLevel,
     values:     Seq[ComponentValueStatusReport]
@@ -230,7 +241,7 @@ final case class ByRuleNodeCompliance(
 
 final case class GroupComponentCompliance(
     id:         NodeId,
-    name:       String,
+    name:       NodeName,
     compliance: ComplianceLevel,
     policyMode: ComputedPolicyMode,
     directives: Seq[ByRuleByNodeByDirectiveCompliance]
@@ -238,7 +249,7 @@ final case class GroupComponentCompliance(
 
 final case class ByRuleByNodeByDirectiveCompliance(
     id:             DirectiveId,
-    name:           String,
+    name:           DirectiveName,
     compliance:     ComplianceLevel,
     skippedDetails: Option[SkippedDetails],
     policyMode:     ComputedPolicyMode,
@@ -246,26 +257,26 @@ final case class ByRuleByNodeByDirectiveCompliance(
 )
 
 sealed trait ByRuleByNodeByDirectiveByComponentCompliance extends ComponentCompliance {
-  def name:       String
+  def name:       ComponentName
   def compliance: ComplianceLevel
 }
 
 final case class ByRuleByNodeByDirectiveByBlockCompliance(
-    name:           String,
+    name:           BlockName,
     reportingLogic: ReportingLogic,
     subComponents:  Seq[ByRuleByNodeByDirectiveByComponentCompliance]
 ) extends ByRuleByNodeByDirectiveByComponentCompliance with BlockCompliance[ByRuleByNodeByDirectiveByComponentCompliance] {
   override def subs: List[ByRuleByNodeByDirectiveByComponentCompliance & ComponentCompliance] = subComponents.toList
 
-  override def componentName: String = name
+  override def componentName: String = name.value
 }
 
 final case class ByRuleByNodeByDirectiveByValueCompliance(
-    name:       String,
+    name:       ValueName,
     compliance: ComplianceLevel,
     values:     Seq[ComponentValueStatusReport]
 ) extends ByRuleByNodeByDirectiveByComponentCompliance {
-  override def componentName: String = name
+  override def componentName: String = name.value
 
   override def allReports: List[ReportType] = values.flatMap(c => c.messages.map(_ => c.status)).toList
 }
@@ -282,7 +293,7 @@ object GroupComponentCompliance {
   // This function do the recursive treatment of components, we will have each time a pair of Sequence of tuple (NodeId , component compliance structure)
   def recurseComponent(
       byRuleComponentCompliance: ByRuleComponentCompliance
-  ): Seq[((NodeId, String, ComputedPolicyMode), ByRuleByNodeByDirectiveByComponentCompliance)] = {
+  ): Seq[((NodeId, NodeName, ComputedPolicyMode), ByRuleByNodeByDirectiveByComponentCompliance)] = {
     byRuleComponentCompliance match {
       // Block case
       case b: ByRuleBlockCompliance =>
@@ -332,36 +343,36 @@ object GroupComponentCompliance {
   def fromDirective(directives: Seq[ByRuleDirectiveCompliance]): immutable.Iterable[GroupComponentCompliance] = {
     for {
       // Regroup all Directive by node getting Nodes values from components
-      (nodeId, data) <- directives.flatMap { d =>
-                          (for {
-                            // Treat all directives deeply
-                            subs <- d.components
-                            s    <- recurseComponent(subs)
-                          } yield {
-                            s
-                          }).groupBy(_._1).map {
-                            // All components were regrouped by nodes
-                            case (nodeId, s) =>
-                              val subs = s.map(_._2)
-                              // Rebuild a Directive compliance for a Node
-                              (
-                                nodeId,
-                                ByRuleByNodeByDirectiveCompliance(
-                                  d.id,
-                                  d.name,
-                                  ComplianceLevel.sum(subs.map(_.compliance)),
-                                  d.skippedDetails,
-                                  d.policyMode,
-                                  subs
-                                )
-                              )
-                          }
+      ((nodeId, nodeName, policyMode), data) <- directives.flatMap { d =>
+                                                  (for {
+                                                    // Treat all directives deeply
+                                                    subs <- d.components
+                                                    s    <- recurseComponent(subs)
+                                                  } yield {
+                                                    s
+                                                  }).groupBy(_._1).map {
+                                                    // All components were regrouped by nodes
+                                                    case (nodeId, s) =>
+                                                      val subs = s.map(_._2)
+                                                      // Rebuild a Directive compliance for a Node
+                                                      (
+                                                        nodeId,
+                                                        ByRuleByNodeByDirectiveCompliance(
+                                                          d.id,
+                                                          d.name,
+                                                          ComplianceLevel.sum(subs.map(_.compliance)),
+                                                          d.skippedDetails,
+                                                          d.policyMode,
+                                                          subs
+                                                        )
+                                                      )
+                                                  }
 
-                        }.groupBy(_._1)
+                                                }.groupBy(_._1)
     } yield {
       // All Directive were regrouped by Nodes (_._1), rebuild a strucutre containing all Directives
       val subs = data.map(_._2)
-      GroupComponentCompliance(nodeId._1, nodeId._2, ComplianceLevel.sum(subs.map(_.compliance)), nodeId._3, subs)
+      GroupComponentCompliance(nodeId, nodeName, ComplianceLevel.sum(subs.map(_.compliance)), policyMode, subs)
     }
   }
 
@@ -371,35 +382,35 @@ object GroupComponentCompliance {
   def fromRules(directives: Seq[ByDirectiveByRuleCompliance]): immutable.Iterable[ByDirectiveNodeCompliance] = {
     for {
       // Regroup all Directive by node getting Nodes values from components
-      (nodeId, data) <- directives.flatMap { d =>
-                          (for {
-                            // Treat all directives deeply
-                            subs <- d.components
-                            s    <- recurseComponent(subs)
-                          } yield {
-                            s
-                          }).groupBy(_._1).map {
-                            // All components were regrouped by nodes
-                            case (nodeId, s) =>
-                              val subs = s.map(_._2)
-                              // Rebuild a Directtive compliance for a Node
-                              (
-                                nodeId,
-                                ByDirectiveByNodeRuleCompliance(
-                                  d.id,
-                                  d.name,
-                                  ComplianceLevel.sum(subs.map(_.compliance)),
-                                  d.policyMode,
-                                  subs
-                                )
-                              )
-                          }
+      ((nodeId, nodeName, policyMode), data) <- directives.flatMap { d =>
+                                                  (for {
+                                                    // Treat all directives deeply
+                                                    subs <- d.components
+                                                    s    <- recurseComponent(subs)
+                                                  } yield {
+                                                    s
+                                                  }).groupBy(_._1).map {
+                                                    // All components were regrouped by nodes
+                                                    case (nodeId, s) =>
+                                                      val subs = s.map(_._2)
+                                                      // Rebuild a Directtive compliance for a Node
+                                                      (
+                                                        nodeId,
+                                                        ByDirectiveByNodeRuleCompliance(
+                                                          d.id,
+                                                          d.name,
+                                                          ComplianceLevel.sum(subs.map(_.compliance)),
+                                                          d.policyMode,
+                                                          subs
+                                                        )
+                                                      )
+                                                  }
 
-                        }.groupBy(_._1)
+                                                }.groupBy(_._1)
     } yield {
       // All Directive were regrouped by Nodes (_._1), rebuild a strucutre containing all Directives
       val subs = data.map(_._2)
-      ByDirectiveNodeCompliance(nodeId._1, nodeId._2, nodeId._3, ComplianceLevel.sum(subs.map(_.compliance)), subs)
+      ByDirectiveNodeCompliance(nodeId, nodeName, policyMode, ComplianceLevel.sum(subs.map(_.compliance)), subs)
     }
   }
 
@@ -452,13 +463,14 @@ final case class ByNodeDirectiveCompliance(
  * These objects are only used to export compliance in CSV format, for example in directive screen.
  */
 object CsvCompliance {
+  import ComponentName.given
 
   // use "," , quote everything with ", line separator is \n
   val csvFormat: CSVFormat = CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).setRecordSeparator("\n").get()
 
   def recurseComponent(
       component: ByRuleComponentCompliance,
-      block:     List[ComponentField]
+      block:     List[ComponentName]
   ): Seq[RuleComponentResult] = {
 
     component match {
@@ -467,18 +479,18 @@ object CsvCompliance {
           node.values.flatMap { value =>
             value.messages.map { report =>
               (
-                BlockField(block),
-                ComponentField(component),
-                NodeField(node),
-                ValueField(value),
-                StatusField(report),
-                MessageField(report)
+                BlockName(block.mkString(",")),
+                component.name,
+                node.name,
+                ValueName(value.componentValue),
+                Status(report.reportType),
+                Message(report.message)
               )
             }
           }
         }
       case component: ByRuleBlockCompliance =>
-        component.subComponents.flatMap(c => recurseComponent(c, block ::: (ComponentField(component) :: Nil)))
+        component.subComponents.flatMap(c => recurseComponent(c, block ::: (component.name :: Nil)))
     }
   }
 
@@ -500,61 +512,80 @@ object CsvCompliance {
     }
   }
 
-  /** Trait that contains Csv[A] and Csv.Header.One[A] instances 
-   * that are common to all values that can be converted to CSV */
-  trait CsvField[A <: String] {
-    given Csv[A] = Csv.instance(a => a)
-    given Csv.Header.One[A] with {}
-  }
+  object CsvComplianceOpaqueTypes {
 
-  opaque type DirectiveField = String
-  object DirectiveField extends CsvField[DirectiveField] {
-    def apply(directive: ByRuleDirectiveCompliance) = directive.name
-  }
+    /** Trait that contains Csv[A] and Csv.Header.One[A] instances
+     * that are common to all values that can be converted to CSV */
+    sealed trait CsvField[A <: String] {
+      given Csv[A] = Csv.instance(a => a)
+      given Csv.Header.One[A] with {}
+    }
 
-  opaque type BlockField = String
-  object BlockField extends CsvField[BlockField] {
-    def apply(block: List[ComponentField]) = block.mkString(",")
-  }
+    type ComponentName = BlockName | ValueName
 
-  opaque type ComponentField = String
-  object ComponentField extends CsvField[ComponentField] {
-    def apply(value: ByRuleValueCompliance) = value.name
-    def apply(block: ByRuleBlockCompliance) = block.name
-  }
+    object ComponentName extends CsvField[ComponentName] {
+      given JsonEncoder[ComponentName] = JsonEncoder[String]
+    }
 
-  opaque type NodeField = String
-  object NodeField extends CsvField[NodeField] {
-    def apply(node: ByRuleNodeCompliance) = node.name
-  }
+    opaque type BlockName = String
 
-  opaque type ValueField = String
-  object ValueField extends CsvField[ValueField] {
-    def apply(value: ComponentValueStatusReport) = value.componentValue
-  }
+    object BlockName extends CsvField[BlockName] {
+      def apply(name: String): BlockName = name
 
-  opaque type StatusField = String
-  object StatusField extends CsvField[StatusField] {
-    import com.normation.rudder.rest.data.ComplianceApiData.serialize
-    def apply(report: MessageStatusReport) = report.reportType.serialize
-  }
+      extension (blockName: BlockName) {
+        def value: String = blockName
+      }
 
-  opaque type MessageField = String
-  object MessageField extends CsvField[MessageField] {
-    def apply(report: MessageStatusReport) = report.message.getOrElse("")
+      given jsonCodec: JsonCodec[BlockName] = JsonCodec.string
+    }
+
+    opaque type ValueName = String
+    object ValueName extends CsvField[ValueName] {
+      def apply(value: String): ValueName = value
+
+      extension (valueName: ValueName) {
+        def value: String = valueName
+      }
+
+      given jsonCodec: JsonCodec[ValueName] = JsonCodec.string
+    }
+
+    opaque type Status = String
+    object Status extends CsvField[Status] {
+      import com.normation.rudder.rest.data.ComplianceApiData.serialize
+      def apply(reportType: ReportType): Status = reportType.serialize
+    }
+
+    opaque type Message = String
+    object Message extends CsvField[Message] {
+      def apply(reportMessage: Option[String]): Message = reportMessage.getOrElse("")
+    }
+
+    opaque type NodeName = Either[NodeId, String]
+
+    object NodeName {
+      def apply(name:  String): NodeName = Right(name)
+      def from(nodeId: NodeId): NodeName = Left(nodeId)
+      given Csv[NodeName]         = Csv.instance {
+        case Left(nodeId) => nodeId.value
+        case Right(name)  => name
+      }
+      given Csv.Header.One[NodeName] with {}
+      given JsonEncoder[NodeName] = JsonEncoder.string.contramap(nodeName => nodeName.getOrElse("Unknown node"))
+    }
   }
 
   type RuleComponentResult =
-    (block: BlockField, component: ComponentField, node: NodeField, value: ValueField, status: StatusField, message: MessageField)
+    (block: BlockName, component: ComponentName, node: NodeName, value: ValueName, status: Status, message: Message)
 
   case class RuleComplianceByDirectiveCsv(
-      directive: DirectiveField,
-      block:     BlockField,
-      component: ComponentField,
-      node:      NodeField,
-      value:     ValueField,
-      status:    StatusField,
-      message:   MessageField
+      directive: DirectiveName,
+      block:     BlockName,
+      component: ComponentName,
+      node:      NodeName,
+      value:     ValueName,
+      status:    Status,
+      message:   Message
   ) derives Csv
   object RuleComplianceByDirectiveCsv {
     import com.normation.rudder.rest.data.CsvCompliance.RuleComponentResult
@@ -564,7 +595,7 @@ object CsvCompliance {
     ): Transformer[RuleComponentResult, RuleComplianceByDirectiveCsv] = {
       Transformer
         .define[RuleComponentResult, RuleComplianceByDirectiveCsv]
-        .withFieldConst(_.directive, DirectiveField(directive))
+        .withFieldConst(_.directive, directive.name)
         .buildTransformer
     }
 
@@ -582,13 +613,13 @@ object CsvCompliance {
   }
 
   case class RuleComplianceByNodeCsv(
-      node:      NodeField,
-      directive: DirectiveField,
-      block:     BlockField,
-      component: ComponentField,
-      value:     ValueField,
-      status:    StatusField,
-      message:   MessageField
+      node:      NodeName,
+      directive: DirectiveName,
+      block:     BlockName,
+      component: ComponentName,
+      value:     ValueName,
+      status:    Status,
+      message:   Message
   ) derives Csv
 
   object RuleComplianceByNodeCsv {
@@ -598,7 +629,7 @@ object CsvCompliance {
     given (using directive: ByRuleDirectiveCompliance): Transformer[RuleComponentResult, RuleComplianceByNodeCsv] = {
       Transformer
         .define[RuleComponentResult, RuleComplianceByNodeCsv]
-        .withFieldConst(_.directive, DirectiveField(directive))
+        .withFieldConst(_.directive, directive.name)
         .buildTransformer
     }
 
@@ -640,6 +671,8 @@ object ComplianceFormat extends Enum[ComplianceFormat] {
  * This is used for serialization of compliance API object. These are pure DTO
  */
 object ComplianceApiData {
+
+  import ComponentName.given
   // generic transformers
   private given complianceLevelTransformer(using precision: CompliancePrecision): Transformer[ComplianceLevel, Double] =
     _.complianceWithoutPending(precision)
@@ -703,7 +736,7 @@ object ComplianceApiData {
 
   final case class ByRuleNodeComplianceApi(
       id:                NodeId,
-      name:              String,
+      name:              NodeName,
       compliance:        Double,
       policyMode:        ComputedPolicyMode,
       complianceDetails: ComplianceSerializable,
@@ -725,7 +758,7 @@ object ComplianceApiData {
   }
 
   final case class ByRuleByNodeByDirectiveByComponentComplianceApi(
-      name:              String,
+      name:              ComponentName,
       compliance:        Double,
       complianceDetails: ComplianceSerializable,
       components:        Option[Seq[ByRuleByNodeByDirectiveByComponentComplianceApi]],
@@ -834,7 +867,7 @@ object ComplianceApiData {
     }
 
     final case class ByRuleComponentComplianceApi(
-        name:              String,
+        name:              ComponentName,
         compliance:        Double,
         complianceDetails: ComplianceSerializable,
         components:        Option[Seq[ByRuleComponentComplianceApi]],
@@ -866,7 +899,7 @@ object ComplianceApiData {
 
     final case class ByDirectiveNodeComplianceApi(
         id:                NodeId,
-        name:              String,
+        name:              NodeName,
         compliance:        Double,
         policyMode:        ComputedPolicyMode,
         complianceDetails: ComplianceSerializable,
@@ -942,7 +975,7 @@ object ComplianceApiData {
 
     final case class ByRuleDirectiveComplianceApi(
         id:                DirectiveId,
-        name:              String,
+        name:              DirectiveName,
         compliance:        Double,
         policyMode:        ComputedPolicyMode,
         complianceDetails: ComplianceSerializable,
@@ -965,7 +998,7 @@ object ComplianceApiData {
     }
 
     final case class ByRuleComponentComplianceApi(
-        name:              String,
+        name:              ComponentName,
         compliance:        Double,
         complianceDetails: ComplianceSerializable,
         components:        Option[Seq[ByRuleComponentComplianceApi]],
@@ -997,7 +1030,7 @@ object ComplianceApiData {
 
     final case class GroupComponentComplianceApi(
         id:                NodeId,
-        name:              String,
+        name:              NodeName,
         compliance:        Double,
         policyMode:        ComputedPolicyMode,
         complianceDetails: ComplianceSerializable,
@@ -1020,7 +1053,7 @@ object ComplianceApiData {
 
     final case class ByRuleByNodeByDirectiveComplianceApi(
         id:                DirectiveId,
-        name:              String,
+        name:              DirectiveName,
         compliance:        Double,
         policyMode:        ComputedPolicyMode,
         complianceDetails: ComplianceSerializable,
@@ -1173,7 +1206,7 @@ object ComplianceApiData {
     }
 
     final case class ByRuleComponentComplianceApi(
-        name:              String,
+        name:              ComponentName,
         compliance:        Double,
         complianceDetails: ComplianceSerializable,
         components:        Option[Seq[ByRuleComponentComplianceApi]],

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.rest.{ComplianceApi as API, *}
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.rest.data.CsvCompliance.*
+import com.normation.rudder.rest.data.CsvCompliance.CsvComplianceOpaqueTypes.*
 import com.normation.rudder.rest.syntax.*
 import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.tenants.QueryContext
@@ -517,7 +518,7 @@ class ComplianceAPIService(
        val bidule = groupsComponents.flatMap { case (nodeId, c) => c.subComponents.map(sub => (nodeId, sub)) }
          .groupBy(_._2.componentName)
        ByRuleBlockCompliance(
-         name,
+         BlockName(name),
          groupsComponents.map(_._2.reportingLogic).head,
          bidule.flatMap(c => components(nodeFacts, globalMode)(c._1, c._2)).toList
        ) :: Nil
@@ -525,7 +526,7 @@ class ComplianceAPIService(
                Nil
              } else {
                ByRuleValueCompliance(
-                 name,
+                 ValueName(name),
                  ComplianceLevel.sum(
                    uniqueComponents.map(_._2.compliance)
                  ), // here, we finally group by nodes for each components !
@@ -537,7 +538,10 @@ class ComplianceAPIService(
                        val policyMode  = ComputePolicyMode.nodeMode(globalMode, optNodeInfo.flatMap(_.rudderSettings.policyMode))
                        ByRuleNodeCompliance(
                          nodeId,
-                         optNodeInfo.map(_.fqdn).getOrElse("Unknown node"),
+                         optNodeInfo.map(_.fqdn) match {
+                           case Some(value) => NodeName(value)
+                           case None        => NodeName.from(nodeId)
+                         },
                          policyMode,
                          ComplianceLevel.sum(components.map(_._2.compliance)),
                          components.sortBy(_._2.componentName).flatMap(_._2.componentValues)
@@ -784,7 +788,7 @@ class ComplianceAPIService(
                 }
                 ByRuleDirectiveCompliance(
                   directiveId,
-                  directive.map(_._2.name).getOrElse("Unknown directive"),
+                  DirectiveName(directive.map(_._2.name).getOrElse("Unknown directive")),
                   ComplianceLevel.sum(
                     nodeDirectives.map(_._2.compliance)
                   ),

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -405,6 +405,7 @@ class RuleApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      import com.normation.rudder.rest.data.CsvCompliance.CsvComplianceOpaqueTypes.ComponentName.given
       given qc: QueryContext = authzToken.qc
 
       getRuleComplianceZIO(req, ruleId)
@@ -438,6 +439,7 @@ class RuleApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      import com.normation.rudder.rest.data.CsvCompliance.CsvComplianceOpaqueTypes.ComponentName.given
       given qc: QueryContext = authzToken.qc
 
       getRuleComplianceZIO(req, ruleId)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.rest.data.ByRuleBlockCompliance
 import com.normation.rudder.rest.data.ByRuleNodeCompliance
 import com.normation.rudder.rest.data.ByRuleValueCompliance
 import com.normation.rudder.rest.data.CsvCompliance
+import com.normation.rudder.rest.data.CsvCompliance.CsvComplianceOpaqueTypes.*
 import com.normation.rudder.web.services.ComputePolicyMode
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
@@ -111,16 +112,16 @@ class TestDirectiveComplianceCsv extends Specification {
           enforce,
           Seq(
             ByRuleBlockCompliance(
-              "Check Cipher TLS_RSA_WITH_DES_CBC_SHA",
+              BlockName("Check Cipher TLS_RSA_WITH_DES_CBC_SHA"),
               ReportingLogic.WeightedReport,
               Seq(
                 ByRuleValueCompliance(
-                  "Command execution",
+                  ValueName("Command execution"),
                   notUsed,
                   List(
                     ByRuleNodeCompliance(
                       NodeId("n1"),
-                      "prod-www-01.lab.rudder.io",
+                      NodeName("prod-www-01.lab.rudder.io"),
                       enforce,
                       notUsed,
                       Seq(
@@ -141,7 +142,7 @@ class TestDirectiveComplianceCsv extends Specification {
                     ),
                     ByRuleNodeCompliance(
                       NodeId("n1"),
-                      "prod-windows-2016.demo.normation.com",
+                      NodeName("prod-windows-2016.demo.normation.com"),
                       enforce,
                       notUsed,
                       Seq(
@@ -163,12 +164,12 @@ class TestDirectiveComplianceCsv extends Specification {
                   )
                 ),
                 ByRuleValueCompliance(
-                  "Audit from Powershell execution",
+                  ValueName("Audit from Powershell execution"),
                   notUsed,
                   List(
                     ByRuleNodeCompliance(
                       NodeId("n1"),
-                      "prod-app-01.lab.rudder.io",
+                      NodeName("prod-app-01.lab.rudder.io"),
                       enforce,
                       notUsed,
                       Seq(
@@ -189,7 +190,7 @@ class TestDirectiveComplianceCsv extends Specification {
                     ),
                     ByRuleNodeCompliance(
                       NodeId("n1"),
-                      "prod-windows-2016.demo.normation.com",
+                      NodeName("prod-windows-2016.demo.normation.com"),
                       enforce,
                       notUsed,
                       Seq(


### PR DESCRIPTION
https://issues.rudder.io/issues/28885

Refactoring with opaque types made in mob programming with @fanf @P4uline @clarktsiory and @skaerg 



Things we learned:
* opaque types visibility, when not being careful about the scope, can lead to subtle errors
  * when the opaque type is NOT at top-level, or not without nested object `object OpaqueTypes { ... }`, anything at the SAME LEVEL as the opaque type will see the underlying type of the opaque type
  * so in that case, it not longer acts as an opaque type but as a type alias (which is not obvious when reading compilation errors)
* union types can be misleading, on opaque types: for example on `type ComponentName = BlockName | ValueName` then we have union of two "string" opaque type
  * then the compiler erasure phase fail when we pattern match `match { case b: BlockName => ...; case v: ValueName }` because that's both on strings