### PR TITLE
Fixes #28901: Campaigns keep running on Windows Server 2022

### DIFF
--- a/policies/module-types/system-updates/src/package_manager/windows_update_agent.rs
+++ b/policies/module-types/system-updates/src/package_manager/windows_update_agent.rs
@@ -494,14 +494,7 @@ impl UpdateManager for WindowsUpdateAgent {
 
     fn reboot(&self, options: &RebootBehavior) -> ResultOutput<()> {
         let mut c = Command::new("shutdown");
-        c.args([
-            "/r",
-            "/t",
-            "0",
-            "/e",
-            "/c",
-            "\"Rudder system update campaign reboot\"",
-        ]);
+        c.args(["/r", "/t", "0"]);
         if options == &RebootBehavior::Force {
             c.arg("/f");
         }


### PR DESCRIPTION
https://issues.rudder.io/issues/28901