### PR TITLE
Fixes #28978: The jinja2 python script is never updated

### DIFF
--- a/policies/module-types/template/src/cli.rs
+++ b/policies/module-types/template/src/cli.rs
@@ -9,7 +9,6 @@ use serde_json::Value;
 use std::fs;
 use std::fs::read_to_string;
 use std::path::PathBuf;
-use tempfile::tempdir;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -49,9 +48,7 @@ impl Cli {
         }
 
         let value: Value = serde_json::from_str(&data)?;
-        let tmp = tempdir()?;
-        let temporary_dir = tmp.path();
-        let renderer = cli.engine.renderer(temporary_dir, None)?;
+        let renderer = cli.engine.renderer(None)?;
         let output = renderer.render(Some(cli.template.as_path()), None, &value)?;
 
         let already_present = cli.out.exists();

--- a/policies/module-types/template/src/engine.rs
+++ b/policies/module-types/template/src/engine.rs
@@ -34,16 +34,12 @@ impl std::fmt::Display for Engine {
 }
 
 impl Engine {
-    pub fn renderer(
-        &self,
-        temporary_dir: &Path,
-        python_version: Option<String>,
-    ) -> Result<Box<dyn TemplateEngine>> {
+    pub fn renderer(&self, python_version: Option<String>) -> Result<Box<dyn TemplateEngine>> {
         Ok(match self {
             Engine::Mustache => Box::new(mustache::MustacheEngine),
             Engine::Minijinja => Box::new(minijinja::MiniJinjaEngine),
             Engine::Jinja2 => Box::new(
-                jinja2::Jinja2Engine::new(temporary_dir.to_path_buf(), python_version)
+                jinja2::Jinja2Engine::new(python_version)
                     .context("Failed to create Jinja2 engine")?,
             ),
         })

--- a/policies/module-types/template/src/engine/jinja2.rs
+++ b/policies/module-types/template/src/engine/jinja2.rs
@@ -9,26 +9,19 @@ use crate::engine::TemplateEngine;
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::Path};
 
 pub(crate) struct Jinja2Engine {
     python_interpreter: String,
-    temporary_dir: PathBuf,
 }
 
 impl Jinja2Engine {
-    pub fn new(temporary_dir: PathBuf, python_version: Option<String>) -> Result<Self> {
+    pub fn new(python_version: Option<String>) -> Result<Self> {
         let python_interpreter = match python_version {
             Some(v) => v,
             None => detect_python_version().context("Could not get python version")?,
         };
-        Ok(Jinja2Engine {
-            python_interpreter,
-            temporary_dir,
-        })
+        Ok(Jinja2Engine { python_interpreter })
     }
 }
 
@@ -53,37 +46,33 @@ impl TemplateEngine for Jinja2Engine {
             _ => unreachable!(),
         };
 
+        let tmp_script = NamedTempFile::new().expect("Failed to create temp script");
+        let template_script_path = tmp_script.into_temp_path();
         let templating_script_content = include_str!("jinja2/render.py");
-        let script_name = "render-jinja2.py";
 
-        let mut path = PathBuf::from(&self.temporary_dir);
-        path.push(script_name);
-        let templating_script_path = path.to_str().unwrap();
-
-        if !fs::exists(templating_script_path)? {
-            fs::write(templating_script_path, templating_script_content)?;
-            #[cfg(target_family = "unix")]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let perms = fs::Permissions::from_mode(0o755);
-                fs::set_permissions(templating_script_path, perms)?;
-            }
-            #[cfg(target_family = "windows")]
-            {
-                let mut perms = fs::metadata(templating_script_path)?.permissions();
-                perms.set_readonly(false);
-                fs::set_permissions(templating_script_path, perms)?;
-            }
+        fs::write(&template_script_path, templating_script_content)?;
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(0o755);
+            fs::set_permissions(&template_script_path, perms)?;
+        }
+        #[cfg(target_family = "windows")]
+        {
+            let mut perms = fs::metadata(&template_script_path)?.permissions();
+            perms.set_readonly(false);
+            fs::set_permissions(&template_script_path, perms)?;
         }
 
         let output = if cfg!(target_os = "linux") {
             let mut child = Command::new(&self.python_interpreter)
-                .args([templating_script_path, template_path])
+                .arg(&template_script_path)
+                .arg(template_path)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .spawn()
-                .unwrap_or_else(|_| panic!("Failed to execute {}", templating_script_path));
+                .unwrap_or_else(|_| panic!("Failed to execute {}", template_script_path.display()));
 
             let stdin = child.stdin.as_mut().unwrap();
             stdin
@@ -93,7 +82,11 @@ impl TemplateEngine for Jinja2Engine {
             let output_info = child.wait_with_output()?;
             if !output_info.status.success() {
                 let output = String::from_utf8_lossy(&output_info.stderr).to_string();
-                bail!("Error {} failed with : {}", script_name, output);
+                bail!(
+                    "Error {} failed with : {}",
+                    template_script_path.display(),
+                    output
+                );
             }
             String::from_utf8_lossy(&output_info.stdout).to_string()
         } else {

--- a/policies/module-types/template/src/lib.rs
+++ b/policies/module-types/template/src/lib.rs
@@ -160,7 +160,6 @@ impl Template {
     fn check_apply_inner(
         mode: PolicyMode,
         p: &TemplateParameters,
-        temporary_dir: &Path,
         backup_dir: &Path,
     ) -> Result<TemplateReport> {
         let output_file = &p.path;
@@ -180,7 +179,7 @@ impl Template {
             bail!("Could not get datastate file")
         };
 
-        let renderer = p.engine.renderer(temporary_dir, None)?;
+        let renderer = p.engine.renderer(None)?;
         let output = renderer.render(
             p.template_path.as_deref(),
             p.template_string.as_deref(),
@@ -296,8 +295,7 @@ impl ModuleType0 for Template {
         assert!(self.validate(parameters).is_ok());
         let p: TemplateParameters = serde_json::from_value(Value::Object(parameters.data.clone()))?;
 
-        let res =
-            Self::check_apply_inner(mode, &p, &parameters.temporary_dir, &parameters.backup_dir);
+        let res = Self::check_apply_inner(mode, &p, &parameters.backup_dir);
         if let Some(r) = p.report_file {
             fs::write(
                 r,


### PR DESCRIPTION
https://issues.rudder.io/issues/28978

We only check for file existence so any content would be considered valid. Plus we use a predictable path, might as well use a real non-persisted tempfile that would prevent all concurrence/toctou issues.