### PR TITLE
Fixes #28967: Enable exhaustive pattern matching checks in Scala 3

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -174,6 +174,7 @@ limitations under the License.
             <arg>-Wunused:locals</arg>          <!-- Warn if a local definition is unused. -->
             <arg>-Wunused:implicits</arg>       <!-- Warn if an implicit parameter is unused. -->
             <arg>-Wunused:privates</arg>        <!-- Warn if a private member is unused. -->
+            <arg>-Ycheck-all-patmat</arg>       <!-- Check exhaustivity and redundancy of all pattern matching (meant for debugging) -->
             <arg>-Ysemanticdb</arg>
           </args>
           <jvmArgs>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -154,6 +154,7 @@ object OrderedComparators extends ComparatorList {
 sealed trait CriterionType extends ComparatorList {
 
   // Base validation, subclass only have to define validateSubCase
+  // Since validated value is often already parsed, it could be changed from String to a dedicated type representation of the value
   def validate(value: String, compName: String): PureResult[String] = comparatorForString(compName) match {
     case Some(c) =>
       c match {
@@ -643,9 +644,10 @@ case object MachineComparator extends LDAPCriterionType {
 
   override def buildFilter(attributeName: String, comparator: CriterionComparator, value: String): Filter = {
     val v = value match {
-      // the machine can't belong to another type
+      // the machine is already validated, so it can't belong to another type, fallback will not be used
       case "Virtual"  => OC_VM
       case "Physical" => OC_PM
+      case _          => OC_MACHINE
     }
     comparator match {
       case Equals => IS(v)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -1987,8 +1987,8 @@ object ExecutionBatch extends Loggable {
             }
             MessageStatusReport(noAnswerType, msg)
           }.toList
-        // check if cardinality is ok
-        case x if (x > cardinality)    =>
+        // if (x > cardinality), unexpected cardinality of result
+        case x                         =>
           filteredReports.map(r => MessageStatusReport(ReportType.Unexpected, r.message)).toList
       }
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -714,23 +714,14 @@ class DirectiveEditForm(
   }
 
   private def onSubmitSave()(implicit qc: QueryContext): JsCmd = {
-    val hasVariableErrors = checkVariables()
-
-    if (formTracker.hasErrors) {
-      onFailure(hasVariableErrors)
-    } else {
+    val hasVariableErrors                               = checkVariables()
+    def onPolicyMode(newPolicyMode: Option[PolicyMode]) = {
       val (addRules, removeRules) = directiveApp.checkRulesToUpdate
       val baseRules               = (addRules ++ removeRules).sortBy(_.id.serialize)
 
       val finalAdd     = addRules.map(r => r.copy(directiveIds = r.directiveIds + directive.id))
       val finalRem     = removeRules.map(r => r.copy(directiveIds = r.directiveIds - directive.id))
       val updatedRules = (finalAdd ++ finalRem).sortBy(_.id.serialize)
-
-      val newPolicyMode = policyModes.get match {
-        case "global"  => None
-        case "enforce" => Some(Enforce)
-        case "audit"   => Some(Audit)
-      }
 
       if (isADirectiveCreation) {
 
@@ -784,9 +775,13 @@ class DirectiveEditForm(
           )
         }
       }
-
-      // display confirmation pop-up that also manage workflows
-
+    }
+    (policyModes.get, formTracker.hasErrors) match {
+      case (_, true)          => onFailure(hasVariableErrors)
+      case ("global", false)  => onPolicyMode(None)
+      case ("enforce", false) => onPolicyMode(Some(Enforce))
+      case ("audit", false)   => onPolicyMode(Some(Audit))
+      case (_, false)         => onFailure(hasVariableErrors = true) // should not happen
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -180,6 +180,8 @@ class CreateCategoryOrGroupPopup(
       </span>
       case "dynamic" =>
         <span title="Nodes will be automatically added and removed so that the list of members always matches this group's search criteria.">Dynamic</span>
+      case _         =>
+        NodeSeq.Empty
     },
     Some(5)
   ) {
@@ -201,6 +203,8 @@ class CreateCategoryOrGroupPopup(
           <span id="textGroupRadio">Group</span>
         case "Category" =>
           <span id="textCategoryRadio">Category</span>
+        case _          =>
+          NodeSeq.Empty
       },
       Some(1)
     ) {
@@ -244,71 +248,70 @@ class CreateCategoryOrGroupPopup(
   }
 
   private def onSubmit(): JsCmd = {
-    if (formTracker.hasErrors) {
-      onFailure & onFailureCallback()
-    } else {
-      val createCategory = piItemType.get match {
-        case "Group"    => false
-        case "Category" => true
+    def onCategory: JsCmd = {
+      woNodeGroupRepository
+        .addGroupCategorytoCategory(
+          new NodeGroupCategory(
+            NodeGroupCategoryId(uuidGen.newUuid),
+            piName.get,
+            piDescription.get,
+            Nil,
+            Nil
+          ),
+          NodeGroupCategoryId(piContainer.get),
+          ModificationId(uuidGen.newUuid),
+          CurrentUser.actor,
+          piReasons.map(_.get)
+        )
+        .toBox match {
+        case Full(x)          => closePopup() & onSuccessCallback(x.id.value) & onSuccessCategory(x)
+        case Empty            =>
+          logger.error("An error occurred while saving the category")
+          formTracker.addFormError(error("An error occurred while saving the category"))
+          onFailure & onFailureCallback()
+        case Failure(m, _, _) =>
+          logger.error("An error occurred while saving the category:" + m)
+          formTracker.addFormError(error(m))
+          onFailure & onFailureCallback()
       }
-      if (createCategory) {
-        woNodeGroupRepository
-          .addGroupCategorytoCategory(
-            new NodeGroupCategory(
-              NodeGroupCategoryId(uuidGen.newUuid),
-              piName.get,
-              piDescription.get,
-              Nil,
-              Nil
-            ),
-            NodeGroupCategoryId(piContainer.get),
-            ModificationId(uuidGen.newUuid),
-            CurrentUser.actor,
-            piReasons.map(_.get)
-          )
-          .toBox match {
-          case Full(x)          => closePopup() & onSuccessCallback(x.id.value) & onSuccessCategory(x)
-          case Empty            =>
-            logger.error("An error occurred while saving the category")
-            formTracker.addFormError(error("An error occurred while saving the category"))
-            onFailure & onFailureCallback()
-          case Failure(m, _, _) =>
-            logger.error("An error occurred while saving the category:" + m)
-            formTracker.addFormError(error(m))
-            onFailure & onFailureCallback()
-        }
-      } else {
-        val query     = None
-        val isDynamic = piStatic.get match { case "dynamic" => true; case _ => false }
-        val srvList   = groupGenerator.map(_.serverList).getOrElse(Set[NodeId]())
-        val nodeId    = NodeGroupId(NodeGroupUid(uuidGen.newUuid))
-        val nodeGroup = NodeGroup(nodeId, piName.get, piDescription.get, Nil, query, isDynamic, srvList, _isEnabled = true)
-        woNodeGroupRepository
-          .create(
-            nodeGroup,
-            NodeGroupCategoryId(piContainer.get),
-            ModificationId(uuidGen.newUuid),
-            CurrentUser.actor,
-            piReasons.map(_.get)
-          )
-          .tap(_ => propertiesService.updateAll())
-          .toBox match {
-          case Full(x)          =>
-            closePopup() &
-            onSuccessCallback(x.group.id.serialize) & onSuccessGroup(
-              Right(x.group),
-              NodeGroupCategoryId(piContainer.get)
-            ) & OnLoad(JsRaw("""$("[href='#groupCriteriaTab']").click();""")) // JsRaw ok, const
-          case Empty            =>
-            logger.error("An error occurred while saving the group")
-            formTracker.addFormError(error("An error occurred while saving the group"))
-            onFailure & onFailureCallback()
-          case Failure(m, _, _) =>
-            logger.error("An error occurred while saving the group: " + m)
-            formTracker.addFormError(error(m))
-            onFailure & onFailureCallback()
-        }
+    }
+    def onGroup:    JsCmd = {
+      val query     = None
+      val isDynamic = piStatic.get match { case "dynamic" => true; case _ => false }
+      val srvList   = groupGenerator.map(_.serverList).getOrElse(Set[NodeId]())
+      val nodeId    = NodeGroupId(NodeGroupUid(uuidGen.newUuid))
+      val nodeGroup = NodeGroup(nodeId, piName.get, piDescription.get, Nil, query, isDynamic, srvList, _isEnabled = true)
+      woNodeGroupRepository
+        .create(
+          nodeGroup,
+          NodeGroupCategoryId(piContainer.get),
+          ModificationId(uuidGen.newUuid),
+          CurrentUser.actor,
+          piReasons.map(_.get)
+        )
+        .tap(_ => propertiesService.updateAll())
+        .toBox match {
+        case Full(x)          =>
+          closePopup() &
+          onSuccessCallback(x.group.id.serialize) & onSuccessGroup(
+            Right(x.group),
+            NodeGroupCategoryId(piContainer.get)
+          ) & OnLoad(JsRaw("""$("[href='#groupCriteriaTab']").click();""")) // JsRaw ok, const
+        case Empty            =>
+          logger.error("An error occurred while saving the group")
+          formTracker.addFormError(error("An error occurred while saving the group"))
+          onFailure & onFailureCallback()
+        case Failure(m, _, _) =>
+          logger.error("An error occurred while saving the group: " + m)
+          formTracker.addFormError(error(m))
+          onFailure & onFailureCallback()
       }
+    }
+    (piItemType.get, formTracker.hasErrors) match {
+      case (_, true)           => onFailure & onFailureCallback()
+      case ("Group", false)    => onGroup
+      case ("Category", false) => onCategory
+      case (_, false)          => onFailure & onFailureCallback()
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -264,6 +264,8 @@ class CreateCloneGroupPopup(
           <span title="The list of member nodes is defined at creation and will not change automatically.">Static</span>
         case "dynamic" =>
           <span title="Nodes will be automatically added and removed so that the list of members always matches this group's search criteria.">Dynamic</span>
+        case _         =>
+          NodeSeq.Empty
       },
       Some(4)
     ) {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
@@ -208,6 +208,7 @@ class InputSizeField(
       case "mb" => oneBD * 1024 * 1024
       case "gb" => oneBD * 1024 * 1024 * 1024
       case "tb" => oneBD * 1024 * 1024 * 1024 * 1024
+      case _    => 0
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -365,6 +365,8 @@ class ReportDisplayer(
                       } policy mode. The run was aborted to further changes</b></li>
                     case "unsupported_agent"      =>
                       <li><b>That node runs an agent too old to run policies from this server, please upgrade the agent. The run was aborted to avoid any unexpected behavior</b></li>
+                    case _                        =>
+                      <li><b>The agent aborted run : {msg}</b></li>
                   }
               }
             }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
@@ -60,7 +60,7 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
 
   private var from:   String            = ""
   val deleteAction:   DeleteAction      = DeleteAction(databaseManager, dbCleaner)
-  private var action: CleanReportAction = deleteAction
+  private val action: CleanReportAction = deleteAction
 
   val DATETIME_FORMAT = "yyyy-MM-dd"
   val DATETIME_PARSER: DateTimeFormatter = DateTimeFormat.forPattern(DATETIME_FORMAT)
@@ -72,13 +72,9 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
     ("#modeSelector" #> <ul>{
       SHtml
         .radio(
-          Seq("Archive", "Delete"),
-          Full("Archive"),
-          { (value: String) =>
-            action = value match {
-              case "Delete" => deleteAction
-            }
-          },
+          Seq("Delete"),
+          Full("Delete"),
+          _ => (),
           ("class", "radio")
         )
         .flatMap(e => <li>

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
@@ -67,6 +67,7 @@ class RuleLineTest extends Specification {
 
   def catName(id: RuleCategoryId): String = id.value match {
     case "rootRuleCategory" => "root rule category"
+    case _                  => id.value
   }
 
   "OKLine serialisation" >> {

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
@@ -90,10 +90,12 @@ class ReportLineTest extends Specification {
 
     def dirName(id: DirectiveId): Full[String] = id.serialize match {
       case "policy" => Full("Directive name")
+      case x        => Full(x)
     }
 
     def ruleName(id: RuleId): Full[String] = id.serialize match {
       case "cr" => Full("Rule name")
+      case x    => Full(x)
     }
 
     LogDisplayer.getReportsLineForNode(reports, dirName, ruleName).toJson.toJsCmd.strip() must beEqualTo(

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
@@ -37,6 +37,7 @@
 
 package com.normation.utils
 
+import cats.syntax.traverse.*
 import java.nio.charset.Charset
 import java.nio.charset.CharsetEncoder
 import zio.Chunk
@@ -217,16 +218,16 @@ object ParseVersion {
   }
 
   def epoch[A: P]: P[Long] = P(num ~ ":")
-  def toSeparator(c: Char): Separator = {
-    c match {
-      case '~' => Separator.Tilde
-      case '-' => Separator.Minus
-      case '+' => Separator.Plus
-      case ',' => Separator.Comma
-      case '.' => Separator.Dot
-    }
+  val toSeparator:      PartialFunction[Char, Separator] = {
+    case '~' => Separator.Tilde
+    case '-' => Separator.Minus
+    case '+' => Separator.Plus
+    case ',' => Separator.Comma
+    case '.' => Separator.Dot
   }
-  def separators[A: P]: P[IndexedSeq[Separator]] = P(CharsWhile(separatorChar).!).map((s: String) => s.toSeq.map(toSeparator))
+  def separators[A: P]: P[List[Separator]]               = P(CharsWhile(separatorChar).!).flatMap((s: String) =>
+    s.toList.traverse(toSeparator.lift(_)).fold(Fail(s"Invalid char in ${s}"))(Pass(_))
+  )
 
   def listOfSepToPart(list: List[Separator]): List[VersionPart]    = {
     list.map {
@@ -238,17 +239,17 @@ object ParseVersion {
     case (seq, n) => // seq is at least 1
       seq.last match {
         case Separator.Tilde =>
-          listOfSepToPart(seq.init.toList) ::: VersionPart.Before(Separator.Tilde, PartType.Numeric(n)) :: Nil
-        case sep             => listOfSepToPart(seq.init.toList) ::: VersionPart.After(sep, PartType.Numeric(n)) :: Nil
+          listOfSepToPart(seq.init) ::: VersionPart.Before(Separator.Tilde, PartType.Numeric(n)) :: Nil
+        case sep             => listOfSepToPart(seq.init) ::: VersionPart.After(sep, PartType.Numeric(n)) :: Nil
       }
   }
 
   def charPart[A: P]: P[List[VersionPart]] = P(separators ~ chars).map {
     case (seq, n) => // seq is at least 1
       (seq.last, n) match {
-        case (Separator.Tilde, s)     => listOfSepToPart(seq.init.toList) ::: VersionPart.Before(Separator.Tilde, s) :: Nil
-        case (sep, c: PartType.Chars) => listOfSepToPart(seq.init.toList) ::: VersionPart.After(sep, c) :: Nil
-        case (sep, prerelease)        => listOfSepToPart(seq.init.toList) ::: VersionPart.Before(sep, prerelease) :: Nil
+        case (Separator.Tilde, s)     => listOfSepToPart(seq.init) ::: VersionPart.Before(Separator.Tilde, s) :: Nil
+        case (sep, c: PartType.Chars) => listOfSepToPart(seq.init) ::: VersionPart.After(sep, c) :: Nil
+        case (sep, prerelease)        => listOfSepToPart(seq.init) ::: VersionPart.Before(sep, prerelease) :: Nil
       }
   }
 

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/VersionTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/VersionTest.scala
@@ -157,13 +157,19 @@ class VersionTest extends Specification {
 
     val msg1 =
       "Error when parsing 'a:18' as a version. Only ascii (non-control, non-space) chars are allowed in a version string."
-    "return left".format(msg1) in {
+    "return left for a:18" in {
       ParseVersion.parse("a:18") must beLeft[String].like { case e => e must contain(msg1) }
     }
 
     val msg2 = "Error when parsing 'a15' as a version. Only ascii (non-control, non-space) chars are allowed in a version string."
-    "return left".format(msg2) in {
+    "return left for a15" in {
       ParseVersion.parse("a15") must beLeft[String].like { case e => e must contain(msg2) }
+    }
+
+    val msg3 =
+      "Error when parsing '1:~:a' as a version. Only ascii (non-control, non-space) chars are allowed in a version string."
+    "return left for 1:~:a" in {
+      ParseVersion.parse("1:~:a") must beLeft[String].like { case e => e must contain(msg3) }
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/28967

Add the `-Ycheck-all-patmat` compiler flag (which is a private one, so I have no measure of the compilation performance impact, but it helped raise actual issues).

Most affected code blocks are old ones, and occur on some `String`:
* in a "select"/"radio" fields
* in a parser, but with values already checked in pre-conditions 

All bits of omitted cases were "invalid cases", that were mostly already validated (hence we had very few, if any, `MatchError` in production), **except** for the `"Archive"` choice, which was removed in [this PR](https://github.com/Normation/rudder/pull/5705) but it was no longer a valid choice.


---
N.B.:
* I couldn't see any noticeable performance penalty during compilation (the compilation time is around the same as before on my machine)
* I checked plugins, there were no such occurrence, they all compile fine