### PR TITLE
Fixes #29007: When a generation is processing, we don't know the last generation status

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -208,7 +208,11 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
             "bg-ok"
         }
       case _            =>
-        "bg-refresh"
+        deploymentStatus.current match {
+          case _: SuccessStatus => "bg-refresh bg-refresh-ok"
+          case _: ErrorStatus   => "bg-refresh bg-refresh-error"
+          case NoStatus => "bg-refresh"
+        }
     }
   }
 
@@ -264,6 +268,18 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
       <li class="list-group-item">Policies building...</li>
       <li class="list-group-item" >{displayDate("Started at ", start)}</li>
     }
+    def lastResultStatement:                NodeSeq = {
+      deploymentStatus.current match {
+        case NoStatus                            => NodeSeq.Empty
+        case SuccessStatus(_, start, end, _)     =>
+          <li class="list-group-item dropdown-header">Last generation:</li> ++
+          commonStatement(start, end, Some("Update took"), "Policies updated", "text-success fa fa-check", "text-success")
+        case ErrorStatus(_, start, end, failure) =>
+          <li class="list-group-item dropdown-header">Last generation:</li> ++
+          commonStatement(start, end, None, "Error during policy update", "text-danger fa fa-times", "text-danger") ++
+          showDetailsPopup(detailsPopup(failure))
+      }
+    }
     val (titleIconClass: String, items: NodeSeq) = deploymentStatus.processing match {
       case IdleDeployer                                        =>
         deploymentStatus.current match {
@@ -287,11 +303,13 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
               "text-danger"
             ) ++ showDetailsPopup(detailsPopup(failure)))
         }
-      case Processing(id, start)                               => "fa-arrows-rotate" -> loadingStatement(start)
-      case ProcessingAndPendingAuto(asked, current, a, e)      => "fa-arrows-rotate" -> loadingStatement(current.started)
-      case ProcessingAndPendingManual(asked, current, a, e, r) => "fa-arrows-rotate" -> loadingStatement(current.started)
+      case Processing(id, start)                               => "fa-arrows-rotate" -> (loadingStatement(start) ++ lastResultStatement)
+      case ProcessingAndPendingAuto(asked, current, a, e)      =>
+        "fa-arrows-rotate" -> (loadingStatement(current.started) ++ lastResultStatement)
+      case ProcessingAndPendingManual(asked, current, a, e, r) =>
+        "fa-arrows-rotate" -> (loadingStatement(current.started) ++ lastResultStatement)
     }
-    val titleIconColorClass                      = deploymentStatus.processing match {
+    val titleIconColorClass = deploymentStatus.processing match {
       case IdleDeployer =>
         deploymentStatus.current match {
           case _: ErrorStatus   => "text-danger"

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
@@ -1182,6 +1182,23 @@ header.main-header .logo-lg img{
   content: "\f021";
   animation: fa-spin 2s infinite linear;
 }
+// additional "previous generation status" icon
+.navbar .navbar-nav li.notifications-menu #generation-status > span:before{
+  display: inline-block;
+  font-family: "Font Awesome 5 Free";
+  font-size: inherit;
+  text-rendering: auto;
+  font-weight: 900;
+  margin-right: 2px;
+}
+.navbar .navbar-nav li.notifications-menu.bg-refresh.bg-refresh-ok #generation-status > span:before{
+  content: "\f00c";
+  color: $rudder-success;
+}
+.navbar .navbar-nav li.notifications-menu.bg-refresh.bg-refresh-error #generation-status > span:before{
+  content: "\f00d";
+  color: #da291c;
+}
 /* ---- */
 #generation-status.label-success{
   background-color: $rudder-success !important;


### PR DESCRIPTION
https://issues.rudder.io/issues/29007

So all the business/backend was here to keep the last status, but it wasn't displayed, which was a pitty. 

I added in the header bar the last status, so that we know even without opening the details if we are generating based on a valid or error state. 

<img width="180" height="70" alt="Screenshot_20260608_130238" src="https://github.com/user-attachments/assets/643c6d78-4d0a-4575-a2f6-ace63733783d" />

<img width="446" height="498" alt="Screenshot_20260608_130154" src="https://github.com/user-attachments/assets/16614c56-0057-42bd-a837-eb2e70b2df90" />


With short generation, it is not very nice to use, since the details menu is regenerated when status change, but the feature is not very usefull for short generation, so it doesn't seem important - it just makes screenshot harder to do :)