### PR TITLE
Fixes #28905: Debug and trace log are not always lazy

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
@@ -289,7 +289,7 @@ object RunHooks {
 
     def logReturnCode(result: HookReturnCode): IOResult[Unit] = {
       for {
-        _ <- ZIO.when(PureHooksLogger.logEffect.isTraceEnabled()) {
+        _ <- PureHooksLogger.ifTraceEnabled {
                PureHooksLogger.For(logIdentifier).trace(s"  -> results: ${result.msg}") *>
                PureHooksLogger.For(logIdentifier).trace(s"  -> stdout : ${result.stdout}") *>
                PureHooksLogger.For(logIdentifier).trace(s"  -> stderr : ${result.stderr}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -351,7 +351,7 @@ class RuddercServiceImpl(
 
   def logReturnCode(result: RuddercResult): IOResult[Unit] = {
     for {
-      _ <- ZIO.when(RuddercLogger.logEffect.isTraceEnabled()) {
+      _ <- RuddercLogger.ifTraceEnabled {
              RuddercLogger.trace(s"  -> results: ${result.code.toString}") *>
              RuddercLogger.trace(
                s"  -> modified files: ${result.fileStatus.map(s => s"${s.path}: ${s.state.value}").mkString(" ; ")}"

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -591,7 +591,7 @@ object RudderLogger {
 
   extension (logger: RudderLogger) {
 
-    def logEffect: Logger = logger
+    def logEffect: RudderEffectLogger = RudderEffectLogger(logger)
 
     /*
      * We don't want that errors happening during log be propagated to the app error channel,
@@ -630,6 +630,32 @@ object RudderLogger {
   }
 }
 
+// non ZIO version - used to make parameters lazy
+opaque type RudderEffectLogger = Logger
+object RudderEffectLogger {
+  def apply(logger: Logger): RudderEffectLogger = logger
+
+  extension (logger: RudderEffectLogger) {
+    def trace(msg: => String): Unit = if (logger.isTraceEnabled()) logger.trace(msg) else ()
+    def debug(msg: => String): Unit = if (logger.isDebugEnabled()) logger.debug(msg) else ()
+    def info(msg:  => String): Unit = if (logger.isInfoEnabled()) logger.info(msg) else ()
+    def warn(msg:  => String): Unit = if (logger.isWarnEnabled()) logger.warn(msg) else ()
+    def error(msg: => String): Unit = if (logger.isErrorEnabled()) logger.error(msg) else ()
+
+    def trace(msg: => String, t: Throwable): Unit = if (logger.isTraceEnabled()) logger.trace(msg, t) else ()
+    def debug(msg: => String, t: Throwable): Unit = if (logger.isDebugEnabled()) logger.debug(msg, t) else ()
+    def info(msg:  => String, t: Throwable): Unit = if (logger.isInfoEnabled()) logger.info(msg, t) else ()
+    def warn(msg:  => String, t: Throwable): Unit = if (logger.isErrorEnabled()) logger.warn(msg, t) else ()
+    def error(msg: => String, t: Throwable): Unit = if (logger.isWarnEnabled()) logger.error(msg, t) else ()
+
+    def isTraceEnabled: Boolean = logger.isTraceEnabled()
+    def isDebugEnabled: Boolean = logger.isDebugEnabled()
+    def isInfoEnabled:  Boolean = logger.isInfoEnabled()
+    def isWarnEnabled:  Boolean = logger.isWarnEnabled()
+    def isErrorEnabled: Boolean = logger.isErrorEnabled()
+  }
+}
+
 // a default implementation that accepts a name for the logger.
 // it will respect slf4j namespacing with ".".
 trait NamedZioLogger {
@@ -643,7 +669,7 @@ trait NamedZioLogger {
   // for compatibility with current Lift convention, use logger = this
   def logPure: NamedZioLogger = this
 
-  def logEffect: Logger = internalLogger.logEffect
+  def logEffect: RudderEffectLogger = internalLogger.logEffect
 
   /*
    * We don't want that errors happening during log be propagated to the app error channel,


### PR DESCRIPTION
https://issues.rudder.io/issues/28905

Use exactly the same approach than for `RudderLogger`. I had to make a choice between `()` or not for the `is...` methods, I chose the one with the least number of changes all around. 