### PR TITLE
Fixes #28962: The node compliance tab is not displayed since #28943

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/PolicyTypes.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/PolicyTypes.scala
@@ -60,10 +60,10 @@ object PolicyTypes {
   }
 
   def fromTypes(t: PolicyTypeName, other: PolicyTypeName*): PolicyTypes = PolicyTypes(NonEmptyChunk(t, other*))
-
   def fromStrings(s: String, other: String*): PolicyTypes = PolicyTypes(
     NonEmptyChunk(PolicyTypeName(s.trim), other.map(s => PolicyTypeName(s.trim))*)
   )
+  def fromIterable(it: Iterable[PolicyTypeName]): Option[PolicyTypes] = NonEmptyChunk.fromIterableOption(it).map(apply)
 
   def fromCons(list: ::[PolicyTypeName]): PolicyTypes = {
     // not sure why, but sortBy loose the type and loosen it to list.
@@ -84,6 +84,10 @@ object PolicyTypes {
   // for simpler compat with Rudder < 8.2 where we only had isSystem
   val rudderSystem: PolicyTypes = PolicyTypes(NonEmptyChunk(PolicyTypeName.rudderSystem))
   val rudderBase:   PolicyTypes = PolicyTypes(NonEmptyChunk(PolicyTypeName.rudderBase))
+
+  extension (opt: Option[PolicyTypes]) {
+    def orRudderBase: PolicyTypes = opt.getOrElse(rudderBase)
+  }
 }
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -460,12 +460,7 @@ object ExpectedReportsSerialisation {
         cs:  List[JsonComponentExpectedReport7_1]
     ) {
       def transform: DirectiveExpectedReports = {
-        val ct = {
-          t match {
-            case Some(value) => value
-            case None        => PolicyTypes.rudderBase
-          }
-        }
+        val ct = t.orRudderBase
         DirectiveExpectedReports(did, pm, ct, sid, cs.map(_.transform))
       }
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -591,12 +591,7 @@ object DirectiveStatusReport {
   def merge(directives: Iterable[DirectiveStatusReport]): Map[DirectiveId, DirectiveStatusReport] = {
     directives.groupBy(_.directiveId).map {
       case (directiveId, reports) =>
-        val tags          = {
-          reports.flatMap(_.policyTypes.types) match {
-            case Nil          => PolicyTypes.rudderBase
-            case c @ ::(_, _) => PolicyTypes.fromCons(c)
-          }
-        }
+        val tags          = PolicyTypes.fromIterable(reports.flatMap(_.policyTypes.types)).orRudderBase
         // in a merge, we keep the overridden only if all directive have an override
         val overridden    = if (reports.forall(_.overridden.isDefined)) reports.headOption.flatMap(_.overridden) else None
         val newComponents = ComponentStatusReport.merge(reports.flatMap(_.components))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -395,10 +395,8 @@ class ActiveTechniqueUnserialisationImpl extends ActiveTechniqueUnserialisation 
                           ) ?~! (s"Missing attribute 'displayName' in entry type policyLibraryTemplate : ${entry}")
       policyTypes       = (activeTechnique \ "policyTypes").headOption
                             .flatMap(s => s.text.fromJson[PolicyTypes].toBox)
-                            .getOrElse(
-                              // by default, for compat reason, if the type is missing, we assume rudder std technique
-                              PolicyTypes.rudderBase
-                            )
+                            // by default, for compat reason, if the type is missing, we assume rudder std technique
+                            .orRudderBase
       isEnabled        <- (activeTechnique \ "isEnabled").headOption.flatMap(s =>
                             tryo(s.text.toBoolean)
                           ) ?~! (s"Missing attribute 'isEnabled' in entry type policyLibraryTemplate : ${entry}")


### PR DESCRIPTION
https://issues.rudder.io/issues/28962

The `rudderBase` fallback seems very common, so standard usage of collection constructors should look like `PolicyTypes.from(...).or(fallback)` (there are already `fromTypes(head, tail)` for the non empty chunk)