### PR TITLE
Fixes #28987: Add '--' before passing arguments to package managers

### DIFF
--- a/policies/module-types/system-updates/src/package_manager/yum.rs
+++ b/policies/module-types/system-updates/src/package_manager/yum.rs
@@ -75,6 +75,7 @@ impl YumPackageManager {
         let mut c = Command::new("yum");
         c.arg("--assumeyes")
             .arg("update")
+            .arg("--")
             .args(packages.iter().map(Self::package_spec_as_argument));
         ResultOutput::command(
             c,

--- a/policies/module-types/system-updates/src/package_manager/zypper.rs
+++ b/policies/module-types/system-updates/src/package_manager/zypper.rs
@@ -72,7 +72,7 @@ impl ZypperPackageManager {
 
     fn software_upgrade(&mut self, packages: &[PackageSpec]) -> ResultOutput<()> {
         let mut c = Command::new("zypper");
-        c.arg("--non-interactive").arg("update");
+        c.arg("--non-interactive").arg("update").arg("--");
         c.args(packages.iter().map(Self::package_spec_as_argument));
         let res_update = ResultOutput::command(
             c,


### PR DESCRIPTION
https://issues.rudder.io/issues/28987

Prevents options injections.