### PR TITLE
Fixes #28948: Group page is empty with group_read permission with nodes in tenants

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -67,7 +67,6 @@ import com.normation.rudder.domain.RudderLDAPConstants.A_RULE_TARGET
 import com.normation.rudder.domain.RudderLDAPConstants.OC_GROUP_CATEGORY
 import com.normation.rudder.domain.RudderLDAPConstants.OC_RUDDER_NODE_GROUP
 import com.normation.rudder.domain.RudderLDAPConstants.OC_SPECIAL_TARGET
-import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.facts.nodes.NodeFactRepository
@@ -81,7 +80,6 @@ import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.services.user.PersonIdentService
 import com.normation.rudder.tenants.ChangeContext
-import com.normation.rudder.tenants.HasSecurityTag
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.TenantCheckLogic
 import com.normation.rudder.tenants.TenantService
@@ -98,8 +96,6 @@ class RoLDAPNodeGroupRepository(
     val ldap:          LDAPConnectionProvider[RoLDAPConnection],
     val mapper:        LDAPEntityMapper,
     val nodeFactRepo:  NodeFactRepository,
-    val tenantService: TenantCheckLogic,
-    val tenantRepo:    TenantService,
     val groupLibMutex: ScalaReadWriteLock // that's a scala-level mutex to have some kind of consistency with LDAP
 ) extends RoNodeGroupRepository with NamedZioLogger {
   repo =>
@@ -604,7 +600,7 @@ class RoLDAPNodeGroupRepository(
 
   // map an LDAPTree to the corresponding `allMaps` datastructure used in
   // `getFullGroupLibrary`
-  private[ldap] def mapLdapTreeToFullCategory(entries: LDAPTree)(implicit qc: QueryContext): IOResult[AllMaps] = {
+  private[ldap] def mapLdapTreeToFullCategory(entries: LDAPTree): IOResult[AllMaps] = {
     val emptyAll = AllMaps(Map(), Map(), Map())
     import rudderDit.GROUP.*
 
@@ -616,54 +612,39 @@ class RoLDAPNodeGroupRepository(
       logPure.warn(error.fullMsg).as(current)
     }
 
-    // tenant filtering is silent by default but can be traced with the appropriate DEBUG log
-    def debugTenantFiltering[A: HasSecurityTag](a: A)(implicit qc: QueryContext): UIO[Unit] = {
-      ApplicationLoggerPure.Tenant.debug(s"In NodeGroup tree: filtering '${a.debugId}' for '${qc.actor.name}'")
-    }
-
     ZIO.foldLeft(entries.toSeq)(emptyAll) {
       case (current, e) =>
         if (isACategory(e)) {
           mapper.entry2NodeGroupCategory(e) match {
-            case Right(item) =>
-              // check visibility for current QC
-              tenantService.filter(item) match {
-                case None           => debugTenantFiltering(item).as(current)
-                case Some(category) =>
-                  // for categories other than root, add it in the list
-                  // of its parent subcategories
-                  val updatedSubCats = if (e.dn == rudderDit.GROUP.dn) {
-                    current.categoriesByCategory
-                  } else {
-                    val catId   = mapper.dn2NodeGroupCategoryId(e.dn.getParent)
-                    val subCats = category.id :: current.categoriesByCategory.getOrElse(catId, Nil)
-                    current.categoriesByCategory + (catId -> subCats)
-                  }
-                  current
-                    .copy(
-                      categories = current.categories + (category.id -> category),
-                      categoriesByCategory = updatedSubCats
-                    )
-                    .succeed
+            case Right(category) =>
+              // for categories other than root, add it in the list
+              // of its parent subcategories
+              val updatedSubCats = if (e.dn == rudderDit.GROUP.dn) {
+                current.categoriesByCategory
+              } else {
+                val catId   = mapper.dn2NodeGroupCategoryId(e.dn.getParent)
+                val subCats = category.id :: current.categoriesByCategory.getOrElse(catId, Nil)
+                current.categoriesByCategory + (catId -> subCats)
               }
-            case Left(err)   => mappingError(current, e, err)
+              current
+                .copy(
+                  categories = current.categories + (category.id -> category),
+                  categoriesByCategory = updatedSubCats
+                )
+                .succeed
+            case Left(err)       => mappingError(current, e, err)
           }
         } else if (isAGroup(e) || isASpecialTarget(e)) {
           mapper.entry2RuleTargetInfo(e) match {
-            case Right(item) =>
-              // check visibility for current QC
-              tenantService.filter(item) match {
-                case None           => debugTenantFiltering(item).as(current)
-                case Some(fullInfo) =>
-                  val catId         = mapper.dn2NodeGroupCategoryId(e.dn.getParent)
-                  val infosForCatId = fullInfo :: current.targetByCategory.getOrElse(catId, Nil)
-                  current
-                    .copy(
-                      targetByCategory = current.targetByCategory + (catId -> infosForCatId)
-                    )
-                    .succeed
-              }
-            case Left(err)   => mappingError(current, e, err)
+            case Right(fullInfo) =>
+              val catId         = mapper.dn2NodeGroupCategoryId(e.dn.getParent)
+              val infosForCatId = fullInfo :: current.targetByCategory.getOrElse(catId, Nil)
+              current
+                .copy(
+                  targetByCategory = current.targetByCategory + (catId -> infosForCatId)
+                )
+                .succeed
+            case Left(err)       => mappingError(current, e, err)
           }
         } else {
           // log error, continue

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
@@ -101,18 +101,6 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
         targetWithNoTenants.toList ++ targetWithTenantsA
       )
     }
-
-    "have an user with only tenant ZoneA see only one group and no system groups" in {
-      implicit val qc = zoneA
-      roGroupRepo.getFullGroupLibrary().runNow.allTargets.values.map(_.debugId) must containTheSameElementsAs(
-        targetWithTenantsA.toSeq
-      )
-    }
-
-    "have an user with only tenant ZoneB see nothing" in {
-      implicit val qc = zoneB
-      roGroupRepo.getFullGroupLibrary().runNow.allTargets.values.map(_.debugId) must containTheSameElementsAs(Nil)
-    }
   }
 
   def newGroup(id: String, tenant: Option[SecurityTag]): NodeGroup =

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/SetupLdapRepositories.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/SetupLdapRepositories.scala
@@ -206,8 +206,6 @@ trait SetupLdapRepositories {
       roLdap,
       ldapMapper,
       nodeFactRepo,
-      tenantService,
-      tenantRepo,
       new ZioTReentrantLock("group-lock")
     )
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2991,8 +2991,6 @@ object RudderConfigInit {
       roLdap,
       ldapEntityMapper,
       nodeFactRepository,
-      tenantCheckLogic,
-      tenantService,
       groupLibReadWriteMutex
     )
     lazy val roNodeGroupRepository: RoNodeGroupRepository = roLdapNodeGroupRepository


### PR DESCRIPTION
https://issues.rudder.io/issues/28948

This look like the minimal change that can be done to restore non-tenant groups:
- remove tenant filtering in group repo, 
- remove associated tests

I tested that with that change, a user with a tenant get back access to all groups. 