### PR TITLE
Fixes #28943: Add an opaque type for the composed reports of node reports

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -184,33 +184,6 @@ trait BlockComplianceByNode[Sub <: ComponentCompliance] extends ComponentComplia
 
 sealed trait StatusReport extends HasCompliance
 
-/**
- * Define two aggregated view of compliance: by node (for
- * a given rule) and by rules (for a given node).
- */
-final class RuleStatusReport private (
-    val forRule: RuleId,
-    val report:  AggregatedStatusReport
-) extends StatusReport {
-  lazy val compliance: ComplianceLevel                     = report.compliance
-  lazy val byNodes:    Map[NodeId, AggregatedStatusReport] =
-    report.reports.groupBy(_.nodeId).view.mapValues(AggregatedStatusReport(_)).toMap
-}
-
-object RuleStatusReport {
-  def apply(ruleId: RuleId, reports: Iterable[RuleNodeStatusReport]): RuleStatusReport = {
-    new RuleStatusReport(ruleId, AggregatedStatusReport(reports.toSet.filter(_.ruleId == ruleId)))
-  }
-
-  /*
-   * Build rule status reports from node reports, deciding which directives should be "skipped"
-   */
-  def fromNodeStatusReports(ruleId: RuleId, nodeReports: Map[NodeId, NodeStatusReport]): RuleStatusReport = {
-    val toKeep = nodeReports.values.flatMap(_.reports.flatMap(_._2.reports)).filter(_.ruleId == ruleId).toList
-    RuleStatusReport(ruleId, toKeep)
-  }
-}
-
 /*
  * meta information about a run compliance analysis -
  * in particular about policy mode errors (agent aborted,
@@ -292,32 +265,140 @@ final case class RunAnalysis(
   }
 }
 
+/**
+ * ComposedCompliance is the value of computed compliance (AggregatedStatusReport)
+ * for each policy type. It's typically for a node, but the aggregation can be
+ * list of nodes, rules, etc.
+ */
+opaque type ComposedReport = Map[PolicyTypeName, AggregatedStatusReport]
+
+object ComposedReport {
+
+  def apply(map: Map[PolicyTypeName, AggregatedStatusReport]): ComposedReport = map
+  def apply(statusReport: Iterable[RuleNodeStatusReport]): ComposedReport = {
+    statusReport.groupBy(_.complianceTag).map { case (tag, reports) => (tag, AggregatedStatusReport(reports)) }
+  }
+
+  extension (nc: ComposedReport) {
+    // Get the compliance level for a given type, or compliance 0 is that type is missing
+    def getCompliance(t: PolicyTypeName): ComplianceLevel = {
+      nc.get(t) match {
+        case Some(x) => x.compliance
+        case None    => ComplianceLevel()
+      }
+    }
+
+    // Get the underlying representation. Typically used in transformers.
+    // Try to avoid it.
+    def getUnderlyingMap: Map[PolicyTypeName, AggregatedStatusReport] = nc
+
+    // Get the computed global compliance level.
+    // For compat reason, node compliance is the sum of all aspects
+    def getComplianceLevel: ComplianceLevel = ComplianceLevel.sum(nc.values.map(_.compliance))
+
+    // get the underlying RuleNodeStatusReports
+    def getReports(
+        keepReport: (r: RuleNodeStatusReport) => Boolean = _ => true
+    ): Chunk[RuleNodeStatusReport] = {
+
+      Chunk.fromIterable(
+        (nc: Map[PolicyTypeName, AggregatedStatusReport]).flatMap((_, agg) => agg.reports.iterator.filter(keepReport))
+      )
+    }
+
+    // a version that let the user know if that policy type is defined
+    def getReportsForPolicyType(pt: PolicyTypeName): Option[Chunk[RuleNodeStatusReport]] = {
+      nc.get(pt).map(x => Chunk.fromIterable(x.reports))
+    }
+
+    // filtering methods
+
+    def nonEmpty: Boolean = (nc: Map[PolicyTypeName, AggregatedStatusReport]).nonEmpty
+    def isEmpty:  Boolean = (nc: Map[PolicyTypeName, AggregatedStatusReport]).isEmpty
+
+    // Filter for only one policy type
+    def forPolicyType(t: PolicyTypeName): ComposedReport = {
+      nc.get(t) match {
+        case Some(r) => Map((t, r))
+        case None    => Map.empty[PolicyTypeName, AggregatedStatusReport]
+      }
+    }
+
+    def filterByRules(ruleIds: Set[RuleId]): ComposedReport = {
+      nc.map((tag, r) => (tag, r.filterByRules(ruleIds)))
+    }
+
+    def filterByDirectives(directiveIds: Set[DirectiveId]): ComposedReport = {
+      nc.map((tag, r) => (tag, r.filterByDirectives(directiveIds)))
+    }
+  }
+}
+
+// Utility to convert between node and rule status reports
+object ConvertStatusReport {
+
+  /*
+   * convert to proto-RuleStatusReports. Final aggregation is not done,
+   * because where it's used (like in ComplianceApi), more filtering need to be done
+   */
+  def fromNodesToRules(
+      nodes:      Iterable[NodeStatusReport],
+      keepReport: (r: RuleNodeStatusReport) => Boolean = _ => true
+  ): Map[RuleId, Iterable[RuleNodeStatusReport]] = {
+
+    nodes
+      .flatMap(_.reports.getReports(keepReport))
+      .groupBy(_.ruleId)
+  }
+
+}
+
+/**
+ * Define two aggregated view of compliance: by node (for
+ * a given rule) and by rules (for a given node).
+ */
+final class RuleStatusReport private (
+    val forRule: RuleId,
+    val report:  AggregatedStatusReport
+) extends StatusReport {
+  override lazy val compliance: ComplianceLevel                     = report.compliance
+  lazy val byNodes:             Map[NodeId, AggregatedStatusReport] =
+    report.reports.groupBy(_.nodeId).view.mapValues(AggregatedStatusReport(_)).toMap
+}
+
+object RuleStatusReport {
+  def apply(ruleId: RuleId, reports: Iterable[RuleNodeStatusReport]): RuleStatusReport = {
+    new RuleStatusReport(ruleId, AggregatedStatusReport(reports.toSet.filter(_.ruleId == ruleId)))
+  }
+
+  /*
+   * Build rule status reports from node reports, deciding which directives should be "skipped"
+   */
+  def fromNodeStatusReports(ruleId: RuleId, nodeReports: Map[NodeId, NodeStatusReport]): RuleStatusReport = {
+    val toKeep = nodeReports.values.flatMap(_.reports.getReports(_.ruleId == ruleId))
+    RuleStatusReport(ruleId, toKeep)
+  }
+}
+
+/**
+ * A `NodeStatusReport` is the artifact giving the compliance for a node, for a run, given expected reports and
+ * a current time (compliance depends on expected reports version).
+ * Compliance is split on several `PolicyType`, at least `system` and `user` one.
+ */
 final case class NodeStatusReport(
     nodeId:     NodeId,
     runInfo:    RunAnalysis,
     statusInfo: RunComplianceInfo,
-    reports:    Map[PolicyTypeName, AggregatedStatusReport]
+    reports:    ComposedReport
 ) extends StatusReport {
   // for compat reason, node compliance is the sum of all aspects
-  lazy val compliance: ComplianceLevel = ComplianceLevel.sum(reports.values.map(_.compliance))
+  override lazy val compliance: ComplianceLevel = reports.getComplianceLevel
 
-  // get the compliance level for a given type, or compliance 0 is that type is missing
-  def getCompliance(t: PolicyTypeName): ComplianceLevel = {
-    reports.get(t) match {
-      case Some(x) => x.compliance
-      case None    => ComplianceLevel()
-    }
-  }
-
-  def systemCompliance: ComplianceLevel = getCompliance(PolicyTypeName.rudderSystem)
-  def baseCompliance:   ComplianceLevel = getCompliance(PolicyTypeName.rudderBase)
+  def systemCompliance: ComplianceLevel = reports.getCompliance(PolicyTypeName.rudderSystem)
+  def baseCompliance:   ComplianceLevel = reports.getCompliance(PolicyTypeName.rudderBase)
 
   def forPolicyType(t: PolicyTypeName): NodeStatusReport = {
-    val r = reports.get(t) match {
-      case Some(r) => Map((t, r))
-      case None    => Map.empty[PolicyTypeName, AggregatedStatusReport]
-    }
-    NodeStatusReport(nodeId, runInfo, statusInfo, r)
+    NodeStatusReport(nodeId, runInfo, statusInfo, reports.forPolicyType(t))
   }
 }
 
@@ -354,7 +435,7 @@ object NodeStatusReport {
       nodeStatusReport.nodeId,
       nodeStatusReport.runInfo,
       nodeStatusReport.statusInfo,
-      nodeStatusReport.reports.map { case (tag, r) => (tag, r.filterByRules(ruleIds)) }
+      nodeStatusReport.reports.filterByRules(ruleIds)
     )
   }
 
@@ -364,7 +445,7 @@ object NodeStatusReport {
       nodeStatusReport.nodeId,
       nodeStatusReport.runInfo,
       nodeStatusReport.statusInfo,
-      nodeStatusReport.reports.map { case (tag, r) => (tag, r.filterByDirectives(directiveIds)) }
+      nodeStatusReport.reports.filterByDirectives(directiveIds)
     )
   }
 }
@@ -507,7 +588,7 @@ final case class DirectiveStatusReport(
 
 object DirectiveStatusReport {
 
-  def merge(directives: List[DirectiveStatusReport]): Map[DirectiveId, DirectiveStatusReport] = {
+  def merge(directives: Iterable[DirectiveStatusReport]): Map[DirectiveId, DirectiveStatusReport] = {
     directives.groupBy(_.directiveId).map {
       case (directiveId, reports) =>
         val tags          = {
@@ -807,13 +888,19 @@ object JsonPostgresqlSerialization {
     implicit val a: Transformer[JNodeStatusReport, NodeStatusReport] = {
       Transformer
         .define[JNodeStatusReport, NodeStatusReport]
-        .withFieldComputed(_.reports, _.reports.map { case (a, b) => (a, b.transformInto[AggregatedStatusReport]) }.toMap)
+        .withFieldComputed(
+          _.reports,
+          r => ComposedReport(r.reports.map { case (a, b) => (a, b.transformInto[AggregatedStatusReport]) }.toMap)
+        )
         .buildTransformer
     }
     implicit val b: Transformer[NodeStatusReport, JNodeStatusReport] = {
       Transformer
         .define[NodeStatusReport, JNodeStatusReport]
-        .withFieldComputed(_.reports, _.reports.map { case (a, b) => (a, b.transformInto[JAggregatedStatusReport]) }.toSeq)
+        .withFieldComputed(
+          _.reports,
+          _.reports.getUnderlyingMap.map((a, b) => (a, b.transformInto[JAggregatedStatusReport])).toSeq
+        )
         .buildTransformer
     }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -391,28 +391,16 @@ final case class NodeStatusReportInternal(
     runInfo:    RunAndConfigInfo,
     statusInfo: RunComplianceInfo,
     overrides:  List[OverriddenPolicy],
-    reports:    Map[PolicyTypeName, AggregatedStatusReport]
+    reports:    ComposedReport
 ) {
   // for compat reason, node compliance is the sum of all aspects
-  lazy val compliance: ComplianceLevel = ComplianceLevel.sum(reports.values.map(_.compliance))
+  lazy val compliance: ComplianceLevel = reports.getComplianceLevel
 
-  // get the compliance level for a given type, or compliance 0 is that type is missing
-  def getCompliance(t: PolicyTypeName): ComplianceLevel = {
-    reports.get(t) match {
-      case Some(x) => x.compliance
-      case None    => ComplianceLevel()
-    }
-  }
-
-  def systemCompliance: ComplianceLevel = getCompliance(PolicyTypeName.rudderSystem)
-  def baseCompliance:   ComplianceLevel = getCompliance(PolicyTypeName.rudderBase)
+  def systemCompliance: ComplianceLevel = reports.getCompliance(PolicyTypeName.rudderSystem)
+  def baseCompliance:   ComplianceLevel = reports.getCompliance(PolicyTypeName.rudderBase)
 
   def forPolicyType(t: PolicyTypeName): NodeStatusReportInternal = {
-    val r = reports.get(t) match {
-      case Some(r) => Map((t, r))
-      case None    => Map.empty[PolicyTypeName, AggregatedStatusReport]
-    }
-    NodeStatusReportInternal(nodeId, runInfo, statusInfo, overrides, r)
+    NodeStatusReportInternal(nodeId, runInfo, statusInfo, overrides, reports.forPolicyType(t))
   }
 
   def toNodeStatusReport(): NodeStatusReport = {
@@ -493,20 +481,18 @@ object NodeStatusReportInternal {
     }
 
     // group map and aggregate
-    val aggregates = {
-      (reportWithOverridden ++ fullyOverridden).groupBy(_.complianceTag).map {
-        case (tag, reports) => (tag, AggregatedStatusReport(reports))
-      }
-    }
+    val aggregates = ComposedReport(reportWithOverridden ++ fullyOverridden)
     NodeStatusReportInternal(nodeId, runInfo, statusInfo, overrides, aggregates)
   }
 }
 
 /**
- * An execution batch contains the node reports for a given Rule / Directive at a given date
- * An execution Batch is at a given time <- TODO : Is it relevant when we have several node ?
+ * Compute node compliance (`NodeStatusReports`) from runs.
+ * This is purely algorithmic (pure).
+ * There is two main function:
+ * - `computeNodesRunInfo` : for a set of nodes, compute their run/expected report information based on a given "now"
+ * - `getNodeStatusReports`: for one node, given its run status and reports, compute compliance
  */
-
 object ExecutionBatch extends Loggable {
   // these patterns must be reluctant matches to avoid strange things
   // when two variables are presents, or something like: ${foo}xxxxxx}.
@@ -598,7 +584,6 @@ object ExecutionBatch extends Loggable {
    * For each node, get the config it has.
    * This method bases its result on THE LAST RUN
    * of each node, and try to discover the run linked information (datetime, config id).
-   *
    */
   def computeNodesRunInfo(
       // The set of run associated with ALL requested node.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -153,10 +153,7 @@ object ReportingService {
   }
 
   def complianceByPolicyType(report: NodeStatusReport, policyType: PolicyTypeName): ComplianceLevel = {
-    ComplianceLevel.sum(report.reports.toSeq.collect {
-      case (t, r) if t == policyType =>
-        r.compliance
-    })
+    report.reports.getCompliance(policyType)
   }
 
   /**
@@ -172,7 +169,7 @@ object ReportingService {
     if (reports.isEmpty) {
       None
     } else { // aggregate values
-      val complianceLevel = ComplianceLevel.sum(reports.flatMap(_._2.reports.map(_._2.compliance)))
+      val complianceLevel = ComplianceLevel.sum(reports.map(_._2.reports.getComplianceLevel))
       val n2              = System.currentTimeMillis
       TimingDebugLogger.trace(s"Aggregating compliance level for  global user compliance in: ${n2 - n1}ms")
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -251,18 +251,18 @@ class StatusReportTest extends Specification {
     }
 
     "Correctly compute the by rule compliance" in {
-      report
-        .reports(PolicyTypeName.rudderBase)
+      report.reports
+        .forPolicyType(PolicyTypeName.rudderBase)
         .filterByRules(Set(RuleId(RuleUid("r1"))))
-        .compliance === ComplianceLevel(pending = 2) and
-      report
-        .reports(PolicyTypeName.rudderBase)
+        .getComplianceLevel === ComplianceLevel(pending = 2) and
+      report.reports
+        .forPolicyType(PolicyTypeName.rudderBase)
         .filterByRules(Set(RuleId(RuleUid("r2"))))
-        .compliance === ComplianceLevel(success = 1) and
-      report
-        .reports(PolicyTypeName.rudderBase)
+        .getComplianceLevel === ComplianceLevel(success = 1) and
+      report.reports
+        .forPolicyType(PolicyTypeName.rudderBase)
         .filterByRules(Set(RuleId(RuleUid("r3"))))
-        .compliance === ComplianceLevel(error = 1)
+        .getComplianceLevel === ComplianceLevel(error = 1)
     }
 
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -3644,7 +3644,7 @@ class ExecutionBatchTest extends Specification {
     val nodeStatus = (getNodeStatusReportsByRule).tupled(param)
 
     "have one detailed reports when we create it with one report" in {
-      nodeStatus(one).reports.size === 1
+      nodeStatus(one).reports.getUnderlyingMap.size === 1
     }
 
     "have one detailed success node when we create it with one success report" in {
@@ -3652,12 +3652,12 @@ class ExecutionBatchTest extends Specification {
     }
 
     "have one detailed rule success directive when we create it with one success report" in {
-      (nodeStatus(one).reports.size === 1) and
-      (nodeStatus(one).reports.head._2.directives.head._1.serialize === "policy")
+      (nodeStatus(one).reports.getUnderlyingMap.size === 1) and
+      (nodeStatus(one).reports.getUnderlyingMap.head._2.directives.head._1.serialize === "policy")
     }
 
     "have no detailed rule non-success directive when we create it with one success report" in {
-      nodeStatus(one).reports.head._2.compliance === ComplianceLevel(success = 1)
+      nodeStatus(one).reports.getUnderlyingMap.head._2.compliance === ComplianceLevel(success = 1)
     }
   }
 
@@ -3699,7 +3699,7 @@ class ExecutionBatchTest extends Specification {
     val nodeStatus = (getNodeStatusReportsByRule).tupled(param)
 
     "have ZERO detailed reports when we create it with one report" in {
-      nodeStatus(one).reports.size === 0
+      nodeStatus(one).reports.getUnderlyingMap.size === 0
     }
   }
 
@@ -3742,7 +3742,9 @@ class ExecutionBatchTest extends Specification {
 
     "have a pending node when we create it with one wrong success report right now" in {
       (nodeStatus.keySet.head === one) and
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.values.flatMap(_.reports)).toSet).compliance === ComplianceLevel(
+      AggregatedStatusReport(
+        nodeStatus.values.flatMap(_.reports.getUnderlyingMap.values.flatMap(_.reports)).toSet
+      ).compliance === ComplianceLevel(
         missing = 1
       )
     }
@@ -3798,7 +3800,9 @@ class ExecutionBatchTest extends Specification {
 
     "have one unexpected node when we create it with one success report" in {
       nodeStatus.head._1 === one and
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.values.flatMap(_.reports)).toSet).compliance === ComplianceLevel(
+      AggregatedStatusReport(
+        nodeStatus.values.flatMap(_.reports.getUnderlyingMap.values.flatMap(_.reports)).toSet
+      ).compliance === ComplianceLevel(
         unexpected = 2
       )
     }
@@ -3842,7 +3846,9 @@ class ExecutionBatchTest extends Specification {
     }
 
     "have one success, and one pending node, in the component detail of the rule" in {
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.values.flatMap(_.reports)).toSet).compliance === ComplianceLevel(
+      AggregatedStatusReport(
+        nodeStatus.values.flatMap(_.reports.getUnderlyingMap.values.flatMap(_.reports)).toSet
+      ).compliance === ComplianceLevel(
         success = 1,
         missing = 1
       )
@@ -3896,7 +3902,9 @@ class ExecutionBatchTest extends Specification {
       nodeStatus.size === 3
     }
     "have one detailed rule report with a 67% compliance" in {
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.values.flatMap(_.reports)).toSet).compliance === ComplianceLevel(
+      AggregatedStatusReport(
+        nodeStatus.values.flatMap(_.reports.getUnderlyingMap.values.flatMap(_.reports)).toSet
+      ).compliance === ComplianceLevel(
         success = 2,
         missing = 1
       )
@@ -4013,7 +4021,7 @@ class ExecutionBatchTest extends Specification {
       )
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.values.flatMap(_.reports)).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.getUnderlyingMap.values.flatMap(_.reports)).toSet)
 
     "have two detailed node rule report" in {
       nodeStatus.size === 3
@@ -4147,7 +4155,7 @@ class ExecutionBatchTest extends Specification {
       )
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.values.flatMap(_.reports)).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.getUnderlyingMap.values.flatMap(_.reports)).toSet)
 
     "have 3 detailed node rule report" in {
       nodeStatus.size === 3
@@ -4276,7 +4284,7 @@ class ExecutionBatchTest extends Specification {
       )
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.values.flatMap(_.reports)).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports.getUnderlyingMap.values.flatMap(_.reports)).toSet)
 
     "have 3 detailed node rule report" in {
       nodeStatus.size === 3
@@ -4360,7 +4368,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === one and
-      nodeStatus.head._2.reports.head._2.compliance.computePercent().success === 100
+      nodeStatus.head._2.reports.getUnderlyingMap.head._2.compliance.computePercent().success === 100
     }
 
   }
@@ -4410,7 +4418,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === NodeId("nodeId") and
-      nodeStatus.head._2.reports.head._2.compliance.computePercent().success === 100
+      nodeStatus.head._2.reports.getUnderlyingMap.head._2.compliance.computePercent().success === 100
     }
   }
 
@@ -4457,7 +4465,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === NodeId("nodeId") and
-      nodeStatus.head._2.reports.head._2.compliance.computePercent().success === 100
+      nodeStatus.head._2.reports.getUnderlyingMap.head._2.compliance.computePercent().success === 100
     }
   }
 
@@ -4632,20 +4640,20 @@ class ExecutionBatchTest extends Specification {
     val nodeStatus = getNodeStatusByRule(param).head._2
 
     "There is two policy types in the report" in {
-      nodeStatus.reports.size === 2
+      nodeStatus.reports.getUnderlyingMap.size === 2
     }
     "have detailed rule report for policy1 of 50% and 100% for policy2 on tag1" in {
-      nodeStatus.reports(tag1).directives("policy1").compliance === ComplianceLevel(success = 1, error = 1) and
-      nodeStatus.reports(tag1).directives("policy2").compliance === ComplianceLevel(success = 2)
+      nodeStatus.reports.getUnderlyingMap(tag1).directives("policy1").compliance === ComplianceLevel(success = 1, error = 1) and
+      nodeStatus.reports.getUnderlyingMap(tag1).directives("policy2").compliance === ComplianceLevel(success = 2)
     }
     "have detailed rule report for policy1 of 100% for policy2 on tag2 and policy is not on that tag" in {
-      nodeStatus.reports(tag2).directives.get("policy1") must beNone and
-      nodeStatus.reports(tag2).directives("policy2").compliance === ComplianceLevel(success = 2)
+      nodeStatus.reports.getUnderlyingMap(tag2).directives.get("policy1") must beNone and
+      nodeStatus.reports.getUnderlyingMap(tag2).directives("policy2").compliance === ComplianceLevel(success = 2)
     }
 
     "have compliance of 75% for tag1 and 100% for tag2" in {
-      nodeStatus.reports(tag1).compliance === ComplianceLevel(success = 3, error = 1) and
-      nodeStatus.reports(tag2).compliance === ComplianceLevel(success = 2)
+      nodeStatus.reports.getUnderlyingMap(tag1).compliance === ComplianceLevel(success = 3, error = 1) and
+      nodeStatus.reports.getUnderlyingMap(tag2).compliance === ComplianceLevel(success = 2)
     }
   }
 
@@ -4750,12 +4758,15 @@ class ExecutionBatchTest extends Specification {
     val nodeStatus = getNodeStatusByRule(param).head._2
 
     "have detailed rule report for policy1 empty and overridden and 100% for policy2" in {
-      val policy1 = nodeStatus.reports(PolicyTypeName.rudderBase).directives("policy1")
+      val policy1 = nodeStatus.reports.getUnderlyingMap(PolicyTypeName.rudderBase).directives("policy1")
 
       policy1.compliance === ComplianceLevel() // it's overridden
       policy1.overridden === Some(overridingPolicyId.ruleId)
 
-      nodeStatus.reports(PolicyTypeName.rudderBase).directives("policy2").compliance === ComplianceLevel(success = 2)
+      nodeStatus.reports
+        .getUnderlyingMap(PolicyTypeName.rudderBase)
+        .directives("policy2")
+        .compliance === ComplianceLevel(success = 2)
     }
   }
 
@@ -4805,7 +4816,7 @@ class ExecutionBatchTest extends Specification {
     val nodeStatus = getNodeStatusByRule(param).head._2
 
     "have rule report for policy1 empty and overridden" in {
-      val policy1 = nodeStatus.reports(PolicyTypeName.rudderBase).directives.get("policy1")
+      val policy1 = nodeStatus.reports.getUnderlyingMap(PolicyTypeName.rudderBase).directives.get("policy1")
 
       policy1 must beSome
       policy1.get.compliance === ComplianceLevel() // it's overridden

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
@@ -207,7 +207,7 @@ class NodeStatusReportRepositoryTest extends Specification {
     // we have one modification because we changed kind from pending to "keep"
     counter.getCount("p") === 1
     // but we kept the existing report with some report (vs missing which has no rule status reports)
-    counter.get("p").reports must not(beEmpty)
+    counter.get("p").reports.getUnderlyingMap must not(beEmpty)
   }
 
   // see issue: https://issues.rudder.io/issues/27180 - when a missing node is cleaned up, we need to keep compliance

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.domain.reports.BlockStatusReport
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.domain.reports.ComponentStatusReport
+import com.normation.rudder.domain.reports.ConvertStatusReport
 import com.normation.rudder.domain.reports.DirectiveStatusReport
 import com.normation.rudder.domain.reports.ValueStatusReport
 import com.normation.rudder.facts.nodes.CoreNodeFact
@@ -86,7 +87,6 @@ import net.liftweb.http.LiftResponse
 import net.liftweb.http.PlainTextResponse
 import net.liftweb.http.Req
 import scala.collection.MapView
-import scala.collection.immutable
 import zio.Chunk
 import zio.ZIO
 import zio.syntax.*
@@ -124,7 +124,7 @@ class ComplianceApi(
 
   /**
    * This endpoint is marked for deprecation and will be replaced with the GetRulesCompliance endpoint in the RulesApi
-   * This endpoint will be deleted in version 10. 
+   * This endpoint will be deleted in version 10.
    * @deprecated
    */
   object GetRules extends LiftApiModule0 {
@@ -156,7 +156,7 @@ class ComplianceApi(
 
   /**
    * This endpoint is marked for deprecation and will be replaced with the GetRulesComplianceId endpoint in the RulesApi
-   * This endpoint will be deleted in version 10. 
+   * This endpoint will be deleted in version 10.
    * @deprecated
    */
   object GetRuleId extends LiftApiModule {
@@ -587,16 +587,13 @@ class ComplianceAPIService(
 
       globalPolicyMode <- getGlobalPolicyMode
 
-      reportsByRule = reportsByNode.flatMap {
-                        case (_, status) =>
-                          status.reports
-                            .get(PolicyTypeName.rudderBase)
-                            .map(_.reports)
-                            .getOrElse(Set.empty)
-                            .filter(r => ruleIds.contains(r.ruleId))
-                      }.groupBy(_.ruleId)
-      t7           <- currentTimeMillis
-      _            <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - group reports by rules in ${t7 - t6} ms")
+      reportsByRule = ConvertStatusReport.fromNodesToRules(
+                        reportsByNode.values,
+                        r => r.complianceTag == PolicyTypeName.rudderBase && ruleIds.contains(r.ruleId)
+                      )
+
+      t7 <- currentTimeMillis
+      _  <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - group reports by rules in ${t7 - t6} ms")
 
     } yield {
 
@@ -721,7 +718,7 @@ class ComplianceAPIService(
       t6            <- currentTimeMillis
       _             <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - findRuleNodeStatusReports in ${t6 - t5} ms")
 
-      reportsByRule = reportsByNode.flatMap { case (_, status) => status.reports.flatMap(_._2.reports) }.groupBy(_.ruleId)
+      reportsByRule = ConvertStatusReport.fromNodesToRules(reportsByNode.values)
       t7            = System.currentTimeMillis()
       _            <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - group reports by rules in ${t7 - t6} ms")
 
@@ -760,7 +757,7 @@ class ComplianceAPIService(
           val (_, policyMode) =
             nodeAndPolicyModeByRules.get(ruleId).getOrElse((Chunk.empty, ComputePolicyMode.global(globalPolicyMode)))
           // aggregate by directives, if level is at least 2
-          val byDirectives: Map[DirectiveId, immutable.Iterable[(NodeId, DirectiveStatusReport)]] = if (computedLevel < 2) {
+          val byDirectives: Map[DirectiveId, Iterable[(NodeId, DirectiveStatusReport)]] = if (computedLevel < 2) {
             Map()
           } else {
             reports.flatMap(r => r.directives.values.map(d => (r.nodeId, d)).toSeq).groupBy(_._2.directiveId)
@@ -792,7 +789,7 @@ class ComplianceAPIService(
                   directiveMode, {
                     // here we want the compliance by components of the directive.
                     // if level is high enough, get all components and group by their name
-                    val byComponents: Map[String, immutable.Iterable[(NodeId, ComponentStatusReport)]] = if (computedLevel < 3) {
+                    val byComponents: Map[String, Iterable[(NodeId, ComponentStatusReport)]] = if (computedLevel < 3) {
                       Map()
                     } else {
                       nodeDirectives.flatMap { case (nodeId, d) => d.components.map(c => (nodeId, c)).toSeq }
@@ -895,18 +892,13 @@ class ComplianceAPIService(
       t2            <- currentTimeMillis
       _             <- TimingDebugLoggerPure.trace(s"getByNodeGroupCompliance - findRuleNodeStatusReports in ${t2 - t1} ms")
 
-      reportsByRule = reportsByNode.flatMap {
-                        case (_, status) =>
-                          // TODO: separate reports that have 'overridden policies' here (skipped)
-                          status.reports
-                            .get(PolicyTypeName.rudderBase)
-                            .map(_.reports)
-                            .getOrElse(Set.empty)
-                            .filter(r =>
-                              (isGlobalCompliance || rules.keySet.contains(r.ruleId)) && currentGroupNodeIds.contains(r.nodeId)
-                            )
-                      }.groupBy(_.ruleId)
-      //
+      reportsByRule = ConvertStatusReport.fromNodesToRules(
+                        reportsByNode.values,
+                        r => {
+                          r.complianceTag == PolicyTypeName.rudderBase &&
+                          (isGlobalCompliance || rules.keySet.contains(r.ruleId)) && currentGroupNodeIds.contains(r.nodeId)
+                        }
+                      )
       t3           <- currentTimeMillis
       _            <- TimingDebugLoggerPure.trace(s"getByNodeGroupCompliance - group reports by rules in ${t3 - t2} ms")
 
@@ -917,7 +909,7 @@ class ComplianceAPIService(
       val nonEmptyRules = reportsByRule.toSeq.flatMap {
         case (ruleId, reports) =>
           // aggregate by directives, if level is at least 2
-          val byDirectives: Map[DirectiveId, immutable.Iterable[(NodeId, DirectiveStatusReport)]] = if (computedLevel < 2) {
+          val byDirectives: Map[DirectiveId, Iterable[(NodeId, DirectiveStatusReport)]] = if (computedLevel < 2) {
             Map()
           } else {
             reports.flatMap(r => r.directives.values.map(d => (r.nodeId, d)).toSeq).groupBy(_._2.directiveId)
@@ -964,7 +956,7 @@ class ComplianceAPIService(
                         // here we want the compliance by components of the directive.
                         // if level is high enough, get all components and group by their name
                         {
-                          val byComponents: Map[String, immutable.Iterable[(NodeId, ComponentStatusReport)]] = {
+                          val byComponents: Map[String, Iterable[(NodeId, ComponentStatusReport)]] = {
                             if (computedLevel < 3) {
                               Map()
                             } else {
@@ -1018,11 +1010,9 @@ class ComplianceAPIService(
         case (nodeId, status) if currentGroupNodeIds.contains(nodeId) =>
           // For non global compliance, we only want the compliance for the rules in the group
           val reports        = status.reports
-            .get(PolicyTypeName.rudderBase)
-            .map(_.reports)
-            .getOrElse(Set.empty)
-            .filter(r => isGlobalCompliance || rules.keySet.contains(r.ruleId))
-            .toSeq
+            .getReports(r =>
+              r.complianceTag == PolicyTypeName.rudderBase && (isGlobalCompliance || rules.keySet.contains(r.ruleId))
+            )
             .sortBy(_.ruleId.serialize)
           val nodePolicyMode = nodeFacts.get(nodeId).flatMap(_.rudderSettings.policyMode)
           val nodeMode       = ComputePolicyMode.nodeMode(globalMode, nodePolicyMode)
@@ -1495,13 +1485,11 @@ class ComplianceAPIService(
             ByNodeNodeCompliance(
               nodeId,
               nodeInfos.get(nodeId).map(_._1).getOrElse("Unknown node"),
-              ComplianceLevel.sum(status.reports.map(_._2.compliance)),
+              status.reports.getComplianceLevel,
               compliance.mode, // Add this line to include no
               nodePolicyMode,
               status.reports
-                .get(policyType)
-                .toSeq
-                .flatMap(_.reports)
+                .getReports(r => r.complianceTag == policyType)
                 .flatMap(r => ruleMap.get(r.ruleId).map(r -> _))
                 .map {
                   case (r, rule) =>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
@@ -99,7 +99,7 @@ class JsonPostresqlSerializationTest extends Specification {
   def buildReport(runAnalysis: RunAnalysis, reports: Map[PolicyTypeName, AggregatedStatusReport])(implicit
       nid: NodeId
   ): NodeStatusReport =
-    NodeStatusReport(nid, runAnalysis, RunComplianceInfo.OK, reports)
+    NodeStatusReport(nid, runAnalysis, RunComplianceInfo.OK, ComposedReport(reports))
 
   /*
    * Create a reports of:

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
@@ -44,6 +44,7 @@ import com.normation.rudder.domain.logger.TimingDebugLogger
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.ComplianceLevelSerialisation.*
+import com.normation.rudder.domain.reports.ConvertStatusReport
 import com.normation.rudder.domain.reports.RuleNodeStatusReport
 import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.tenants.QueryContext
@@ -133,12 +134,7 @@ class AsyncComplianceService(
       for {
         reports <- reportingService.findRuleNodeStatusReports(nodeIds, ruleIds)
       } yield {
-        // We need to take values before flatmap, because we are using a Map here and will lose values on first level because keys are policyTypes
-        // Using values at each level ensure that we still have all our data at the end
-        val found      = reports.values.flatMap(_.reports.values).flatMap(_.reports).groupBy(_.ruleId).map {
-          case (ruleId, reports) =>
-            toCompliance(ruleId, reports)
-        }
+        val found      = ConvertStatusReport.fromNodesToRules(reports.values).map((ruleId, rs) => toCompliance(ruleId, rs))
         // add missing elements with "None" compliance, see #7281, #8030, #8141, #11842
         val missingIds = ruleIds -- found.keySet
         found ++ (missingIds.map(id => (id, None)))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
@@ -404,11 +404,8 @@ object ComplianceData extends Loggable {
   ): RuleComplianceLines = {
 
     val ruleComplianceLine = for {
-      (ruleId, aggregate) <- (report.reports
-                               .getOrElse(tag, AggregatedStatusReport(Nil))
-                               .reports
-                               .groupBy(_.ruleId)
-                               .map { case (id, rules) => (id, AggregatedStatusReport(rules)) })
+      (ruleId, aggregate) <-
+        ConvertStatusReport.fromNodesToRules(List(report)).map((id, rules) => (id, AggregatedStatusReport(rules)))
       rule                <- rules.find(_.id == ruleId)
     } yield {
       val nodeMode = allNodeInfos.get(nodeId).flatMap(_.rudderSettings.policyMode)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -721,7 +721,7 @@ class ReportDisplayer(
      */
     for {
       (_, directive) <-
-        DirectiveStatusReport.merge(nodeStatusReports.reports.toList.flatMap(_._2.reports.toList.flatMap(_.directives.values)))
+        DirectiveStatusReport.merge(nodeStatusReports.reports.getReports().flatMap(_.directives.values))
       value          <- directive.getValues(v => v.status == status)
     } yield {
       val (techName, techVersion) = directiveLib.allDirectives

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -197,7 +197,7 @@ class HomePage extends SecureDispatchSnippet with StatefulSnippet with Loggable 
 
       // TODO : we could first compute per nodes, and then compute the globalCompliance by excluding the pending nodes
       compliancePerNodes =
-        reports.map { case (nodeId, status) => (nodeId, ComplianceLevel.sum(status.reports.map(_._2.compliance))) }
+        reports.map { case (nodeId, status) => (nodeId, status.reports.getComplianceLevel) }
       global             = if (reports.isEmpty) {
                              None
                            } else {


### PR DESCRIPTION
https://issues.rudder.io/issues/28943

The main change is creating an opaque type for `Map[PolicyTypeName, AggregatedReport]`. In addition that allows to factor allow common filtering operation here. 
We also very often switch from a list of `NodeStatusReport`s to a list of proto-`RuleStatusReport`s - proto because we need to do a bit more filtering then. I factored out that into a conversion object. 

Actually, it looks like other repeated complicated operation on `ComplianceApi` should likely be in similar transormation objects, but I wanted to keep that change not too big. 