### PR TITLE
Fixes #28925: Campaign report do not log the reboot command error if any

### DIFF
--- a/policies/module-types/system-updates/src/campaign.rs
+++ b/policies/module-types/system-updates/src/campaign.rs
@@ -3,6 +3,7 @@
 
 #![allow(clippy::borrowed_box)]
 
+use crate::output::ResultOutput;
 use crate::package_manager::{PackageId, PackageList};
 use crate::{
     CampaignType, PackageParameters, RebootBehavior, RebootType, Schedule,
@@ -11,7 +12,7 @@ use crate::{
     output::{Report, ScheduleReport, Status},
     package_manager::{PackageSpec, UpdateManager},
 };
-use anyhow::Result;
+use anyhow::{Result, bail};
 use chrono::{DateTime, Duration, Utc};
 use rudder_module_type::Outcome;
 use std::collections::HashMap;
@@ -167,11 +168,37 @@ pub fn do_update(
     p: &RunnerParameters,
     db: &mut PackageDatabase,
     package_manager: &mut Box<dyn UpdateManager>,
-) -> Result<bool> {
+) -> Result<RebootResult> {
     db.start_event(&p.event_id, Utc::now())?;
-    let (report, reboot) = update(package_manager, p.reboot_type, &p.campaign_type)?;
-    db.schedule_post_event(&p.event_id, &report)?;
-    Ok(reboot)
+    let (mut report, reboot_needed) = update(package_manager, p.reboot_type, &p.campaign_type)?;
+    do_reboot(p, db, package_manager, reboot_needed, &mut report)
+}
+
+pub fn do_reboot(
+    p: &RunnerParameters,
+    db: &mut PackageDatabase,
+    pm: &mut Box<dyn UpdateManager>,
+    reboot_needed: bool,
+    report: &mut Report,
+) -> Result<RebootResult> {
+    db.reboot(&p.event_id, report)?;
+    db.schedule_post_event(&p.event_id, report)?;
+    if p.reboot_type == RebootType::Always
+        || (p.reboot_type == RebootType::AsNeeded && reboot_needed)
+    {
+        let rr: ResultOutput<()> = pm.reboot(&p.reboot_behavior);
+        // We have to early fail if the reboot command encounter any failure.
+        // The technique code is expecting the log file to be written in case of error
+        if rr.inner.is_err() {
+            report.step(rr);
+            let now_finished = Utc::now();
+            db.completed(&p.event_id, now_finished, report)?;
+            bail!("Reboot failure")
+        }
+        Ok(RebootResult::Success)
+    } else {
+        Ok(RebootResult::Skipped)
+    }
 }
 
 pub fn do_post_update(p: &RunnerParameters, db: &mut PackageDatabase) -> Result<Outcome> {
@@ -192,8 +219,13 @@ pub fn do_post_update(p: &RunnerParameters, db: &mut PackageDatabase) -> Result<
 }
 
 /// Shortcut method to send an error report directly
-pub fn fail_campaign(reason: &str, report_file: Option<&PathBuf>) -> Result<Outcome> {
-    let mut report = Report::new();
+pub fn fail_campaign(
+    reason: &str,
+    event_id: &str,
+    db: &PackageDatabase,
+    report_file: Option<&PathBuf>,
+) -> Result<Outcome> {
+    let mut report = db.get_report(event_id).unwrap_or_default();
     report.stderr(reason);
     report.status = Status::Error;
     if let Some(ref f) = report_file {
@@ -290,6 +322,12 @@ fn update(
     }
 
     Ok((report, false))
+}
+
+#[derive(Debug, PartialEq)]
+pub enum RebootResult {
+    Success,
+    Skipped,
 }
 
 /// Can run just after upgrade, or at next run in case of reboot.

--- a/policies/module-types/system-updates/src/db.rs
+++ b/policies/module-types/system-updates/src/db.rs
@@ -249,6 +249,20 @@ impl PackageDatabase {
             .map(|_| ())
     }
 
+    /// Reboot if needed. Should follow the Update action
+    pub fn reboot(&mut self, event_id: &str, report: &Report) -> Result<(), rusqlite::Error> {
+        self.conn
+            .execute(
+                "update update_events set status = ?1, report = ?2 where event_id = ?3",
+                (
+                    UpdateStatus::RunningReboot.to_string(),
+                    serde_json::to_string(report).unwrap(),
+                    &event_id,
+                ),
+            )
+            .map(|_| ())
+    }
+
     /// Schedule post-event action. Can happen after a reboot in a separate run.
     ///
     pub fn schedule_post_event(

--- a/policies/module-types/system-updates/src/runner.rs
+++ b/policies/module-types/system-updates/src/runner.rs
@@ -1,5 +1,5 @@
+use crate::campaign::RebootResult;
 use crate::{
-    RebootType,
     campaign::{
         FullSchedule, RunnerParameters, do_post_update, do_schedule, do_update, fail_campaign,
     },
@@ -7,7 +7,7 @@ use crate::{
     package_manager::UpdateManager,
     state::UpdateStatus,
 };
-use anyhow::{Result, bail};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use rudder_module_type::{Outcome, splay::splayed_start};
 
@@ -76,22 +76,10 @@ impl Runner {
                     Ok(Continuation::Stop(outcome))
                 }
             }
-            Action::Update => {
-                let reboot_needed = do_update(&self.parameters, &mut self.db, &mut self.pm)?;
-
-                if self.parameters.reboot_type == RebootType::Always
-                    || (self.parameters.reboot_type == RebootType::AsNeeded && reboot_needed)
-                {
-                    // Async reboot
-                    let result = self.pm.reboot(&self.parameters.reboot_behavior);
-                    match result.inner {
-                        Ok(_) => Ok(Continuation::Stop(Outcome::Success(None))),
-                        Err(e) => bail!("Reboot failed: {:?}", e),
-                    }
-                } else {
-                    Ok(Continuation::Continue)
-                }
-            }
+            Action::Update => match do_update(&self.parameters, &mut self.db, &mut self.pm)? {
+                RebootResult::Success => Ok(Continuation::Stop(Outcome::Success(None))),
+                RebootResult::Skipped => Ok(Continuation::Continue),
+            },
             Action::PostUpdate => {
                 self.db.post_event(&self.parameters.event_id)?;
                 let outcome = do_post_update(&self.parameters, &mut self.db)?;
@@ -138,7 +126,12 @@ impl Runner {
                 }
                 Err(e) => {
                     // Send the report to server
-                    fail_campaign(&format!("{e:?}"), self.parameters.report_file.as_ref())?;
+                    fail_campaign(
+                        &format!("{e:?}"),
+                        &self.parameters.event_id,
+                        &self.db,
+                        self.parameters.report_file.as_ref(),
+                    )?;
                     return Err(e);
                 }
             }

--- a/policies/module-types/system-updates/src/state.rs
+++ b/policies/module-types/system-updates/src/state.rs
@@ -13,9 +13,11 @@ use std::{
 pub enum UpdateStatus {
     /// Wait until schedule
     ScheduledUpdate,
-    /// Schedule is reached, start update and reboot if necessary
+    /// Schedule is reached, start update
     RunningUpdate,
-    /// Update is over, waiting for next agent run for post-actions in case of a reboot
+    /// Update is done, reboot the server if needed
+    RunningReboot,
+    /// Update and reboot are over, waiting for next agent run for post-actions in case of a reboot
     PendingPostActions,
     /// Running post-actions and report
     RunningPostActions,
@@ -28,9 +30,10 @@ impl Display for UpdateStatus {
         f.write_str(match self {
             Self::ScheduledUpdate => "scheduled",
             Self::RunningUpdate => "running",
-            Self::Completed => "completed",
+            Self::RunningReboot => "running-reboot",
             Self::PendingPostActions => "pending-post-actions",
             Self::RunningPostActions => "running-post-actions",
+            Self::Completed => "completed",
         })
     }
 }
@@ -40,11 +43,12 @@ impl FromStr for UpdateStatus {
 
     fn from_str(s: &str) -> anyhow::Result<Self, Self::Err> {
         match s {
-            "running" => Ok(Self::RunningUpdate),
             "scheduled" => Ok(Self::ScheduledUpdate),
-            "completed" => Ok(Self::Completed),
+            "running" => Ok(Self::RunningUpdate),
+            "running-reboot" => Ok(Self::RunningReboot),
             "pending-post-actions" => Ok(Self::PendingPostActions),
             "running-post-actions" => Ok(Self::RunningPostActions),
+            "completed" => Ok(Self::Completed),
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Invalid input",


### PR DESCRIPTION
https://issues.rudder.io/issues/28925

This PR changes the default behavior of the runner when an unexpected failure occurs.
It now always tries to write the Json report in case of a failure, from the one in the database if any.

It also introduces two new states:

- PendingReboot: does nothing, is only used to store the current report in base before trying to reboot
- RunningReboot: runs the reboot command if needed and schedule the post_update_events if it succeeds