### PR TITLE
Fixes #28722: POC architecture documentation c4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -535,6 +535,77 @@ pipeline {
         stage('Publish') {
             when { not { changeRequest() } }
             parallel {
+                stage('adr-doc') {
+                    agent {
+                        dockerfile {
+                            label 'generic-docker'
+                            filename 'ci/common.Dockerfile'
+                            // mount cache
+                            args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
+                        }
+                    }
+                    when { expression { latestVersion == true } }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            dir("adr") {
+                                sh script: 'make', label: 'build adr doc'
+                                withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
+                                    sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" book/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/adr/', label: 'publish techniques docs'
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        failure {
+                            script {
+                                failedBuild = true
+                                errors.add("Publish - Rust ADR docs")
+                                slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
+                                slackSend(channel: slackResponse.threadId, message: "Error while publishing ADR docs - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
+                            }
+                        }
+                        cleanup {
+                            script {
+                                cleanWs(deleteDirs: true, notFailBuild: true)
+                            }
+                        }
+                    }
+                }
+                stage('rust-dev-doc') {
+                    agent {
+                        dockerfile {
+                            label 'generic-docker'
+                            filename 'policies/Dockerfile'
+                            additionalBuildArgs  "--build-arg RUDDER_VER=${RUDDER_VERSION}-nightly"
+                            // mount cache
+                            args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
+                        }
+                    }
+                    when { not { branch 'master' } }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh script: 'make dev-doc', label: 'rust dev doc'
+                            withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
+                                sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" target/doc/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/${RUDDER_VERSION}/rust/', label: 'publish techniques docs'
+                            }
+                        }
+                    }
+                    post {
+                        failure {
+                            script {
+                                failedBuild = true
+                                errors.add("Publish - Rust dev docs")
+                                slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
+                                slackSend(channel: slackResponse.threadId, message: "Error while publishing rust dev docs - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
+                            }
+                        }
+                        cleanup {
+                            script {
+                                cleanWs(deleteDirs: true, notFailBuild: true)
+                            }
+                        }
+                    }
+                }
                 stage('graphic-charter') {
                     agent {
                         dockerfile {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
                     steps {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                             dir('architecture-doc') {
-                                sh script: 'java -jar /usr/bin/structurizr.war export -format static -output target -workspace rudder-containers.dsl ', label: 'build architecture documentation'
+                                sh script: 'java -jar /usr/bin/structurizr.war export -format static -output target -workspace rudder-containers.dsl', label: 'build architecture documentation'
                                 withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
                                     sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" target/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/${RUDDER_VERSION}/architecture-doc/', label: "publish architecture documentation"
                                 }
@@ -534,77 +534,6 @@ pipeline {
         stage('Publish') {
             when { not { changeRequest() } }
             parallel {
-                stage('adr-doc') {
-                    agent {
-                        dockerfile {
-                            label 'generic-docker'
-                            filename 'ci/common.Dockerfile'
-                            // mount cache
-                            args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
-                        }
-                    }
-                    when { expression { latestVersion == true } }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            dir("adr") {
-                                sh script: 'make', label: 'build adr doc'
-                                withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
-                                    sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" book/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/adr/', label: 'publish techniques docs'
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        failure {
-                            script {
-                                failedBuild = true
-                                errors.add("Publish - Rust ADR docs")
-                                slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
-                                slackSend(channel: slackResponse.threadId, message: "Error while publishing ADR docs - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
-                            }
-                        }
-                        cleanup {
-                            script {
-                                cleanWs(deleteDirs: true, notFailBuild: true)
-                            }
-                        }
-                    }
-                }
-                stage('rust-dev-doc') {
-                    agent {
-                        dockerfile {
-                            label 'generic-docker'
-                            filename 'policies/Dockerfile'
-                            additionalBuildArgs  "--build-arg RUDDER_VER=${RUDDER_VERSION}-nightly"
-                            // mount cache
-                            args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
-                        }
-                    }
-                    when { not { branch 'master' } }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            sh script: 'make dev-doc', label: 'rust dev doc'
-                            withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
-                                sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" target/doc/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/${RUDDER_VERSION}/rust/', label: 'publish techniques docs'
-                            }
-                        }
-                    }
-                    post {
-                        failure {
-                            script {
-                                failedBuild = true
-                                errors.add("Publish - Rust dev docs")
-                                slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
-                                slackSend(channel: slackResponse.threadId, message: "Error while publishing rust dev docs - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
-                            }
-                        }
-                        cleanup {
-                            script {
-                                cleanWs(deleteDirs: true, notFailBuild: true)
-                            }
-                        }
-                    }
-                }
                 stage('graphic-charter') {
                     agent {
                         dockerfile {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,41 @@ pipeline {
     stages {
         stage('Tests') {
             parallel {
+                stage('architecture-doc') {
+                    agent {
+                        dockerfile {
+                            label 'generic-docker'
+                            filename 'webapp/sources/Dockerfile'
+                            args '-u 0:0'
+                        }
+                    }
+                    when { not { branch 'master' } }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            dir('architecture-doc') {
+                                sh script: 'java -jar /usr/bin/structurizr.war export -format static -output target -workspace rudder-containers.dsl ', label: 'build architecture documentation'
+                                withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
+                                    sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" target/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/${RUDDER_VERSION}/architecture-doc/', label: "publish architecture documentation"
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        failure {
+                            script {
+                                failedBuild = true
+                                errors.add("Publish - architecture documentation")
+                                slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
+                                slackSend(channel: slackResponse.threadId, message: "Error when publishing architecture documentation - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
+                            }
+                        }
+                        cleanup {
+                            script {
+                                cleanWs(deleteDirs: true, notFailBuild: true)
+                            }
+                        }
+                    }
+                }
                 stage('policies-methods') {
                     agent {
                         dockerfile {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
                 stage('architecture-doc') {
                     agent {
                         dockerfile {
+                            additionalBuildArgs "--build-arg JDK_VERSION=21" // to be compatible with structurizr war version.
                             label 'generic-docker'
                             filename 'webapp/sources/Dockerfile'
                             args '-u 0:0'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,42 +27,6 @@ pipeline {
     stages {
         stage('Tests') {
             parallel {
-                stage('architecture-doc') {
-                    agent {
-                        dockerfile {
-                            additionalBuildArgs "--build-arg JDK_VERSION=21" // to be compatible with structurizr war version.
-                            label 'generic-docker'
-                            filename 'webapp/sources/Dockerfile'
-                            args '-u 0:0'
-                        }
-                    }
-                    when { not { branch 'master' } }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            dir('architecture-doc') {
-                                sh script: 'java -jar /usr/bin/structurizr.war export -format static -output target -workspace rudder-containers.dsl', label: 'build architecture documentation'
-                                withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
-                                    sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" target/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/${RUDDER_VERSION}/architecture-doc/', label: "publish architecture documentation"
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        failure {
-                            script {
-                                failedBuild = true
-                                errors.add("Publish - architecture documentation")
-                                slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
-                                slackSend(channel: slackResponse.threadId, message: "Error when publishing architecture documentation - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
-                            }
-                        }
-                        cleanup {
-                            script {
-                                cleanWs(deleteDirs: true, notFailBuild: true)
-                            }
-                        }
-                    }
-                }
                 stage('policies-methods') {
                     agent {
                         dockerfile {
@@ -562,6 +526,42 @@ pipeline {
                                 errors.add("Publish - Rust ADR docs")
                                 slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
                                 slackSend(channel: slackResponse.threadId, message: "Error while publishing ADR docs - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
+                            }
+                        }
+                        cleanup {
+                            script {
+                                cleanWs(deleteDirs: true, notFailBuild: true)
+                            }
+                        }
+                    }
+                }
+                stage('architecture-doc') {
+                    agent {
+                        dockerfile {
+                            additionalBuildArgs "--build-arg JDK_VERSION=21" // to be compatible with structurizr war version.
+                            label 'generic-docker'
+                            filename 'webapp/sources/Dockerfile'
+                            args '-u 0:0'
+                        }
+                    }
+                    when { not { branch 'master' } }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            dir('architecture-doc') {
+                                sh script: 'java -jar /usr/bin/structurizr.war export -format static -output target -workspace rudder-containers.dsl', label: 'build architecture documentation'
+                                withCredentials([sshUserPrivateKey(credentialsId: 'docs-publish', keyFileVariable: 'KEY_FILE', passphraseVariable: '', usernameVariable: 'KEY_USER')]) {
+                                    sh script: 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -i${KEY_FILE} -p${SSH_PORT}" target/ ${KEY_USER}@${HOST_DOCS}:/var/www-docs/devel/${RUDDER_VERSION}/architecture-doc/', label: "publish architecture documentation"
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        failure {
+                            script {
+                                failedBuild = true
+                                errors.add("Publish - architecture documentation")
+                                slackResponse = updateSlack(errors, slackResponse, version, changeUrl, false)
+                                slackSend(channel: slackResponse.threadId, message: "Error when publishing architecture documentation - <${currentBuild.absoluteUrl}|Link>", color: "#CC3421")
                             }
                         }
                         cleanup {

--- a/architecture-doc/README.md
+++ b/architecture-doc/README.md
@@ -1,0 +1,5 @@
+# Architecture documentation
+
+- c4 see https://c4model.com/introduction
+- write files using structurizr dsl https://docs.structurizr.com/dsl
+- online editor https://playground.structurizr.com/

--- a/architecture-doc/rudder-containers.dsl
+++ b/architecture-doc/rudder-containers.dsl
@@ -1,0 +1,85 @@
+workspace "Name" "Description"
+
+
+    model {
+        archetypes {
+            webapp = container
+            database = container
+            relayd = container
+            slapd = container
+            git = container
+            agent = softwareSystem {
+                tags agent
+            }
+        }
+
+        !identifiers hierarchical
+
+        group "Sub network" {
+            a1 = agent "Agent 1" {
+                tags agent
+            }
+
+            a2 = agent "Agent 2"{
+                tags agent
+            }
+            a3 = agent "Agent 3"{
+                tags agent
+            }
+            relay = agent "Relay" {
+                tags agent
+            }
+        }
+
+        ss = softwareSystem "Rudder Server" {
+            wa = webapp "Jetty"
+            db = database "Postgresql" {
+                tags "database"
+            }
+            ap = container "Apache"
+            sre = relayd "relayd"
+            sd = slapd "slapd"
+            git = git "Git configuration"
+        }
+
+        a1 -> relay "Sends reports, inventories and download policies"
+        a2 -> relay "Sends reports, inventories and download policies"
+        a3 -> relay "Sends reports, inventories and download policies"
+        relay -> ss "Sends reports, inventories and download policies"
+        relay -> ss.ap "Sends reports, inventories and download policies"
+
+        ss.wa -> ss.db
+        ss.wa -> ss.sd
+        ss.wa -> ss.sre
+        ss.wa -> ss.git
+        ss.ap -> ss.wa
+    }
+
+    views {
+        styles {
+            element "Group:subnetwork" {
+                color #ff0000
+            }
+            element "database" {
+                shape cylinder
+            }
+            element "agent" {
+                shape circle
+                width 200
+                height 200
+            }
+        }
+
+        systemLandscape {
+            include *
+            autolayout lr
+        }
+
+        container ss {
+            include *
+        }
+
+
+    }
+
+}

--- a/webapp/sources/Dockerfile
+++ b/webapp/sources/Dockerfile
@@ -10,5 +10,7 @@ RUN apt-get update && apt-get install -y curl gpg
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
 
+RUN curl -O /usr/bin/structurizr.war https://download.structurizr.com/structurizr-2026.05.22.war
+
 RUN apt-get update && apt-get install -y nodejs rsync
 

--- a/webapp/sources/Dockerfile
+++ b/webapp/sources/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y curl gpg
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
 
-RUN curl -O /usr/bin/structurizr.war https://download.structurizr.com/structurizr-2026.05.22.war
+RUN curl -o /usr/bin/structurizr.war https://download.structurizr.com/structurizr-2026.05.22.war
 
 RUN apt-get update && apt-get install -y nodejs rsync
 

--- a/webapp/sources/Dockerfile
+++ b/webapp/sources/Dockerfile
@@ -1,4 +1,5 @@
 ARG JDK_VERSION=17
+
 FROM maven:3-eclipse-temurin-${JDK_VERSION}
 LABEL ci=rudder/webapp/sources/Dockerfile
 


### PR DESCRIPTION
https://issues.rudder.io/issues/28722

Replacing previous PR: https://github.com/Normation/rudder/pull/7075

Add a c4 architecture documentation using structurizr dsl, with two levels of details in this example :

- the container view

<img width="1203" height="1091" alt="Screenshot From 2026-05-29 10-50-25" src="https://github.com/user-attachments/assets/3465111d-5b91-4729-a4c6-8387b279b528" />


- the system landscape view

<img width="1247" height="894" alt="Screenshot From 2026-05-29 10-49-30" src="https://github.com/user-attachments/assets/8fcf8762-7657-4bf3-a31d-ccaaa0dee9f9" />

The documentation output :
https:docs.rudder.io](https://docs.rudder.io/devel/9.1/architecture-doc/
