### PR TITLE
Fixes #28965: Property creation on root server is not peristed after rebooting

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryDit.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryDit.scala
@@ -158,19 +158,19 @@ final case class InventoryDit(val BASE_DN: DN, val SOFTWARE_BASE_DN: DN, val nam
 
       def genericModel(id: NodeId): LDAPEntry = {
         val mod = model(id)
-        mod.addValues(A_OC, OC.objectClassNames(OC_UNIX_NODE).toSeq*)
+        mod.addValues(A_OC, OC.objectClassNames(OC_UNIX_NODE)*)
         mod
       }
 
       def linuxModel(id: NodeId): LDAPEntry = {
         val mod = model(id)
-        mod.addValues(A_OC, OC.objectClassNames(OC_LINUX_NODE).toSeq*)
+        mod.addValues(A_OC, OC.objectClassNames(OC_LINUX_NODE)*)
         mod
       }
 
       def windowsModel(id: NodeId): LDAPEntry = {
         val mod = model(id)
-        mod.addValues(A_OC, OC.objectClassNames(OC_WINDOWS_NODE).toSeq*)
+        mod.addValues(A_OC, OC.objectClassNames(OC_WINDOWS_NODE)*)
         mod
       }
 
@@ -271,7 +271,7 @@ class UUID_ENTRY[U <: Uuid](val entryObjectClass: String, val rdnAttributeName: 
 
   def model(uuid: U): LDAPEntry = {
     val mod = LDAPEntry(dn(uuid))
-    mod.resetValuesTo(A_OC, OC.objectClassNames(entryObjectClass).toSeq*)
+    mod.resetValuesTo(A_OC, OC.objectClassNames(entryObjectClass)*)
     mod
   }
 }
@@ -286,7 +286,7 @@ class OU(ouName: String, parentDn: DN) extends ENTRY1("ou", ouName) {
   lazy val dn = new DN(rdn, parentDn)
   def model: LDAPEntry = {
     val mod = LDAPEntry(dn)
-    mod.resetValuesTo(A_OC, OC.objectClassNames(OC_OU).toSeq*)
+    mod.resetValuesTo(A_OC, OC.objectClassNames(OC_OU)*)
     mod
   }
 }
@@ -302,7 +302,7 @@ class ELT[U <: Uuid](eltObjectClass: String, override val rdnAttribute: Tuple1[S
   def dn(uuid: U, y: String) = new DN(rdn(y), parentEntry.dn(uuid))
   def model(uuid: U, y: String): LDAPEntry = {
     val mod = LDAPEntry(new DN(rdn(y), parentEntry.dn(uuid)))
-    mod.resetValuesTo(A_OC, OC.objectClassNames(eltObjectClass).toSeq*)
+    mod.resetValuesTo(A_OC, OC.objectClassNames(eltObjectClass)*)
     mod
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/NodeDit.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/NodeDit.scala
@@ -63,13 +63,13 @@ class NodeDit(val BASE_DN: DN) extends AbstractDit {
 
       def nodeModel(uuid: NodeId): LDAPEntry = {
         val mod = LDAPEntry(this.dn(uuid.value))
-        mod.resetValuesTo(A_OC, OC.objectClassNames(OC_RUDDER_NODE).toSeq*)
+        mod.resetValuesTo(A_OC, OC.objectClassNames(OC_RUDDER_NODE)*)
         mod
       }
 
       def policyServerNodeModel(id: NodeId): LDAPEntry = {
         val mod = LDAPEntry(this.dn(id.value))
-        mod.resetValuesTo(A_OC, OC.objectClassNames(OC_POLICY_SERVER_NODE).toSeq*)
+        mod.resetValuesTo(A_OC, OC.objectClassNames(OC_POLICY_SERVER_NODE)*)
         mod
       }
     }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
@@ -394,18 +394,12 @@ sealed class RoLDAPConnection(
 }
 
 object RwLDAPConnection {
-  import ResultCode.*
 
   /**
    * Default error on which we don't want to throw an exception
    * but only log a message for Add operation
    */
-  def onlyReportOnAdd(errorCode: ResultCode): Boolean = {
-    errorCode match {
-      case ATTRIBUTE_OR_VALUE_EXISTS | ENTRY_ALREADY_EXISTS => true
-      case _                                                => false
-    }
-  }
+  def onlyReportOnAdd(errorCode: ResultCode): Boolean = false
 
   /**
    * Default error on which we don't want to throw an exception
@@ -417,12 +411,7 @@ object RwLDAPConnection {
    * Default error on which we don't want to throw an exception
    * but only log a message for Modify operation
    */
-  def onlyReportOnModify(errorCode: ResultCode): Boolean = {
-    errorCode match {
-      case ATTRIBUTE_OR_VALUE_EXISTS | ENTRY_ALREADY_EXISTS => true
-      case _                                                => false
-    }
-  }
+  def onlyReportOnModify(errorCode: ResultCode): Boolean = false
 
   /**
    * Default error on which we don't want to throw an exception
@@ -559,9 +548,10 @@ class RwLDAPConnection(
       (x: @unchecked) match {
         case ex: LDAPException =>
           if (onlyReportThat(ex.getResultCode)) {
-            logIgnoredException(record.getDN, modName, ex)
+            logIgnoredException(record.getDN, modName, ex) *>
             LDIFNoopChangeRecord(record.getParsedDN).succeed
           } else {
+            LDAPConnectionLogger.debug(s"Error on modify action for request: ${toLDIFChangeRecord(req).toString}") *>
             LDAPRudderError
               .BackendException(
                 s"Error when doing action '${modName}' with and LDIF change request: ${ex.getDiagnosticMessage}",
@@ -575,7 +565,7 @@ class RwLDAPConnection(
     }
   }
 
-  private def logIgnoredException(dn: => String, action: String, e: Throwable): Unit = {
+  private def logIgnoredException(dn: => String, action: String, e: Throwable): UIO[Unit] = {
     val diagnostic = e match {
       case ex: LDAPException => ex.getResultString
       case ex => ex.getMessage

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
@@ -35,7 +35,7 @@ object LDAPRudderError {
   // errors due to some LDAPException
   final case class BackendException(msg: String, cause: Throwable) extends LDAPRudderError {
     override def fullMsg: String = super.fullMsg + s"; cause was: ${RudderError.formatException(cause)} ;" +
-      s"you probably need to increase value ldap.maxPoolSize property in configuration file, please check the documentation - see https://docs.rudder.io/reference/7.0/administration/performance.html#_ldap_configuration"
+      s"if the problem is load related, you may need to increase value ldap.maxPoolSize property in configuration file, please check the documentation - see https://docs.rudder.io/reference/7.0/administration/performance.html#_ldap_configuration"
   }
 
   // errors where there is a result, but result is not SUCCESS

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/schema/LDAPSchema.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/schema/LDAPSchema.scala
@@ -53,7 +53,7 @@ class LDAPSchema {
     ocs.getOrElse(className.toLowerCase, throw new NoSuchElementException(s"Missing LDAP Object in the Schema: $className"))
 
   /**
-   * Optionaly get the ObjectClass whose name is className
+   * Optionally get the ObjectClass whose name is className
    */
   def get(className: String): Option[LDAPObjectClass] = ocs.get(className.toLowerCase)
 
@@ -117,10 +117,16 @@ class LDAPSchema {
    */
   def parents(objectClass: String): List[String] = parentsReg(objectClass.toLowerCase)
 
-  def objectClassNames(objectClass: String): List[String] = apply(objectClass).name :: parents(objectClass)
+  def objectClassNames(objectClass: String): List[String] = {
+    // object classes are case-insensitive, which can cause problems as https://issues.rudder.io/issues/28965
+    // if we don't use .name and distinct
+    (objectClass :: parents(objectClass)).map(apply(_).name).distinct
+  }
 
-  def objectClasses(objectClass: String): LDAPObjectClasses =
-    LDAPObjectClasses(this.objectClassNames(objectClass).map(apply(_))*)
+  def objectClasses(objectClass: String): LDAPObjectClasses = {
+    // we did demux in objectClassNames
+    LDAPObjectClasses(this.objectClassNames(objectClass).map(apply)*)
+  }
 
   /**
    * Given a set of object classes which are ALL registered,

--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/schema/SchemaTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/schema/SchemaTest.scala
@@ -71,4 +71,9 @@ class SchemaTest extends Specification {
   "several branches, several shared levels" >>
   (OC.demux("top", "L1_0", "L1_1", "L1_2", "L1_0_0", "L1_0_1", "L1_0_2", "L1_2_0", "L1_0_0_0") must
   containTheSameElementsAs(Seq(OC("L1_0_0_0"), OC("L1_0_1"), OC("L1_0_2"), OC("L1_1"), OC("L1_2_0"))))
+
+  "case independent name" >>
+  (OC.objectClassNames("l1_0_1") must
+  containTheSameElementsAs(Seq("L1_0_1", "L1_0", "top")))
+
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/28965

So, this was entertening. 

There was several problems: 

- `logIgnoredException` is really a `ZIO` effect, and it was never ran, so we didn't have a chance to see that their was ignored exception in LDAP layer; 
- said ignored exception doesn't seem to make sense anymore. Here, it would report a success (what was happengin) while actually, there was a big problem: the save wasn't done. I think they used to be useful before we had ZIO, but now, they are counter effective. I removed them. It might cause problem - I don't know if they would be bigger than not saving something and saying all is good. 
- we were triggering that ignored exception because we were trying to add both object class `ruddernode` and `rudderNode`. This is because at some point in time, when looking for parents of an object, we didn't stepped to their object classes to get their normalized name. So since key in the "all object classes" map are lower case, we had inconsistencies. 

There was also some useless `.toSeq`.

