### PR TITLE
Fixes #28945: Add tenant management to configuration objects

### DIFF
--- a/adr/webapp/multi-tenants/28945-object-tenant-tag-lifecycle.md
+++ b/adr/webapp/multi-tenants/28945-object-tenant-tag-lifecycle.md
@@ -1,0 +1,40 @@
+# Object tenant tag lifecycle: creation, change, and monotonic growth
+
+* Status: accepted (monotonic-growth part: implementation pending)
+* Deciders: FAR
+* Date: 2026-07-03
+
+## Context
+
+We must define how a configuration object gets its tenant tag, who may change it, and how historical data
+(the event log) stays sound when a tag changes over time. Migration requires that pre-existing (untagged)
+objects can be assigned tenants, so tags cannot be made fully immutable from the start.
+
+## Decision
+
+**Creation.** When an object is created without an explicit tag, it inherits the creator's *writable*
+tenants (`restrictToWrite.toSecurityTag`), never the read-only ones - a read-only tenant must not leak into a
+created object. When the tenant feature is disabled, created objects are `None`. An explicitly provided tag
+is still validated: the creator must be able to write it.
+
+**Change.** Only an administrator (all-tenants grant) may change an object's tenant list. A non-admin's
+attempt to change the list is ignored and the existing tag kept. This also makes a read-modify-write
+round-trip safe: a tenant only ever reads the tenants it owns, so re-saving the object cannot accidentally
+drop the tenants it could not see.
+
+**Monotonic growth (accepted; implementation pending).** An object may only *gain* visibility, never lose it
+(`None ⊂ ByTenants(S ⊆ S') ⊂ Open`). To narrow an object's tenants, one duplicates it into a fresh object and
+chooses the narrower list at creation time. This law makes event-log filtering sound: record the object's
+*pre-change* tag alongside each event and filter event reads by `grant.canSee(T_event)`. Because tags only
+grow, `T_event ⊆ T_now`, so anyone who can see an event can currently see the object (no leak), while a
+tenant added *after* a change never sees that change's pre-membership values (no historical-value leak).
+Deleting a whole tenant is safe (it is also removed from every grant), and reusing a tenant id is an intended
+recovery path for an accidentally deleted tenant (to be documented).
+
+## Consequences
+
+* Predictable, leak-free creation and admin-only re-scoping.
+* The monotonic-growth law reverses the earlier "an admin can drop a tenant from an object" behavior and its
+  test; those must be rewritten when the law is implemented.
+* Event-log soundness additionally requires persisting the per-event tenant tag (an event-log schema change +
+  migration of existing rows to admin-only). This is deferred to its own change.

--- a/adr/webapp/multi-tenants/28945-security-context-propagation.md
+++ b/adr/webapp/multi-tenants/28945-security-context-propagation.md
@@ -1,0 +1,46 @@
+# Propagating the security context with QueryContext / ChangeContext
+
+* Status: accepted
+* Deciders: FAR
+* Date: 2026-07-03
+
+## Context
+
+Every repository read and write must know the acting actor's tenant grant in order to filter results and
+authorize changes. Two properties are required:
+
+* the grant must be established only at trusted edges (REST request handler, Lift snippet, or a managed
+  system service) and never re-derived deep in the call stack, where it would be easy to get wrong or spoof;
+* there must be a guarantee that no code path forgets to pass it - a silent hole would be a security bug.
+
+## Decision
+
+Introduce two context objects carrying the actor and their `TenantAccessGrant`:
+
+* `QueryContext` (abbreviated `qc`) for read operations;
+* `ChangeContext` (abbreviated `cc`) for write operations (also carries modification id / date / message).
+
+They are passed as Scala 3 `using`/`given` implicit parameters on the repository APIs. Because the whole
+chain takes an implicit context, the compiler enforces it is threaded end-to-end: a missing context is a
+**compile error, not a runtime hole**.
+
+The context is filled only at edges:
+
+* REST handlers build it from the authenticated user (`AuthzToken` → `qc`/`cc`);
+* Lift snippets obtain it through the safe-snippet pattern (see ADR
+  `28452-avoid-currentuser-for-querycontext-in-lift-snippets`);
+* system operations use explicit, named, all-tenants contexts (`QueryContext.systemQC`,
+  `ChangeContext.newForRudder`).
+
+At authentication the grant is refined against the set of currently existing tenants
+(`refineTenantAccessGrant`), so a grant referencing a deleted tenant collapses (`ByTenants` shrinks, and to
+`None` if nothing remains).
+
+## Consequences
+
+* Adding a repository method forces the caller to provide a context; the "no hole" property is checked by
+  the compiler rather than by review.
+* The escape hatches for system/unknown contexts (`systemQC`, `todoQC`, `noneQC`, `newForRudder`) are few,
+  named, and greppable, so they can be audited.
+* Known follow-up: only the REST authentication path refines the grant today; the interactive UI login path
+  does not yet call `refineTenantAccessGrant`, so a UI session can outlive a tenant's deletion.

--- a/adr/webapp/multi-tenants/28945-system-objects-are-admin-only.md
+++ b/adr/webapp/multi-tenants/28945-system-objects-are-admin-only.md
@@ -1,0 +1,44 @@
+# System configuration objects are admin-only, uniformly
+
+* Status: accepted
+* Deciders: FAR
+* Date: 2026-07-03
+
+## Context
+
+With tenants, an `Open` object is (by decision) visible - and writable/deletable - by anyone: the protection
+of shared/library objects is the pre-existing `system` flag, not the security tag. But a system object now
+carries a cross-tenant *scope*: it is shared/global, so a change to one - even one that looks tenant-local -
+can have effects on several tenants' nodes. Deciding what a system object is and how it behaves is therefore
+not something a tenant-scoped actor should be able to do.
+
+Note also that `None`-tagged objects (the default) are already admin-only through the normal
+visibility/`canModify` rules; the gap is a system object tagged `Open` or `ByTenants`, which `canSee`/
+`canModify` would otherwise let a tenant actor change.
+
+## Decision
+
+Managing (create / modify / move / delete) a **system** object is allowed only to an actor with an
+all-tenants (admin) grant. This is enforced uniformly, on every write of every tenant-scoped repository,
+inside `TenantCheckLogic`:
+
+* folded into `checkModify`, `checkDelete` and `manageCreate`/`manageUpdate` (which read `obj.isSystem`);
+* `checkAdmin` covers system operations that have no `HasSecurityTag` object (e.g. policy server targets).
+
+`HasSecurityTag.isSystem` has **no default**: each instance states its own system notion explicitly (a rule/
+directive/group/category exposes its `isSystem`; an active technique is system when it carries the system
+policy type; properties, parameters and nodes are never system).
+
+Container checks (`checkWriteInto`) are intentionally **not** system-gated: creating a tenant object under a
+system root category is normal and must stay allowed.
+
+## Consequences
+
+* No-op for legitimate flows: system objects are `None`-tagged by default (already admin-restricted) and all
+  internal system maintenance runs with an all-tenants context, so the guard never blocks it. Its value is
+  closing the `Open`/`ByTenants` system-object case.
+* `system` becomes a load-bearing, cross-tenant protection: an object's "system" meaning and behavior are an
+  administrator responsibility.
+* The distinction between "modify this object" (`checkModify`, system-gated) and "create under this
+  container" (`checkWriteInto`, not system-gated) is essential - conflating them would forbid tenants from
+  creating anything under the system root categories.

--- a/adr/webapp/multi-tenants/28945-tenant-enforcement-at-policy-generation.md
+++ b/adr/webapp/multi-tenants/28945-tenant-enforcement-at-policy-generation.md
@@ -1,0 +1,42 @@
+# Enforcing the tenant boundary at policy generation
+
+* Status: accepted
+* Deciders: FAR
+* Date: 2026-07-03
+
+## Context
+
+A tenant tag on a configuration object is a *visibility* filter. The dangerous part is *effect*: a rule
+owned by a tenant must not generate policy on another tenant's nodes, nor apply another tenant's directives.
+Rule targets (`AllTarget`, groups) and dynamic-group membership can otherwise cross tenant lines even when
+the rule itself is only visible to its tenant. Policy generation runs as a system operation (it fetches all
+objects), so the read-time tenant filtering does not apply there.
+
+## Decision
+
+Convert a rule's `SecurityTag` into a read-grant *scope* (`None`/`Open` → `All`; `ByTenants(ts)` → a read
+grant on `ts`) and enforce, when a rule is resolved to nodes during generation:
+
+* **node level (load-bearing):** keep only the targeted nodes whose `security` the rule's scope can see. This
+  is a monotonic clamp on the fully-resolved node set, so it contains any composite target
+  (union/intersection/exclusion) and any node wrongly present in a group's `serverList`.
+* **target level:** drop simple targets the rule cannot see - foreign groups, and admin-only special targets
+  (`AllTarget` etc., which have no tenant), so they are not usable by a tenant-scoped rule.
+* **directive level:** drop directives the rule does not share a tenant with.
+
+Dynamic-group membership is computed under the **group's own** tenant scope, so a group only ever contains
+nodes its tenants can see, regardless of who triggers the update.
+
+Untagged/admin objects map to the `All` scope, so admin rules and non-tenant deployments are unaffected.
+
+## Consequences
+
+* The node-level filter is the actual guarantee; the target- and directive-level filters add consistency and
+  keep admin-only special targets out of tenant rules.
+* Because a tenant rule drops admin-only special targets, a tenant rule whose only target is `AllTarget`
+  targets nothing - a tenant must use a group to select "all my nodes".
+* The `NodeFact`-derived data needed at generation (is-policy-server + tenant tag) travels as a single
+  `NodeSecurityInfo` per node rather than as two parallel maps.
+* Known follow-up: rule "applied" status (`RuleApplicationStatusService` / `getAppliedRuleIds`) still resolves
+  nodes without the node-level tenant filter, so it can report a rule as applied on nodes generation would
+  exclude. It must be made consistent with generation.

--- a/adr/webapp/multi-tenants/28945-tenant-filtering-repository-proxies.md
+++ b/adr/webapp/multi-tenants/28945-tenant-filtering-repository-proxies.md
@@ -1,0 +1,47 @@
+# Tenant filtering as repository proxies, authorization centralized in TenantCheckLogic
+
+* Status: accepted
+* Deciders: FAR
+* Date: 2026-07-03
+
+## Context
+
+Tenant filtering must be added to persistence without entangling it with the existing `LDAPRepositories`,
+which are large and must stay reviewable. We also want a single, small, unit-testable home for every
+tenant/authorization decision, so that a new repository method cannot accidentally bypass a check.
+
+## Decision
+
+**Separate persistence from tenant logic with proxies.** The `LDAPRepositories` stay tenant-agnostic (pure
+persistence). Each is wrapped by a proxy (`RoTenant*` / `WoTenant*`) that:
+
+* on reads, post-filters results with the tenant scoping;
+* on writes, authorizes the operation, then delegates the actual fetch/store to the underlying repo.
+
+Only the proxies are wired into the application. The raw repositories are used solely for internal plumbing
+(archive import/export).
+
+**Abstract taggable objects with a typeclass.** `HasSecurityTag[A]` exposes `security`, `isSystem`,
+`debugId`, `updateSecurityContext`. Every taggable type provides an instance.
+
+**Centralize all authorization in `TenantCheckLogic`** (`checkTenant`). Proxies never read `accessGrant.*`
+directly; they only call the service, which is the single authorization entry point:
+
+* read filtering: `check` / `filter` / `collect` / `filterStream` / `getMapView`;
+* `checkModify(obj)` - may change/move this object: tenant write-visibility **and** system-admin-only;
+* `checkWriteInto(container)` - may create/move children under this container: tenant write-visibility only,
+  deliberately **not** system-gated (tenant objects live under the shared/system root categories);
+* `checkDelete(obj)` - delete authorization (a delete is a write, so same rules as `checkModify`);
+* `checkAdmin` - admin-only operations that have no object to check (e.g. policy server targets);
+* `manageCreate` / `manageUpdate` - the create/update tag logic, which also enforce the system-object rule.
+
+The lattice primitives (`canSee`, `canModify`, `restrictToWrite`, `plus`) remain on `TenantAccessGrant` and
+are used only *inside* the service.
+
+## Consequences
+
+* The authorization surface is small and testable in isolation; the persistence layer is reviewed unchanged.
+* A new write method cannot forget a tenant/system check - it must go through `checkTenant`.
+* The YAML-based REST test framework was extended to drive API logic under several user profiles
+  (admin / single-tenant / multi-tenant / read-only tenant / no-tenant), which pins these laws end to end.
+* Slight indirection cost (a proxy per repository) in exchange for a clean, auditable separation.

--- a/adr/webapp/multi-tenants/28945-tenant-model-and-security-tags.md
+++ b/adr/webapp/multi-tenants/28945-tenant-model-and-security-tags.md
@@ -1,0 +1,55 @@
+# Tenant model and security tags
+
+* Status: accepted
+* Deciders: FAR
+* Date: 2026-07-03
+
+## Context
+
+Rudder needs to give an actor (user or API account) a *restricted view* of configuration objects
+(active techniques, directives, rules, node groups, global parameters, and their categories) and nodes.
+This segmentation - "tenants" - must be:
+
+* orthogonal to the existing rights/roles system: it is a pre-filter that produces a smaller world, on top
+  of which the usual authorization then applies;
+* backward compatible and migratable: existing deployments have no tenants, and people want to keep their
+  existing rules/groups/etc and merely sort them into tenants afterwards.
+
+We need a single model shared by all taggable objects (nodes already had a simplified tenant notion).
+
+## Decision
+
+A *tenant* is an arbitrary segmentation identifier (ascii-alnum + `-`/`_`). Two orthogonal notions:
+
+**Object side - `SecurityTag`** (optional on each taggable object):
+
+* `None` (no tag): visible only to an actor with an all-tenants grant (admin). This is the default and the
+  migration state of every pre-existing object.
+* `ByTenants(tenants)`: visible to an actor sharing at least one of the listed tenants. An empty list means
+  admin-only.
+* `Open`: visible to everyone whatever their grant - used for library/shared roots that all tenants must see.
+
+**Actor side - `TenantAccessGrant`**:
+
+* `All`: sees everything (admin); this is what a user with no tenant restriction gets, so non-tenant
+  deployments behave exactly as before.
+* `None`: sees nothing.
+* `ByTenants(accesses)`: a list of `tenantId:permission` where permission is `r` (read) or `rw` (read+write);
+  a bare `tenantId` means `rw` for backward compatibility.
+
+**Laws**:
+
+* Read: an actor sees an object iff its grant is `All`, or the object is `Open`, or they share a tenant
+  (whose access allows read) with a `ByTenants` object.
+* Write: same, but only `rw` tenants are considered (`restrictToWrite` drops the `r`-only accesses, so the
+  actor behaves as if it did not have the grant for a read-only tenant).
+* Visibility is monotone: `None` (admin only) ⊂ `ByTenants(S)` ⊆ `ByTenants(S')` for `S ⊆ S'` ⊂ `Open`.
+
+## Consequences
+
+* Non-tenant deployments are unchanged: pre-existing objects are `None` (admin-only) and users default to
+  the `All` grant, so everyone sees everything.
+* Nodes are unified under the same `SecurityTag`/grant model as configuration objects.
+* The JSON serialization of `SecurityTag` (`{"tenants":[...]}` for `ByTenants`, `"open"` for `Open`, absent
+  for `None`) is an external API contract and must be evolved carefully.
+* The lifecycle of the tag (who assigns/changes it, how it may evolve) is defined in a dedicated ADR.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
@@ -178,9 +178,8 @@ object TechniqueGenerationMode extends Enum[TechniqueGenerationMode] {
 final case class TechniqueDeprecationInfo(message: String) extends AnyVal
 
 /**
- * A Policy is made of a name, a description, and the list of templates name relevant
- * The templates are found thanks to the Descriptor file which holds all the relevant
- * informations
+ * A Policy is made of a name, a description, and the list of templates name relevant.
+ * The templates are found thanks to the Descriptor file which holds all the relevant information
  * A policy may or may not be shown (ex : common which is a system policy)
  * @author Nicolas Charles
  *

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueCategory.scala
@@ -66,6 +66,7 @@ object TechniqueCategoryMetadata {
   given HasSecurityTag[TechniqueCategoryMetadata] with {
     extension (a: TechniqueCategoryMetadata) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.name
       override def updateSecurityContext(security: Option[SecurityTag]): TechniqueCategoryMetadata = a.copy(security = security)
     }
@@ -253,6 +254,7 @@ object RootTechniqueCategory {
   given HasSecurityTag[RootTechniqueCategory] with {
     extension (a: RootTechniqueCategory) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.toString
       override def updateSecurityContext(security: Option[SecurityTag]): RootTechniqueCategory = a.copy(security = security)
     }
@@ -275,6 +277,7 @@ object SubTechniqueCategory {
   given HasSecurityTag[SubTechniqueCategory] with {
     extension (a: SubTechniqueCategory) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.toString
       override def updateSecurityContext(security: Option[SecurityTag]): SubTechniqueCategory = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -324,7 +324,7 @@ object JsonQueryObjects {
       value:       Option[ConfigValue],
       description: Option[String],
       inheritMode: Option[InheritMode],
-      security:    Option[SecurityTag] = None
+      security:    Option[SecurityTag]
   ) {
     def updateParameter(parameter: GlobalParameter): GlobalParameter = {
       // provider from API is force set to default.
@@ -962,7 +962,7 @@ class ZioJsonExtractor(queryParser: CmdbQueryParser & JsonQueryLexer) {
       value       <- params.parse2("value", GenericProperty.parseValue(_))
       inheritMode <- params.parse2("inheritMode", InheritMode.parseString(_))
     } yield {
-      JQGlobalParameter(params.optGet("id"), value, params.optGet("description"), inheritMode)
+      JQGlobalParameter(params.optGet("id"), value, params.optGet("description"), inheritMode, None)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -483,7 +483,10 @@ object JsonQueryObjects {
               q.map(Some(_)),
               dynamic,
               enabled,
-              security
+              // like JQRule/JQDirective/JQGlobalParameter: if the request does not carry a security
+              // tag, keep the existing one (do not wipe it). The actual tenant-change authorization
+              // is enforced later by TenantCheckLogic.manageUpdate.
+              security.orElse(group.security)
             )
           )
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -76,6 +76,7 @@ import com.normation.rudder.services.queries.StringCriterionLine
 import com.normation.rudder.services.queries.StringQuery
 import com.normation.rudder.services.servers.AllowedNetwork
 import com.normation.rudder.services.servers.DeleteMode
+import com.normation.rudder.tenants.SecurityTag
 import com.typesafe.config.ConfigValue
 import enumeratum.Enum
 import enumeratum.EnumEntry
@@ -234,7 +235,8 @@ object JsonQueryObjects {
       policyMode:       Option[Option[PolicyMode]] = None,
       tags:             Option[Tags] = None, // for clone
 
-      source: Option[DirectiveId] = None
+      source:   Option[DirectiveId] = None,
+      security: Option[SecurityTag] = None
   ) {
     val onlyName: Boolean = displayName.isDefined &&
       shortDescription.isEmpty &&
@@ -248,20 +250,22 @@ object JsonQueryObjects {
       tags.isEmpty // no need to check source or reason
 
     def updateDirective(directive: Directive): Directive = {
-      directive.patchUsing(
-        PatchDirective(
-          id,
-          techniqueVersion,
-          parameters.flatMap(_.get("section").map(s => SectionVal.toMapVariables(s.toSectionVal._2))),
-          displayName,
-          shortDescription,
-          policyMode,
-          longDescription,
-          priority,
-          enabled,
-          tags
+      directive
+        .patchUsing(
+          PatchDirective(
+            id,
+            techniqueVersion,
+            parameters.flatMap(_.get("section").map(s => SectionVal.toMapVariables(s.toSectionVal._2))),
+            displayName,
+            shortDescription,
+            policyMode,
+            longDescription,
+            priority,
+            enabled,
+            tags
+          )
         )
-      )
+        .copy(security = security.orElse(directive.security))
     }
   }
 
@@ -276,7 +280,8 @@ object JsonQueryObjects {
       enabled:                             Option[Boolean] = None,
       tags:                                Option[Tags] = None, // for clone
 
-      source: Option[RuleId] = None
+      source:   Option[RuleId] = None,
+      security: Option[SecurityTag] = None
   ) {
 
     val onlyName: Boolean = displayName.isDefined &&
@@ -308,7 +313,8 @@ object JsonQueryObjects {
         directiveIds = updateDirectives,
         targets = updateTargets,
         isEnabledStatus = updateEnabled,
-        tags = updateTags
+        tags = updateTags,
+        security = security.orElse(rule.security)
       )
     }
   }
@@ -317,11 +323,17 @@ object JsonQueryObjects {
       id:          Option[String],
       value:       Option[ConfigValue],
       description: Option[String],
-      inheritMode: Option[InheritMode]
+      inheritMode: Option[InheritMode],
+      security:    Option[SecurityTag] = None
   ) {
     def updateParameter(parameter: GlobalParameter): GlobalParameter = {
       // provider from API is force set to default.
-      parameter.patch(PatchProperty(id, value, Some(PropertyProvider.defaultPropertyProvider), description, inheritMode))
+      val patched =
+        parameter.patch(PatchProperty(id, value, Some(PropertyProvider.defaultPropertyProvider), description, inheritMode))
+      security match {
+        case None      => patched
+        case Some(tag) => patched.withSecurity(Some(tag))
+      }
     }
   }
 
@@ -368,7 +380,8 @@ object JsonQueryObjects {
       properties:  Option[List[GroupProperty]],
       query:       Option[Option[Query]],
       isDynamic:   Option[Boolean],
-      _isEnabled:  Option[Boolean]
+      _isEnabled:  Option[Boolean],
+      security:    Option[SecurityTag]
   )
 
   final case class JQGroupCategory private[apidata] (
@@ -433,7 +446,8 @@ object JsonQueryObjects {
       dynamic:                             Option[Boolean] = None,
       enabled:                             Option[Boolean] = None,
       @jsonAliases("category") categoryId: Option[NodeGroupCategoryId] = None,
-      source:                              Option[NodeGroupId] = None
+      source:                              Option[NodeGroupId] = None,
+      security:                            Option[SecurityTag] = None
   ) {
 
     val onlyName: Boolean = displayName.isDefined &&
@@ -458,18 +472,20 @@ object JsonQueryObjects {
                       properties.map(_ ::: group.properties.filter(p => p.visibility == Hidden && !propNames.contains(p.name)))
                     )
       } yield {
-        group.patchUsing(
-          GroupPatch(
-            // we can't change id, but revision yes
-            Some(NodeGroupId(group.id.uid, id.map(_.rev).getOrElse(group.id.rev))),
-            displayName,
-            description,
-            Some(p),
-            q.map(Some(_)),
-            dynamic,
-            enabled
+        group
+          .patchUsing(
+            GroupPatch(
+              // we can't change id, but revision yes
+              Some(NodeGroupId(group.id.uid, id.map(_.rev).getOrElse(group.id.rev))),
+              displayName,
+              description,
+              Some(p),
+              q.map(Some(_)),
+              dynamic,
+              enabled,
+              security
+            )
           )
-        )
       }
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -87,6 +87,7 @@ import com.normation.rudder.services.queries.*
 import com.normation.rudder.services.reports.ChangesByRule
 import com.normation.rudder.services.servers.AllowedNetwork
 import com.normation.rudder.services.servers.InstanceId
+import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
 import com.normation.rudder.tenants.TenantId
 import com.normation.utils.DateFormaterService
@@ -697,12 +698,17 @@ object JsonResponseObjects {
 
   final case class JRActiveTechnique(
       name:     String,
-      versions: List[String]
+      versions: List[String],
+      security: Option[SecurityTag]
   ) derives JsonEncoder
 
   object JRActiveTechnique {
-    def fromTechnique(activeTechnique: FullActiveTechnique): JRActiveTechnique = {
-      JRActiveTechnique(activeTechnique.techniqueName.value, activeTechnique.techniques.map(_._1.serialize).toList)
+    def fromTechnique(activeTechnique: FullActiveTechnique)(using qc: QueryContext): JRActiveTechnique = {
+      JRActiveTechnique(
+        activeTechnique.techniqueName.value,
+        activeTechnique.techniques.map(_._1.serialize).toList,
+        qc.accessGrant.visibleSecurityTag(activeTechnique.security)
+      )
     }
   }
 
@@ -954,7 +960,9 @@ object JsonResponseObjects {
     def empty(id: String): JRDirective =
       JRDirective(None, id, "", "", "", "", "", Map(), 5, enabled = false, system = false, policyMode = "", tags = List(), None)
 
-    def fromDirective(technique: Technique, directive: Directive, crId: Option[ChangeRequestId]): JRDirective = {
+    def fromDirective(technique: Technique, directive: Directive, crId: Option[ChangeRequestId])(using
+        qc: QueryContext
+    ): JRDirective = {
       directive
         .into[JRDirective]
         .enableBeanGetters
@@ -974,6 +982,7 @@ object JsonResponseObjects {
         )
         .withFieldComputed(_.policyMode, _.policyMode.map(_.name).getOrElse("default"))
         .withFieldComputed(_.tags, x => JRTags.fromTags(x.tags))
+        .withFieldConst(_.security, qc.accessGrant.visibleSecurityTag(directive.security))
         .transform
     }
   }
@@ -987,7 +996,7 @@ object JsonResponseObjects {
       techniques:    List[JRDirectiveTreeTechnique]
   ) derives JsonEncoder
   object JRDirectiveTreeCategory {
-    def fromActiveTechniqueCategory(technique: FullActiveTechniqueCategory): JRDirectiveTreeCategory = {
+    def fromActiveTechniqueCategory(technique: FullActiveTechniqueCategory)(using qc: QueryContext): JRDirectiveTreeCategory = {
       JRDirectiveTreeCategory(
         technique.name,
         technique.description,
@@ -1004,7 +1013,7 @@ object JsonResponseObjects {
   ) derives JsonEncoder
 
   object JRDirectiveTreeTechnique {
-    def fromActiveTechnique(technique: FullActiveTechnique): JRDirectiveTreeTechnique = {
+    def fromActiveTechnique(technique: FullActiveTechnique)(using qc: QueryContext): JRDirectiveTreeTechnique = {
       JRDirectiveTreeTechnique(
         technique.techniqueName.value,
         technique.newestAvailableTechnique.map(_.name).getOrElse(technique.techniqueName.value),
@@ -1090,7 +1099,7 @@ object JsonResponseObjects {
         crId:       Option[ChangeRequestId],
         policyMode: Option[String],
         status:     Option[(String, Option[String])]
-    ): JRRule = {
+    )(using qc: QueryContext): JRRule = {
       rule
         .into[JRRule]
         .enableBeanGetters
@@ -1104,6 +1113,7 @@ object JsonResponseObjects {
         .withFieldComputed(_.tags, x => JRTags.fromTags(rule.tags))
         .withFieldConst(_.policyMode, policyMode)
         .withFieldConst(_.status, status.map(s => JRApplicationStatus(s._1, s._2)))
+        .withFieldConst(_.security, qc.accessGrant.visibleSecurityTag(rule.security))
         .transform
     }
   }
@@ -1207,7 +1217,7 @@ object JsonResponseObjects {
         cat:      RuleCategory,
         allRules: Map[String, Seq[(Rule, Option[String], Option[(String, Option[String])])]],
         parent:   Option[String]
-    ): JRFullRuleCategory = {
+    )(using qc: QueryContext): JRFullRuleCategory = {
       cat
         .into[JRFullRuleCategory]
         .withFieldConst(_.parent, parent)
@@ -1323,14 +1333,23 @@ object JsonResponseObjects {
       value:           ConfigValue,
       description:     String,
       inheritMode:     Option[InheritMode],
-      provider:        Option[PropertyProvider]
+      provider:        Option[PropertyProvider],
+      security:        Option[SecurityTag]
   )
 
   object JRGlobalParameter {
     import GenericProperty.*
-    def empty(name: String): JRGlobalParameter = JRGlobalParameter(None, name, "".toConfigValue, "", None, None)
-    def fromGlobalParameter(p: GlobalParameter, crId: Option[ChangeRequestId]): JRGlobalParameter = {
-      JRGlobalParameter(crId.map(_.value.toString), p.name, p.value, p.description, p.inheritMode, p.provider)
+    def empty(name: String): JRGlobalParameter = JRGlobalParameter(None, name, "".toConfigValue, "", None, None, None)
+    def fromGlobalParameter(p: GlobalParameter, crId: Option[ChangeRequestId])(using qc: QueryContext): JRGlobalParameter = {
+      JRGlobalParameter(
+        crId.map(_.value.toString),
+        p.name,
+        p.value,
+        p.description,
+        p.inheritMode,
+        p.provider,
+        qc.accessGrant.visibleSecurityTag(p.security)
+      )
     }
 
     given JsonEncoder[JRGlobalParameter] = DeriveJsonEncoder
@@ -2056,7 +2075,9 @@ object JsonResponseObjects {
       security = None
     )
 
-    def fromGroup(group: NodeGroup, catId: NodeGroupCategoryId, crId: Option[ChangeRequestId]): JRGroup = {
+    def fromGroup(group: NodeGroup, catId: NodeGroupCategoryId, crId: Option[ChangeRequestId])(using
+        qc: QueryContext
+    ): JRGroup = {
       group
         .into[JRGroup]
         .enableBeanGetters
@@ -2070,6 +2091,7 @@ object JsonResponseObjects {
         .withFieldComputed(_.properties, _.properties.filter(_.visibility == Displayed).map(JRProperty.fromGroupProp(_)))
         .withFieldComputed(_.target, x => GroupTarget(x.id).target)
         .withFieldComputed(_.system, _.isSystem)
+        .withFieldConst(_.security, qc.accessGrant.visibleSecurityTag(group.security))
         .transform
     }
 
@@ -2127,7 +2149,7 @@ object JsonResponseObjects {
     def fromCategory(
         cat:    FullNodeGroupCategory,
         parent: Option[NodeGroupCategoryId]
-    ): JRFullGroupCategory = {
+    )(using qc: QueryContext): JRFullGroupCategory = {
       cat
         .into[JRFullGroupCategory]
         .withFieldConst(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
@@ -66,7 +66,7 @@ object StartAutomaticReporting
  * A class that periodically check if there is some new non compliant reports to log.
  *
  * parameter reportLogInterval define the interval between two reports check
- * Informations of logs a are taken from different repository
+ * Information of logs are taken from different repository
  */
 class AutomaticReportLogger(
     propertyRepository:  RudderPropertiesRepository,
@@ -79,6 +79,9 @@ class AutomaticReportLogger(
 
   private val propertyName = "rudder.batch.reports.logInterval"
   val logger               = ScheduledJobLogger
+
+  // that class has system level read on every tenants
+  given cc: QueryContext = QueryContext.systemQC
 
   if (reportLogInterval < 1) {
     logger.info("Disable automatic non-compliant logger since property %s is 0 or negative".format(propertyName))
@@ -115,7 +118,7 @@ class AutomaticReportLogger(
             logger.warn("Automatic report logger has never run, logging latest 100 non compliant reports")
             val isSuccess = (for {
               hundredReports <- reportsRepository.getLastHundredErrorReports(reportsKind).toIO
-              nodes          <- nodeFactRepository.getAll()(using QueryContext.systemQC)
+              nodes          <- nodeFactRepository.getAll()
               rules          <- ruleRepository.getAll(true)
               directives     <- directiveRepository.getFullDirectiveLibrary()
             } yield {
@@ -229,7 +232,7 @@ class AutomaticReportLogger(
       val startAt = lastProcessedId + 1
       logger.debug(s"Writing non-compliant-report logs between ids ${startAt} and ${maxId} (both included)")
       (for {
-        nodes      <- nodeFactRepository.getAll()(using QueryContext.systemQC)
+        nodes      <- nodeFactRepository.getAll()
         rules      <- ruleRepository.getAll(true)
         directives <- directiveRepository.getFullDirectiveLibrary()
       } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/configuration/ConfigurationRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/configuration/ConfigurationRepository.scala
@@ -60,6 +60,7 @@ import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.repository.xml.TechniqueRevisionRepository
+import com.normation.rudder.tenants.QueryContext
 import zio.*
 import zio.syntax.*
 
@@ -84,11 +85,11 @@ trait RoConfigurationRepository {
   /*
    * Get a directive and its matching active technique for the given (id, version)
    */
-  def getDirective(id: DirectiveId): IOResult[Option[ActiveDirective]]
+  def getDirective(id: DirectiveId)(using qc: QueryContext): IOResult[Option[ActiveDirective]]
   def getTechnique(id: TechniqueId): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]]
-  def getRule(id:      RuleId):      IOResult[Option[Rule]]
+  def getRule(id:      RuleId)(using qc:      QueryContext): IOResult[Option[Rule]]
 
-  def getDirectiveLibrary(ids: Set[DirectiveId]): IOResult[FullActiveTechniqueCategory]
+  def getDirectiveLibrary(ids: Set[DirectiveId])(using qc: QueryContext): IOResult[FullActiveTechniqueCategory]
 
   def getDirectiveRevision(uid: DirectiveUid): IOResult[List[RevisionInfo]]
 }
@@ -122,7 +123,7 @@ class ConfigurationRepositoryImpl(
     groupRevisionRepo:     GroupRevisionRepository
 ) extends ConfigurationRepository {
 
-  override def getDirective(id: DirectiveId): IOResult[Option[ActiveDirective]] = {
+  override def getDirective(id: DirectiveId)(using qc: QueryContext): IOResult[Option[ActiveDirective]] = {
     (id.rev match {
       case GitVersion.DEFAULT_REV =>
         roDirectiveRepository.getActiveTechniqueAndDirective(id)
@@ -144,7 +145,7 @@ class ConfigurationRepositoryImpl(
     }
   }
 
-  override def getRule(id: RuleId): IOResult[Option[Rule]] = {
+  override def getRule(id: RuleId)(using qc: QueryContext): IOResult[Option[Rule]] = {
     id.rev match {
       case GitVersion.DEFAULT_REV =>
         roRuleRepository.getOpt(id)
@@ -157,7 +158,7 @@ class ConfigurationRepositoryImpl(
     directiveRevisionRepo.getRevisions(uid)
   }
 
-  def getDirectiveLibrary(ids: Set[DirectiveId]): IOResult[FullActiveTechniqueCategory] = {
+  def getDirectiveLibrary(ids: Set[DirectiveId])(using qc: QueryContext): IOResult[FullActiveTechniqueCategory] = {
     def nonDefaultRev(rev: Revision): Boolean = rev != GitVersion.DEFAULT_REV
     val versionedDirectives = ids.filter(x => nonDefaultRev(x.rev))
     for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroup.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroup.scala
@@ -121,6 +121,7 @@ object NodeGroup {
   given HasSecurityTag[NodeGroup] with {
     extension (a: NodeGroup) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.debugString
       override def updateSecurityContext(security: Option[SecurityTag]): NodeGroup = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroupCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroupCategory.scala
@@ -74,6 +74,7 @@ object NodeGroupCategory {
   given HasSecurityTag[NodeGroupCategory] with {
     extension (a: NodeGroupCategory) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.value
       override def updateSecurityContext(security: Option[SecurityTag]): NodeGroupCategory = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/ActiveTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/ActiveTechnique.scala
@@ -80,6 +80,9 @@ object ActiveTechnique {
     extension (a: ActiveTechnique) {
       override def security: Option[SecurityTag] = a.security
 
+      // an active technique is "system" when it carries the system policy type
+      override def isSystem: Boolean = a.policyTypes.isSystem
+
       override def debugId: String = a.id.value
 
       override def updateSecurityContext(security: Option[SecurityTag]): ActiveTechnique =

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/ActiveTechniqueCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/ActiveTechniqueCategory.scala
@@ -58,6 +58,7 @@ object ActiveTechniqueCategory {
   given HasSecurityTag[ActiveTechniqueCategory] with {
     extension (a: ActiveTechniqueCategory) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.value
       override def updateSecurityContext(security: Option[SecurityTag]): ActiveTechniqueCategory = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
@@ -224,6 +224,7 @@ object Directive {
   given HasSecurityTag[Directive] with {
     extension (a: Directive) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.debugString
       override def updateSecurityContext(security: Option[SecurityTag]): Directive = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Rule.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Rule.scala
@@ -109,6 +109,8 @@ object Rule {
     extension (a: Rule) {
       override def security: Option[SecurityTag] = a.security
 
+      override def isSystem: Boolean = a.isSystem
+
       override def debugId: String = a.id.debugString
 
       override def updateSecurityContext(security: Option[SecurityTag]): Rule =

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -539,6 +539,7 @@ object FullRuleTargetInfo {
   given HasSecurityTag[FullRuleTargetInfo] with {
     extension (a: FullRuleTargetInfo) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.target.target.target
       override def updateSecurityContext(security: Option[SecurityTag]): FullRuleTargetInfo = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -748,6 +748,8 @@ object NodeProperty {
   given HasSecurityTag[NodeProperty] with {
     extension (a: NodeProperty) {
       override def security: Option[SecurityTag] = a.security
+      // properties have no system notion
+      override def isSystem: Boolean             = false
       override def debugId:  String              = a.debugId
       override def updateSecurityContext(security: Option[SecurityTag]): NodeProperty = a.withSecurity(security)
     }
@@ -794,6 +796,8 @@ object GroupProperty {
   given HasSecurityTag[GroupProperty] with {
     extension (a: GroupProperty) {
       override def security: Option[SecurityTag] = a.security
+      // properties have no system notion
+      override def isSystem: Boolean             = false
       override def debugId:  String              = a.debugId
       override def updateSecurityContext(security: Option[SecurityTag]): GroupProperty = a.withSecurity(security)
     }
@@ -927,6 +931,8 @@ object GlobalParameter {
   given HasSecurityTag[GlobalParameter] with {
     extension (a: GlobalParameter) {
       override def security: Option[SecurityTag] = a.security
+      // global parameters have no system flag
+      override def isSystem: Boolean             = false
       override def debugId:  String              = a.debugId
       override def updateSecurityContext(security: Option[SecurityTag]): GlobalParameter = a.withSecurity(security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -441,7 +441,8 @@ object GenericProperty {
     s match {
       case None          => c
       case Some(None)    => c.withoutPath(GenericProperty.SECURITY)
-      case Some(Some(v)) => c.withValue(GenericProperty.SECURITY, ConfigFactory.parseString(v.toJson).root())
+      // the security tag is stored as a json string (the `security` getter reads it with `getString`)
+      case Some(Some(v)) => c.withValue(GenericProperty.SECURITY, ConfigValueFactory.fromAnyRef(v.toJson))
     }
   }
 
@@ -652,7 +653,7 @@ object GenericProperty {
       security:    Option[SecurityTag], // optional for backward compat. None means "no tenant"
       options:     ConfigParseOptions = ConfigParseOptions.defaults()
   ): Config = {
-    val m = new java.util.HashMap[String, ConfigValue]()
+    val m              = new java.util.HashMap[String, ConfigValue]()
     m.put(NAME, ConfigValueFactory.fromAnyRef(name))
     rev match {
       case GitVersion.DEFAULT_REV => // nothing
@@ -662,7 +663,9 @@ object GenericProperty {
     description.foreach(x => m.put(DESCRIPTION, ConfigValueFactory.fromAnyRef(x)))
     m.put(VALUE, value)
     mode.foreach(x => m.put(INHERIT_MODE, ConfigValueFactory.fromAnyRef(x.value)))
-    GenericProperty.patchVisibility(ConfigFactory.parseMap(m, options.getOriginDescription), visibility)
+    val withVisibility = GenericProperty.patchVisibility(ConfigFactory.parseMap(m, options.getOriginDescription), visibility)
+    // `security.map(Some(_))`: None means "no tenant" (leave the path absent), Some(tag) sets it
+    GenericProperty.patchSecurity(withVisibility, security.map(Some(_)))
   }
 
   def valueToConfig(value: ConfigValue): Config = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -77,7 +77,7 @@ import zio.syntax.*
 
 trait SubGroupComparatorRepository {
   def getNodeIds(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Chunk[NodeId]]
-  def getGroups: IOResult[Chunk[SubGroupChoice]]
+  def getGroups(using qc: QueryContext): IOResult[Chunk[SubGroupChoice]]
 }
 // default implementation out of test use GroupRepo for that
 class DefaultSubGroupComparatorRepository(repo: RoNodeGroupRepository) extends SubGroupComparatorRepository {
@@ -89,7 +89,7 @@ class DefaultSubGroupComparatorRepository(repo: RoNodeGroupRepository) extends S
     }
   }
 
-  override def getGroups: IOResult[Chunk[SubGroupChoice]] = {
+  override def getGroups(using qc: QueryContext): IOResult[Chunk[SubGroupChoice]] = {
     repo.getAll().map(seq => Chunk.fromIterable(seq).map(g => SubGroupChoice(g.id, g.name)))
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -308,6 +308,9 @@ object NodeFact {
     extension (a: NodeFact) {
       override def security: Option[SecurityTag] = a.rudderSettings.security
 
+      // nodes are not system configuration objects: node writes are governed by tenant scoping only
+      override def isSystem: Boolean = false
+
       override def debugId: String = a.id.value
 
       override def updateSecurityContext(security: Option[SecurityTag]): NodeFact =
@@ -1012,6 +1015,8 @@ object CoreNodeFact {
   given HasSecurityTag[CoreNodeFact] with {
     extension (a: CoreNodeFact) {
       override def security:                                             Option[SecurityTag] = a.rudderSettings.security
+      // nodes are not system configuration objects: node writes are governed by tenant scoping only
+      override def isSystem:                                             Boolean             = false
       override def debugId:                                              String              = a.id.value
       override def updateSecurityContext(security: Option[SecurityTag]): CoreNodeFact        =
         a.modify(_.rudderSettings.security).setTo(security)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -123,10 +123,11 @@ trait NodeFactRepository {
   }
 
   /*
-   * Get the number of active managed nodes.
-   * This should be made fast, because it's typically used in license check.
+   * Get the number of active managed nodes visible in the given security context.
+   * This should be made fast, because it's typically used in license check (use `systemQC`
+   * there to get the non-tenant-scoped, global count).
    */
-  def getNumberOfManagedNodes(): IOResult[Int]
+  def getNumberOfManagedNodes()(using qc: QueryContext): IOResult[Int]
 
   /*
    * Get node on given status
@@ -155,7 +156,7 @@ trait NodeFactRepository {
     statusCompat(status, (qc, s) => slowGet(nodeId)(using qc, s, attrs))
   }
 
-  def getNodesBySoftwareName(softName: String): IOResult[List[(NodeId, Software)]]
+  def getNodesBySoftwareName(softName: String)(using qc: QueryContext): IOResult[List[(NodeId, Software)]]
 
   /*
    * get all node facts.
@@ -340,39 +341,39 @@ object CoreNodeFactRepository {
   }
 
   def make(
-      storage:       NodeFactStorage,
-      softByName:    GetNodesBySoftwareName,
-      tenantRepos:   TenantService,
-      tenantService: TenantCheckLogic,
-      callbacks:     Chunk[NodeFactChangeEventCallback],
-      savePreChecks: Chunk[NodeFact => IOResult[Unit]] = defaultSavePreChecks // that should really be used apart in some tests
+      storage:          NodeFactStorage,
+      softByName:       GetNodesBySoftwareName,
+      tenantService:    TenantService,
+      tenantCheckLogic: TenantCheckLogic,
+      callbacks:        Chunk[NodeFactChangeEventCallback],
+      savePreChecks:    Chunk[NodeFact => IOResult[Unit]] = defaultSavePreChecks // that should really be used apart in some tests
   ): IOResult[CoreNodeFactRepository] = for {
     _        <- InventoryDataLogger.debug("Getting pending node info for node fact repos")
     pending  <- storage.getAllPending()(using SelectFacts.none).map(f => (f.id, f.toCore)).runCollect.map(_.toMap)
     _        <- InventoryDataLogger.debug("Getting accepted node info for node fact repos")
     accepted <- storage.getAllAccepted()(using SelectFacts.none).map(f => (f.id, f.toCore)).runCollect.map(_.toMap)
     _        <- InventoryDataLogger.debug("Creating node fact repos")
-    repo     <- make(storage, softByName, tenantRepos, tenantService, pending, accepted, callbacks, savePreChecks)
+    repo     <- make(storage, softByName, tenantService, tenantCheckLogic, pending, accepted, callbacks, savePreChecks)
   } yield {
     repo
   }
 
   def make(
-      storage:       NodeFactStorage,
-      softByName:    GetNodesBySoftwareName,
-      tenantRepo:    TenantService,
-      tenantService: TenantCheckLogic,
-      pending:       Map[NodeId, CoreNodeFact],
-      accepted:      Map[NodeId, CoreNodeFact],
-      callbacks:     Chunk[NodeFactChangeEventCallback],
-      savePreChecks: Chunk[NodeFact => IOResult[Unit]]
+      storage:          NodeFactStorage,
+      softByName:       GetNodesBySoftwareName,
+      tenantService:    TenantService,
+      tenantCheckLogic: TenantCheckLogic,
+      pending:          Map[NodeId, CoreNodeFact],
+      accepted:         Map[NodeId, CoreNodeFact],
+      callbacks:        Chunk[NodeFactChangeEventCallback],
+      savePreChecks:    Chunk[NodeFact => IOResult[Unit]]
   ): UIO[CoreNodeFactRepository] = for {
     p    <- Ref.make(pending)
     a    <- Ref.make(accepted)
     lock <- ReentrantLock.make()
     cbs  <- Ref.make(callbacks)
   } yield {
-    new CoreNodeFactRepository(storage, softByName, tenantRepo, tenantService, p, a, cbs, savePreChecks, lock)
+    new CoreNodeFactRepository(storage, softByName, tenantService, tenantCheckLogic, p, a, cbs, savePreChecks, lock)
   }
 
   // a version for tests
@@ -427,8 +428,8 @@ class SoftDaoGetNodesBySoftwareName(val softwareDao: ReadOnlySoftwareDAO) extend
 class CoreNodeFactRepository(
     storage:          NodeFactStorage,
     softwareByName:   GetNodesBySoftwareName,
-    tenantRepository: TenantService,
-    tenantService:    TenantCheckLogic,
+    tenantService:    TenantService,
+    tenantCheckLogic: TenantCheckLogic,
     pendingNodes:     Ref[Map[NodeId, CoreNodeFact]],
     acceptedNodes:    Ref[Map[NodeId, CoreNodeFact]],
     callbacks:        Ref[Chunk[NodeFactChangeEventCallback]],
@@ -501,7 +502,7 @@ class CoreNodeFactRepository(
   private[nodes] def getOnRef(ref: Ref[Map[NodeId, CoreNodeFact]], nodeId: NodeId)(implicit
       qc: QueryContext
   ): IOResult[Option[CoreNodeFact]] = {
-    tenantService.getMapView(ref, nodeId)
+    tenantCheckLogic.getMapView(ref, nodeId)
   }
 
   /*
@@ -533,7 +534,11 @@ class CoreNodeFactRepository(
     }
   }
 
-  override def getNumberOfManagedNodes(): IOResult[Int] = enabledNodes.get
+  override def getNumberOfManagedNodes()(using qc: QueryContext): IOResult[Int] = {
+    // fast path: admin (and everyone when the tenant feature is disabled) uses the precomputed global count
+    if (qc.accessGrant == TenantAccessGrant.All) enabledNodes.get
+    else acceptedNodes.get.map(ns => countEnabled(ns.filter { case (_, n) => qc.accessGrant.canSee(n) }))
+  }
 
   override def get(
       nodeId: NodeId
@@ -585,13 +590,13 @@ class CoreNodeFactRepository(
                       }
                     }
                 }
-    } yield tenantService.flatMap(res)
+    } yield tenantCheckLogic.flatMap(res)
   }
 
   private[nodes] def getAllOnRef[A](
       ref: Ref[Map[NodeId, CoreNodeFact]]
   )(implicit qc: QueryContext): IOResult[MapView[NodeId, CoreNodeFact]] = {
-    tenantService.filterMapView(ref)
+    tenantCheckLogic.filterMapView(ref)
   }
 
   override def getAll()(implicit qc: QueryContext, status: SelectNodeStatus): IOResult[MapView[NodeId, CoreNodeFact]] = {
@@ -607,7 +612,7 @@ class CoreNodeFactRepository(
   }
 
   override def slowGetAll()(implicit qc: QueryContext, status: SelectNodeStatus, attrs: SelectFacts): IOStream[NodeFact] = {
-    tenantService.filterStream(
+    tenantCheckLogic.filterStream(
       if (attrs == SelectFacts.none) {
         ZStream.fromIterableZIO(getAll()(using qc, status).map(_.map(cnf => NodeFact.fromMinimal(cnf._2))))
       } else {
@@ -622,8 +627,23 @@ class CoreNodeFactRepository(
     )
   }
 
-  override def getNodesBySoftwareName(softName: String): IOResult[List[(NodeId, Software)]] = {
-    softwareByName(softName)
+  override def getNodesBySoftwareName(softName: String)(using qc: QueryContext): IOResult[List[(NodeId, Software)]] = {
+    for {
+      res      <- softwareByName(softName)
+      // the DAO returns (nodeId, software) for ALL nodes regardless of tenant: filter out the
+      // ones the current security context can't see. Nodes unknown to the cache are only visible
+      // to admins (same semantic as `canSee` on an absent/untagged object).
+      accepted <- acceptedNodes.get
+      pending  <- pendingNodes.get
+    } yield {
+      res.filter {
+        case (id, _) =>
+          accepted.get(id).orElse(pending.get(id)) match {
+            case Some(nf) => qc.accessGrant.canSee(nf)
+            case None     => qc.accessGrant.canSee(Option.empty[SecurityTag])
+          }
+      }
+    }
   }
 
   /*
@@ -652,7 +672,7 @@ class CoreNodeFactRepository(
         nodes.get(nodeId) match {
           case None           => (Right(StorageChangeEventDelete.Noop(nodeId)), nodes)
           case Some(existing) =>
-            tenantService.checkDelete(existing, cc) match {
+            tenantCheckLogic.checkDelete(existing, cc) match {
               case Left(err) => (Left(err), nodes)
               case Right(n)  =>
                 val e = StorageChangeEventDelete.Deleted(NodeFact.fromMinimal(n), SelectFacts.none)
@@ -702,8 +722,8 @@ class CoreNodeFactRepository(
                                    Inconsistency(s"Error: can not change tenant of missing node with Id '${id.value}'").fail
                                }
         (nodeFact, selected) = pair
-        tenantStatus        <- tenantRepository.getStatus
-        es                  <- tenantService.manageUpdate(core, nodeFact, cc, tenantStatus) { updated =>
+        tenantStatus        <- tenantService.getStatus
+        es                  <- tenantCheckLogic.manageUpdate(core, nodeFact, cc, tenantStatus) { updated =>
                                  for {
                                    // first we persist on cold storage, which is more likely to fail. Plus, for history reason, some
                                    // mapping are not exactly isomorphic, and some normalization can happen - for ex, for missing machine.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
@@ -70,7 +70,7 @@ class PostCommitInventoryHooks[A](
     HOOKS_IGNORE_SUFFIXES: List[String],
     nodeFactRepo:          NodeFactRepository
 ) extends PostCommit[A] {
-  import QueryContext.todoQC
+
   import scala.jdk.CollectionConverters.*
   override val name = "post_commit_inventory:run_node-inventory-received_hooks"
 
@@ -78,7 +78,7 @@ class PostCommitInventoryHooks[A](
     val node  = inventory.node.main
     val hooks = (for {
       systemEnv <- IOResult.attempt(java.lang.System.getenv.asScala.toSeq).map(seq => HookEnvPairs.build(seq*))
-      nHooks    <- nodeFactRepo.getStatus(node.id).flatMap {
+      nHooks    <- nodeFactRepo.getStatus(node.id)(using QueryContext.systemQC).flatMap {
                      case PendingInventory  =>
                        val n = "node-inventory-received-pending"
                        RunHooks.getHooksPure(HOOKS_D + "/" + n, HOOKS_IGNORE_SUFFIXES).map(h => (n, h))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
@@ -59,6 +59,7 @@ import com.normation.rudder.repository.xml.TechniqueArchiver
 import com.normation.rudder.services.workflows.ChangeRequestService
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import zio.*
 import zio.syntax.*
 
@@ -116,6 +117,9 @@ class DeleteEditorTechniqueImpl(
     }
 
     def removeTechnique(techniqueId: TechniqueId, technique: domain.Technique): IOResult[Unit] = {
+      // here, we can only see directives in user tenant. So it may happen that we ask for directive deletion,
+      // but can't see them all, and fail when trying to delete the technique because of other directives. It seems that it is what we want.
+      given qc: QueryContext = changeContext.toQC
       for {
         directives       <- readDirectives
                               .getFullDirectiveLibrary()
@@ -152,11 +156,8 @@ class DeleteEditorTechniqueImpl(
                                 ().succeed
                               case Some(activeTechnique) =>
                                 writeDirectives.deleteActiveTechnique(
-                                  activeTechnique.id,
-                                  changeContext.modId,
-                                  changeContext.actor,
-                                  Some(s"Deleting active technique '${techniqueId.name.value}'")
-                                )
+                                  activeTechnique.id
+                                )(using changeContext.withMsg(s"Deleting active technique '${techniqueId.name.value}'"))
                             }
         editorTechniques <- techniqueReader
                               .getTechnique(BundleName(techniqueId.name.value), techniqueId.version.version.toVersionString)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCheckCache.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCheckCache.scala
@@ -45,6 +45,7 @@ import com.normation.rudder.domain.logger.StatusLoggerPure
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.repository.FullActiveTechnique
 import com.normation.rudder.repository.RoDirectiveRepository
+import com.normation.rudder.tenants.QueryContext
 import net.liftweb.common.SimpleActor
 import zio.*
 import zio.syntax.*
@@ -259,11 +260,11 @@ class TechniqueCheckStatusService(
 class TechniqueActiveStatusService(directiveRepo: RoDirectiveRepository) extends ReadEditorTechniqueActiveStatus {
 
   override def getActiveStatus(id: BundleName): IOResult[Option[TechniqueActiveStatus]]          = {
-    directiveRepo.getActiveTechnique(TechniqueName(id.value)).map(_.map(techniqueActiveStatus(_)))
+    directiveRepo.getActiveTechnique(TechniqueName(id.value))(using QueryContext.systemQC).map(_.map(techniqueActiveStatus(_)))
   }
   override def getActiveStatuses():             IOResult[Map[BundleName, TechniqueActiveStatus]] = {
     directiveRepo
-      .getFullDirectiveLibrary()
+      .getFullDirectiveLibrary()(using QueryContext.systemQC)
       .map(_.allActiveTechniques.map((_, t) => techniqueId(t) -> techniqueActiveStatus(t)).toMap)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
@@ -68,10 +68,14 @@ class NodePropertiesServiceImpl(
     propertiesRepository:  PropertiesRepository
 ) extends NodePropertiesService {
   override def updateAll(): IOResult[Unit] = {
+
+    // this is a rudder operation
+    given qc: QueryContext = QueryContext.systemQC
+
     for {
       params      <- globalPropsRepo.getAllGlobalParameters().map(_.map(x => (x.name, x)).toMap)
-      groups      <- roNodeGroupRepository.getFullGroupLibrary()(using QueryContext.systemQC)
-      nodes       <- nodeFactRepository.getAll()(using QueryContext.systemQC).map(_.values)
+      groups      <- roNodeGroupRepository.getFullGroupLibrary()
+      nodes       <- nodeFactRepository.getAll().map(_.values)
       mergedGroups = {
         groups.allGroups.map {
           case (gid, group) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
@@ -144,6 +144,8 @@ object FullActiveTechnique {
   given HasSecurityTag[FullActiveTechnique] with {
     extension (a: FullActiveTechnique) {
       override def security: Option[SecurityTag] = a.security
+      // an active technique is "system" when it carries the system policy type
+      override def isSystem: Boolean             = a.policyTypes.isSystem
       override def debugId:  String              = a.id.value
       override def updateSecurityContext(security: Option[SecurityTag]): FullActiveTechnique = a.copy(security = security)
     }
@@ -305,7 +307,7 @@ final case class FullActiveTechniqueCategory(
             Nil,
             isEnabled = true,
             policyTypes = PolicyTypes.rudderBase,
-            security = cc.accessGrant.toSecurityTag // inherit user tenant creating that technique
+            security = cc.accessGrant.restrictToWrite.toSecurityTag // inherit user tenant creating that technique
           )
         case Some(fat) =>
           fat.modify(_.acceptationDatetimes).using(_ ++ newTimes).modify(_.techniques).using(_ ++ newTechs)
@@ -335,6 +337,7 @@ object FullActiveTechniqueCategory {
   given HasSecurityTag[FullActiveTechniqueCategory] with {
     extension (a: FullActiveTechniqueCategory) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.value
       override def updateSecurityContext(security: Option[SecurityTag]): FullActiveTechniqueCategory = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
@@ -45,11 +45,10 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.HasSecurityTag
+import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.Utils
@@ -355,7 +354,7 @@ trait RoDirectiveRepository {
    * Get the full directive library with all information,
    * from techniques to directives
    */
-  def getFullDirectiveLibrary(): IOResult[FullActiveTechniqueCategory]
+  def getFullDirectiveLibrary()(using qc: QueryContext): IOResult[FullActiveTechniqueCategory]
 
   /**
    * Try to find the directive with the given ID.
@@ -363,13 +362,15 @@ trait RoDirectiveRepository {
    * Full((parent,directive)) : found the directive (directive.id == directiveId) in given parent
    * Failure => an error happened.
    */
-  def getDirective(directiveId: DirectiveUid): IOResult[Option[Directive]]
+  def getDirective(directiveId: DirectiveUid)(using qc: QueryContext): IOResult[Option[Directive]]
 
   /**
    * retrieve a Directive with its parent Technique and the
    * binding Active Technique
    */
-  def getDirectiveWithContext(directiveId: DirectiveUid): IOResult[Option[(Technique, ActiveTechnique, Directive)]]
+  def getDirectiveWithContext(
+      directiveId: DirectiveUid
+  )(using qc: QueryContext): IOResult[Option[(Technique, ActiveTechnique, Directive)]]
 
   /**
    * Find the active technique for which the given directive is an instance.
@@ -377,13 +378,15 @@ trait RoDirectiveRepository {
    * Return empty if no such directive is known,
    * fails if no active technique match the directive.
    */
-  def getActiveTechniqueAndDirective(id: DirectiveId): IOResult[Option[(ActiveTechnique, Directive)]]
+  def getActiveTechniqueAndDirective(id: DirectiveId)(using qc: QueryContext): IOResult[Option[(ActiveTechnique, Directive)]]
 
   /**
    * Get directives for given technique.
    * A not known technique id is a failure.
    */
-  def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean = false): IOResult[Seq[Directive]]
+  def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean = false)(using
+      qc: QueryContext
+  ): IOResult[Seq[Directive]]
 
   /**
    * Get all pairs of (category details, Set(active technique))
@@ -398,14 +401,14 @@ trait RoDirectiveRepository {
    */
   def getActiveTechniqueByCategory(
       includeSystem: Boolean = false
-  ): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]]
+  )(using qc: QueryContext): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]]
 
   /**
    * Find back an active technique thanks to its id.
    * Return Empty if the active technique is not found,
    * Fails on error.
    */
-  def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId): IOResult[Option[ActiveTechnique]]
+  def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[Option[ActiveTechnique]]
 
   /**
    * Find back an active technique thanks to the id of its referenced
@@ -413,7 +416,7 @@ trait RoDirectiveRepository {
    * Return Empty if the active technique is not found,
    * Fails on error.
    */
-  def getActiveTechnique(techniqueName: TechniqueName): IOResult[Option[ActiveTechnique]]
+  def getActiveTechnique(techniqueName: TechniqueName)(using qc: QueryContext): IOResult[Option[ActiveTechnique]]
 
   /**
    * Retrieve the list of parents for the given active technique,
@@ -421,30 +424,36 @@ trait RoDirectiveRepository {
    * Return empty if the path can not be build
    * (missing technique, missing category, etc)
    */
-  def activeTechniqueBreadCrump(id: ActiveTechniqueId): IOResult[List[ActiveTechniqueCategory]]
+  def activeTechniqueBreadCrump(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]]
 
   /**
    * Root user categories
    */
-  def getActiveTechniqueLibrary: IOResult[ActiveTechniqueCategory]
+  def getActiveTechniqueLibrary(using qc: QueryContext): IOResult[ActiveTechniqueCategory]
 
   /**
    * Return all categories non system (lightweight version, with no children)
    * @return
    */
-  def getAllActiveTechniqueCategories(includeSystem: Boolean = false): IOResult[Seq[ActiveTechniqueCategory]]
+  def getAllActiveTechniqueCategories(includeSystem: Boolean = false)(using
+      qc: QueryContext
+  ): IOResult[Seq[ActiveTechniqueCategory]]
 
   /**
    * Get an active technique by its ID
    */
-  def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[Option[ActiveTechniqueCategory]]
+  def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[Option[ActiveTechniqueCategory]]
 
   /**
    * Get the direct parent of the given category.
    * Return empty for root of the hierarchy, fails if the category
    * is not in the repository
    */
-  def getParentActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[ActiveTechniqueCategory]
+  def getParentActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[ActiveTechniqueCategory]
 
   /**
    * Return the list of parents for that category, the nearest parent
@@ -452,9 +461,11 @@ trait RoDirectiveRepository {
    * The the last parent is not the root of the library, return a Failure.
    * Also return a failure if the path to top is broken in any way.
    */
-  def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[List[ActiveTechniqueCategory]]
+  def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[List[ActiveTechniqueCategory]]
 
-  def getParentsForActiveTechnique(id: ActiveTechniqueId): IOResult[ActiveTechniqueCategory]
+  def getParentsForActiveTechnique(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[ActiveTechniqueCategory]
 
   /**
    * TODO: Never use, remove in rudder 7.0
@@ -478,11 +489,8 @@ trait WoDirectiveRepository {
    */
   def saveDirective(
       inActiveTechniqueId: ActiveTechniqueId,
-      directive:           Directive,
-      modId:               ModificationId,
-      actor:               EventActor,
-      reason:              Option[String]
-  ): IOResult[Option[DirectiveSaveDiff]]
+      directive:           Directive
+  )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]]
 
   /**
    * Save the given system directive into given user technique
@@ -498,11 +506,8 @@ trait WoDirectiveRepository {
    */
   def saveSystemDirective(
       inActiveTechniqueId: ActiveTechniqueId,
-      directive:           Directive,
-      modId:               ModificationId,
-      actor:               EventActor,
-      reason:              Option[String]
-  ): IOResult[Option[DirectiveSaveDiff]]
+      directive:           Directive
+  )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]]
 
   /**
    * Delete a directive.
@@ -516,11 +521,8 @@ trait WoDirectiveRepository {
    * System directive can't be deleted.
    */
   def delete(
-      id:     DirectiveUid,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[Option[DeleteDirectiveDiff]]
+      id: DirectiveUid
+  )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]]
 
   /**
    * Delete a directive's system.
@@ -531,11 +533,8 @@ trait WoDirectiveRepository {
    * If no directive has such id, return a success.
    */
   def deleteSystemDirective(
-      id:     DirectiveUid,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[Option[DeleteDirectiveDiff]]
+      id: DirectiveUid
+  )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]]
 
   /**
    * Create an active technique from the parameter WBTechnique
@@ -593,11 +592,8 @@ trait WoDirectiveRepository {
    * If no such element exists, it is a success.
    */
   def deleteActiveTechnique(
-      id:     ActiveTechniqueId,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[ActiveTechniqueId]
+      id: ActiveTechniqueId
+  )(using cc: ChangeContext): IOResult[ActiveTechniqueId]
 
   /**
    * Add the given category into the given parent category in the
@@ -733,8 +729,8 @@ class InitDirectivesTree(
       }
     }
 
-    // apply with root cat children ids
-    roDirectiveRepository.getActiveTechniqueLibrary.toBox.flatMap { root =>
+    // init ref lib by appling with root cat children ids. This as system action, agnostic of tenants
+    roDirectiveRepository.getActiveTechniqueLibrary(using QueryContext.systemQC).toBox.flatMap { root =>
       bestEffort(techniqueRepository.getTechniqueLibrary.subCategoryIds.toSeq)(id => recCopyRef(id, root))
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.HasSecurityTag
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
 import com.normation.utils.Utils
@@ -213,6 +214,16 @@ final case class FullNodeGroupCategory(
 
 }
 
+object FullNodeGroupCategory {
+  given HasSecurityTag[FullNodeGroupCategory] with {
+    extension (a: FullNodeGroupCategory) {
+      override def security: Option[SecurityTag] = a.security
+      override def debugId:  String              = a.id.value
+      override def updateSecurityContext(security: Option[SecurityTag]): FullNodeGroupCategory = a.copy(security = security)
+    }
+  }
+}
+
 trait RoNodeGroupRepository {
 
   /**
@@ -222,7 +233,7 @@ trait RoNodeGroupRepository {
    */
   def getFullGroupLibrary()(implicit qc: QueryContext): IOResult[FullNodeGroupCategory]
 
-  def categoryExists(id: NodeGroupCategoryId): IOResult[Boolean]
+  def categoryExists(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean]
 
   /**
    * Get a server group by its id. Fail if not present.
@@ -248,30 +259,29 @@ trait RoNodeGroupRepository {
    * @param id
    * @return
    */
-  def getNodeGroupCategory(id: NodeGroupId): IOResult[NodeGroupCategory]
+  def getNodeGroupCategory(id: NodeGroupId)(using qc: QueryContext): IOResult[NodeGroupCategory]
 
   /**
    * Get all node groups defined in that repository
    */
-  // TODO: add QC
-  def getAll(): IOResult[Seq[NodeGroup]]
+  def getAll()(using qc: QueryContext): IOResult[Seq[NodeGroup]]
 
   /**
    * Get all node groups by ids
    */
-  def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[NodeGroup]]
+  def getAllByIds(ids: Seq[NodeGroupId])(using qc: QueryContext): IOResult[Seq[NodeGroup]]
 
   /**
    * Get all the node group id and the set of ndoes within
    * Goal is to be more efficient
    */
-  def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]]
+  def getAllNodeIds()(using qc: QueryContext): IOResult[Map[NodeGroupId, Set[NodeId]]]
 
   /**
    * Get all the node group id and the set of ndoes within
    * Goal is to be more efficient
    */
-  def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]]
+  def getAllNodeIdsChunk()(using qc: QueryContext): IOResult[Map[NodeGroupId, Chunk[NodeId]]]
 
   /**
    * Get all pairs of (category details, Set(node groups) )
@@ -291,11 +301,11 @@ trait RoNodeGroupRepository {
 
   /**
    * Retrieve all groups that have at least one of the given
-   * node ID in there member list.
+   * node ID in their member list.
    * @param nodeIds
    * @return
    */
-  def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]]
+  def findGroupWithAnyMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]]
 
   /**
    * Retrieve all groups that have ALL given node ID in their
@@ -303,18 +313,18 @@ trait RoNodeGroupRepository {
    * @param nodeIds
    * @return
    */
-  def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]]
+  def findGroupWithAllMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]]
 
   /**
    * Root group category
    */
-  def getRootCategory(): NodeGroupCategory
+  def getRootCategory()(using qc: QueryContext): NodeGroupCategory
 
-  def getRootCategoryPure(): IOResult[NodeGroupCategory]
+  def getRootCategoryPure()(using qc: QueryContext): IOResult[NodeGroupCategory]
 
   /**
    * Get all pairs of (categoryid, category)
-   * in a map in which keys are the parent category of the
+   * in a map in which keys are the parent category of
    * the template. The map is sorted by categories:
    * SortedMap {
    *   "/"           -> [root]
@@ -323,26 +333,26 @@ trait RoNodeGroupRepository {
    *   "/cat2"       -> [/cat2_details]
    *   ...
    */
-  def getCategoryHierarchy: IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]]
+  def getCategoryHierarchy(using qc: QueryContext): IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]]
 
   /**
    * Return all categories
    * @return
    */
-  def getAllGroupCategories(includeSystem: Boolean = false): IOResult[Seq[NodeGroupCategory]]
+  def getAllGroupCategories(includeSystem: Boolean = false)(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]]
 
   /**
    * Get a group category by its id
    * @param id
    * @return
    */
-  def getGroupCategory(id: NodeGroupCategoryId): IOResult[NodeGroupCategory]
+  def getGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory]
 
   /**
    * Get the direct parent of the given category.
    * Fails if the category is not in the repository or for root category
    */
-  def getParentGroupCategory(id: NodeGroupCategoryId): IOResult[NodeGroupCategory]
+  def getParentGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory]
 
   /**
    * Return the list of parents for that category, the nearest parent
@@ -350,13 +360,13 @@ trait RoNodeGroupRepository {
    * The last parent is not the root of the library, return a Failure.
    * Also return a failure if the path to top is broken in any way.
    */
-  def getParents_NodeGroupCategory(id: NodeGroupCategoryId): IOResult[List[NodeGroupCategory]]
+  def getParents_NodeGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[List[NodeGroupCategory]]
 
   /**
    * Returns all non system categories + the root category
    * Caution, they are "lightweight" group categories (no children)
    */
-  def getAllNonSystemCategories(): IOResult[Seq[NodeGroupCategory]]
+  def getAllNonSystemCategories()(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]]
 
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -218,6 +218,7 @@ object FullNodeGroupCategory {
   given HasSecurityTag[FullNodeGroupCategory] with {
     extension (a: FullNodeGroupCategory) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.value
       override def updateSecurityContext(security: Option[SecurityTag]): FullNodeGroupCategory = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ParameterRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ParameterRepository.scala
@@ -37,47 +37,38 @@
 
 package com.normation.rudder.repository
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.archives.ParameterArchiveId
 import com.normation.rudder.domain.properties.AddGlobalParameterDiff
 import com.normation.rudder.domain.properties.DeleteGlobalParameterDiff
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.ModifyGlobalParameterDiff
 import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 
 /**
  * The Parameter Repository (Read Only) to read parameters from LDAP
  */
 trait RoParameterRepository {
 
-  def getGlobalParameter(parameterName: String): IOResult[Option[GlobalParameter]]
+  def getGlobalParameter(parameterName: String)(using qc: QueryContext): IOResult[Option[GlobalParameter]]
 
-  def getAllGlobalParameters(): IOResult[Seq[GlobalParameter]]
+  def getAllGlobalParameters()(using qc: QueryContext): IOResult[Seq[GlobalParameter]]
 }
 
 trait WoParameterRepository {
   def saveParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): IOResult[AddGlobalParameterDiff]
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): IOResult[AddGlobalParameterDiff]
 
   def updateParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): IOResult[Option[ModifyGlobalParameterDiff]]
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): IOResult[Option[ModifyGlobalParameterDiff]]
 
   def delete(
       parameterName: String,
-      provider:      Option[PropertyProvider],
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String]
-  ): IOResult[Option[DeleteGlobalParameterDiff]]
+      provider:      Option[PropertyProvider]
+  )(using cc: ChangeContext): IOResult[Option[DeleteGlobalParameterDiff]]
 
   /**
    * A (dangerous) method that replace all existing parameters

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/RuleRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/RuleRepository.scala
@@ -37,10 +37,10 @@
 
 package com.normation.rudder.repository
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.policies.*
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 
 /**
  * The directive repository.
@@ -54,25 +54,26 @@ trait RoRuleRepository {
   /**
    * Try to find the rule with the given ID.
    */
-  def getOpt(ruleId: RuleId): IOResult[Option[Rule]]
+  def getOpt(ruleId: RuleId)(using qc: QueryContext): IOResult[Option[Rule]]
 
   /**
    * Find the rule with the given ID (error if not found)
    */
-  def get(ruleId: RuleId): IOResult[Rule] = getOpt(ruleId).notOptional(s"Rule with id '${ruleId.serialize}' was not found")
+  def get(ruleId: RuleId)(using qc: QueryContext): IOResult[Rule] =
+    getOpt(ruleId).notOptional(s"Rule with id '${ruleId.serialize}' was not found")
 
   /**
    * Return all rules.
    * To get only applied one, you can post-filter the seq
    * with the method RuleTargetService#isApplied
    */
-  def getAll(includeSystem: Boolean = false): IOResult[Seq[Rule]]
+  def getAll(includeSystem: Boolean = false)(using qc: QueryContext): IOResult[Seq[Rule]]
 
   /**
    * Return all rules ids.
    * Optionnaly include system rules
    */
-  def getIds(includeSystem: Boolean = false): IOResult[Set[RuleId]]
+  def getIds(includeSystem: Boolean = false)(using qc: QueryContext): IOResult[Set[RuleId]]
 
 }
 
@@ -88,7 +89,7 @@ trait WoRuleRepository {
    *
    * We can't create a rule with a revision, it will fail. Use #load for that.
    */
-  def create(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[AddRuleDiff]
+  def create(rule: Rule)(using cc: ChangeContext): IOResult[AddRuleDiff]
 
   /**
    * Update the rule with the given ID with the given
@@ -99,7 +100,7 @@ trait WoRuleRepository {
    *
    * We can't update a rule with a revision, it will fail. Use #load for that.
    */
-  def update(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Option[ModifyRuleDiff]]
+  def update(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]]
 
   /**
    * Load a rule with a specific revision in LDAP for generation - that means
@@ -111,20 +112,20 @@ trait WoRuleRepository {
    * - when revision is a specific commit id, it will always be a noop,
    * - when revision is a moving reference, like a branch name, HEAD is loaded.
    */
-  def load(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]
+  def load(rule: Rule)(using cc: ChangeContext): IOResult[Unit]
 
   /**
    * Unload a rule with the corresponding uid/revision: it will stop to be taken into account in
    * policy generation. If the revision is DEFAULT_REVISION, that method will fail and you should
    * use delete for that.
    */
-  def unload(ruleId: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]
+  def unload(ruleId: RuleId)(using cc: ChangeContext): IOResult[Unit]
 
   /**
    * Update the system configuration rule with the given ID with the given
    * parameters.
    */
-  def updateSystem(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Option[ModifyRuleDiff]]
+  def updateSystem(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]]
 
   /**
    * Delete the rule with the given ID.
@@ -133,9 +134,9 @@ trait WoRuleRepository {
    * and error or not).
    * A system rule can not be deleted.
    */
-  def delete(id: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[DeleteRuleDiff]
+  def delete(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff]
 
-  def deleteSystemRule(id: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[DeleteRuleDiff]
+  def deleteSystemRule(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff]
 
   /**
    * A (dangerous) method that replace all existing rules

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
@@ -649,19 +649,24 @@ class RoTenantRuleRepo(
 }
 
 class WoTenantRuleRepo(
-    checkTenant:   TenantCheckLogic,
-    tenantService: TenantService,
-    underlying:    WoRuleRepository,
-    roRepo:        RoRuleRepository
+    checkTenant:    TenantCheckLogic,
+    tenantService:  TenantService,
+    underlying:     WoRuleRepository,
+    roRepo:         RoRuleRepository,
+    roRuleCategory: RoRuleCategoryRepository
 ) extends RoRuleRepository with WoRuleRepository {
 
   // the read part is just delegated to the (tenant-filtering) `roRepo`
   export roRepo.*
 
   override def create(rule: Rule)(using cc: ChangeContext): IOResult[AddRuleDiff] = {
+    given QueryContext = cc.toQC
     for {
-      status <- tenantService.getStatus
-      result <- checkTenant.manageCreate(rule, cc, status)(r => underlying.create(r))
+      // an object can only be created in a category the user can see and modify
+      parentCat <- roRuleCategory.get(rule.categoryId)
+      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      status    <- tenantService.getStatus
+      result    <- checkTenant.manageCreate(rule, cc, status)(r => underlying.create(r))
     } yield result
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
@@ -1,0 +1,841 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.repository
+
+import com.normation.cfclerk.domain.*
+import com.normation.errors.*
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.archives.ParameterArchiveId
+import com.normation.rudder.domain.archives.RuleArchiveId
+import com.normation.rudder.domain.nodes.*
+import com.normation.rudder.domain.policies.*
+import com.normation.rudder.domain.properties.*
+import com.normation.rudder.rule.category.*
+import com.normation.rudder.tenants.*
+import com.softwaremill.quicklens.*
+import com.unboundid.ldif.LDIFChangeRecord
+import java.time.Instant
+import scala.collection.immutable.SortedMap
+import zio.*
+
+/*
+ * This file contains the tenant filtering logic for technique, directive, rule, group, parameter repositories.
+ * The main idea:
+ *   - for all read operation, we post-filter all objects with the tenant scoping
+ *   - for all write operation:
+ *       - we check for an existing with object to see what tenants it could get,
+ *       - then we check for see, and for write
+ */
+
+// ----- Directives -----------------------------------
+
+class RoTenantDirectiveRepo(
+    checkTenant: TenantCheckLogic,
+    underlying:  RoDirectiveRepository
+) extends RoDirectiveRepository {
+
+  private def filterFATC(c: FullActiveTechniqueCategory)(using qc: QueryContext): Option[FullActiveTechniqueCategory] = {
+    checkTenant
+      .check(c)
+      .map { cat =>
+        cat
+          .modify(_.subCategories)
+          .setTo(cat.subCategories.flatMap(filterFATC))
+          .modify(_.activeTechniques)
+          .setTo(checkTenant.collect(cat.activeTechniques) { at =>
+            at.modify(_.directives).setTo(checkTenant.filter(at.directives))
+          })
+      }
+  }
+
+  override def getFullDirectiveLibrary()(using qc: QueryContext): IOResult[FullActiveTechniqueCategory] = {
+    underlying
+      .getFullDirectiveLibrary()
+      .map(filterFATC)
+      .notOptional(s"Root directive library category is not visible by '${qc.actor.name}'")
+  }
+
+  override def getDirective(directiveId: DirectiveUid)(using qc: QueryContext): IOResult[Option[Directive]] = {
+    underlying.getDirective(directiveId).map(checkTenant.flatMap(_))
+  }
+
+  override def getDirectiveWithContext(
+      directiveId: DirectiveUid
+  )(using qc: QueryContext): IOResult[Option[(Technique, ActiveTechnique, Directive)]] = {
+    underlying.getDirectiveWithContext(directiveId).map {
+      case None          => None
+      // we don't check technique, only active technique. The technique at that level doesn't hold
+      // tenants. It should likely. Like in the yaml, else it's not easy to migrate that part
+      // with archive
+      case Some(a, b, c) => checkTenant.check(b).zip(checkTenant.check(c)).map(_ => (a, b, c))
+    }
+  }
+
+  override def getActiveTechniqueAndDirective(
+      id: DirectiveId
+  )(using qc: QueryContext): IOResult[Option[(ActiveTechnique, Directive)]] = {
+    // only check directive
+    underlying.getActiveTechniqueAndDirective(id).map(checkTenant.flatMap(_))
+  }
+
+  override def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean)(using
+      qc: QueryContext
+  ): IOResult[Seq[Directive]] = {
+    underlying.getDirectives(activeTechniqueId, includeSystem).map(checkTenant.filter(_))
+  }
+
+  override def getActiveTechniqueByCategory(
+      includeSystem: Boolean
+  )(using qc: QueryContext): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = {
+    underlying.getActiveTechniqueByCategory(includeSystem).map { map =>
+      implicit val o: Ordering[List[ActiveTechniqueCategoryId]] = ActiveTechniqueCategoryOrdering
+      SortedMap(map.collect {
+        case (path, cwat) if checkTenant.check(cwat.category).isDefined =>
+          path -> cwat.modify(_.templates).setTo(checkTenant.filter(cwat.templates))
+      }.toSeq*)
+    }
+  }
+
+  override def getActiveTechniqueByActiveTechnique(
+      id: ActiveTechniqueId
+  )(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = {
+    underlying.getActiveTechniqueByActiveTechnique(id).map(checkTenant.flatMap(_))
+  }
+
+  override def getActiveTechnique(techniqueName: TechniqueName)(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = {
+    underlying.getActiveTechnique(techniqueName).map(checkTenant.flatMap(_))
+  }
+
+  override def getAllActiveTechniqueCategories(includeSystem: Boolean)(using
+      qc: QueryContext
+  ): IOResult[Seq[ActiveTechniqueCategory]] = {
+    underlying.getAllActiveTechniqueCategories(includeSystem).map(checkTenant.filter(_))
+  }
+
+  override def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[Option[ActiveTechniqueCategory]] = {
+    underlying.getActiveTechniqueCategory(id).map(checkTenant.flatMap(_))
+  }
+
+  // Navigation methods (delegate, tenant filtering would break semantic)
+  override def activeTechniqueBreadCrump(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] =
+    underlying.activeTechniqueBreadCrump(id)
+
+  // active category only has ID for children, we can't filter yet
+  override def getActiveTechniqueLibrary(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
+    underlying.getActiveTechniqueLibrary
+      .map(checkTenant.check(_))
+      .notOptional(
+        s"'${qc.actor}' doesn't have access to root directive category"
+      )
+  }
+
+  override def getParentActiveTechniqueCategory(
+      id: ActiveTechniqueCategoryId
+  )(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
+    underlying
+      .getParentActiveTechniqueCategory(id)
+      .map(checkTenant.check(_))
+      .notOptional(
+        s"'${qc.actor}' doesn't have access to directive category '${id.value}''"
+      )
+  }
+
+  override def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[List[ActiveTechniqueCategory]] = {
+    underlying.getParentsForActiveTechniqueCategory(id).map(checkTenant.filter(_))
+  }
+
+  override def getParentsForActiveTechnique(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
+    underlying
+      .getParentsForActiveTechnique(id)
+      .map(checkTenant.check(_))
+      .notOptional(
+        s"'${qc.actor}' doesn't have access to parent of category '${id.value}''"
+      )
+  }
+
+  override def containsDirective(id: ActiveTechniqueCategoryId): zio.UIO[Boolean] = {
+    underlying.containsDirective(id)
+  }
+}
+
+class WoTenantDirectiveRepo(
+    checkTenant:   TenantCheckLogic,
+    tenantService: TenantService,
+    underlying:    WoDirectiveRepository,
+    roRepo:        RoDirectiveRepository
+) extends RoDirectiveRepository with WoDirectiveRepository {
+
+  // the read part is just delegated to the (tenant-filtering) `roRepo`
+  export roRepo.*
+
+  private def saveInternal(inActiveTechniqueId: ActiveTechniqueId, directive: Directive, system: Boolean)(using
+      cc: ChangeContext
+  ): IOResult[Option[DirectiveSaveDiff]] = {
+    given QueryContext = cc.toQC
+    for {
+      parentAt <- roRepo
+                    .getActiveTechniqueByActiveTechnique(inActiveTechniqueId)
+                    .notOptional(s"Can not find active technique with id '${inActiveTechniqueId.value}'")
+      _        <- cc.accessGrant.canModifyOrFail(parentAt)(ZIO.unit)
+      oldDir   <- roRepo.getActiveTechniqueAndDirective(DirectiveId(directive.id.uid))
+      status   <- tenantService.getStatus
+      result   <- checkTenant.manageUpdate(oldDir.map(_._2), directive, cc, status) { dir =>
+                    if (system) underlying.saveSystemDirective(inActiveTechniqueId, dir)
+                    else underlying.saveDirective(inActiveTechniqueId, dir)
+                  }
+    } yield result
+  }
+
+  override def saveDirective(inActiveTechniqueId: ActiveTechniqueId, directive: Directive)(using
+      cc: ChangeContext
+  ): IOResult[Option[DirectiveSaveDiff]] =
+    saveInternal(inActiveTechniqueId, directive, system = false)
+
+  override def saveSystemDirective(inActiveTechniqueId: ActiveTechniqueId, directive: Directive)(using
+      cc: ChangeContext
+  ): IOResult[Option[DirectiveSaveDiff]] =
+    saveInternal(inActiveTechniqueId, directive, system = true)
+
+  override def delete(id: DirectiveUid)(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = {
+    given QueryContext = cc.toQC
+    for {
+      existing <- roRepo.getActiveTechniqueAndDirective(DirectiveId(id))
+      _        <- ZIO.foreach(existing)(p => checkTenant.checkDelete(p._2, cc).toIO)
+      result   <- underlying.delete(id)
+    } yield result
+  }
+
+  override def deleteSystemDirective(id: DirectiveUid)(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = {
+    given QueryContext = cc.toQC
+    for {
+      existing <- roRepo.getActiveTechniqueAndDirective(DirectiveId(id))
+      _        <- ZIO.foreach(existing)(p => checkTenant.checkDelete(p._2, cc).toIO)
+      result   <- underlying.deleteSystemDirective(id)
+    } yield result
+  }
+
+  override def addTechniqueInUserLibrary(
+      categoryId:    ActiveTechniqueCategoryId,
+      techniqueName: TechniqueName,
+      versions:      Seq[TechniqueVersion],
+      policyTypes:   PolicyTypes
+  )(implicit cc: ChangeContext): IOResult[ActiveTechnique] = {
+    given QueryContext = cc.toQC
+    val probe          = ActiveTechnique(
+      ActiveTechniqueId(techniqueName.value),
+      techniqueName,
+      AcceptationDateTime(Map()),
+      policyTypes = policyTypes,
+      security = None
+    )
+    for {
+      parentCat <- roRepo.getActiveTechniqueCategory(categoryId).notOptional(s"Category '${categoryId.value}' was not found")
+      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      status    <- tenantService.getStatus
+      result    <- checkTenant.manageCreate(probe, cc, status) { _ =>
+                     underlying.addTechniqueInUserLibrary(categoryId, techniqueName, versions, policyTypes)
+                   }
+    } yield result
+  }
+
+  override def move(id: ActiveTechniqueId, newCategoryId: ActiveTechniqueCategoryId)(implicit
+      cc: ChangeContext
+  ): IOResult[ActiveTechniqueId] = {
+    given QueryContext = cc.toQC
+    for {
+      at      <- roRepo.getActiveTechniqueByActiveTechnique(id).notOptional(s"Active technique '${id.value}' was not found")
+      _       <- cc.accessGrant.canModifyOrFail(at)(ZIO.unit)
+      destCat <- roRepo.getActiveTechniqueCategory(newCategoryId).notOptional(s"Category '${newCategoryId.value}' was not found")
+      _       <- cc.accessGrant.canModifyOrFail(destCat)(ZIO.unit)
+      result  <- underlying.move(id, newCategoryId)
+    } yield result
+  }
+
+  override def changeStatus(id: ActiveTechniqueId, status: Boolean)(implicit cc: ChangeContext): IOResult[ActiveTechniqueId] = {
+    given QueryContext = cc.toQC
+    for {
+      at     <- roRepo.getActiveTechniqueByActiveTechnique(id).notOptional(s"Active technique '${id.value}' was not found")
+      _      <- cc.accessGrant.canModifyOrFail(at)(ZIO.unit)
+      result <- underlying.changeStatus(id, status)
+    } yield result
+  }
+
+  override def setAcceptationDatetimes(id: ActiveTechniqueId, datetimes: Map[TechniqueVersion, Instant])(implicit
+      cc: ChangeContext
+  ): IOResult[ActiveTechniqueId] = {
+    given QueryContext = cc.toQC
+    for {
+      at     <- roRepo.getActiveTechniqueByActiveTechnique(id).notOptional(s"Active technique '${id.value}' was not found")
+      _      <- cc.accessGrant.canModifyOrFail(at)(ZIO.unit)
+      result <- underlying.setAcceptationDatetimes(id, datetimes)
+    } yield result
+  }
+
+  override def deleteActiveTechnique(id: ActiveTechniqueId)(using cc: ChangeContext): IOResult[ActiveTechniqueId] = {
+    given QueryContext = cc.toQC
+    for {
+      existing <- roRepo.getActiveTechniqueByActiveTechnique(id)
+      _        <- ZIO.foreach(existing)(at => checkTenant.checkDelete(at, cc).toIO)
+      result   <- underlying.deleteActiveTechnique(id)
+    } yield result
+  }
+
+  override def addActiveTechniqueCategory(that: ActiveTechniqueCategory, into: ActiveTechniqueCategoryId)(implicit
+      cc: ChangeContext
+  ): IOResult[ActiveTechniqueCategory] = {
+    given QueryContext = cc.toQC
+    for {
+      parentCat <- roRepo.getActiveTechniqueCategory(into).notOptional(s"Category '${into.value}' was not found")
+      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      status    <- tenantService.getStatus
+      result    <- checkTenant.manageCreate(that, cc, status)(cat => underlying.addActiveTechniqueCategory(cat, into))
+    } yield result
+  }
+
+  override def saveActiveTechniqueCategory(category: ActiveTechniqueCategory)(implicit
+      cc: ChangeContext
+  ): IOResult[ActiveTechniqueCategory] = {
+    given QueryContext = cc.toQC
+    for {
+      old    <- roRepo.getActiveTechniqueCategory(category.id).notOptional(s"Category '${category.id.value}' was not found")
+      status <- tenantService.getStatus
+      result <- checkTenant.manageUpdate(Some(old), category, cc, status)(cat => underlying.saveActiveTechniqueCategory(cat))
+    } yield result
+  }
+
+  override def deleteCategory(id: ActiveTechniqueCategoryId, checkEmpty: Boolean)(implicit
+      cc: ChangeContext
+  ): IOResult[ActiveTechniqueCategoryId] = {
+    given QueryContext = cc.toQC
+    for {
+      existing <- roRepo.getActiveTechniqueCategory(id)
+      _        <- ZIO.foreach(existing)(cat => checkTenant.checkDelete(cat, cc).toIO)
+      result   <- underlying.deleteCategory(id, checkEmpty)
+    } yield result
+  }
+
+  override def move(
+      categoryId:    ActiveTechniqueCategoryId,
+      intoParent:    ActiveTechniqueCategoryId,
+      optionNewName: Option[ActiveTechniqueCategoryId]
+  )(implicit cc: ChangeContext): IOResult[ActiveTechniqueCategoryId] = {
+    given QueryContext = cc.toQC
+    for {
+      cat       <- roRepo.getActiveTechniqueCategory(categoryId).notOptional(s"Category '${categoryId.value}' was not found")
+      _         <- cc.accessGrant.canModifyOrFail(cat)(ZIO.unit)
+      parentCat <- roRepo.getActiveTechniqueCategory(intoParent).notOptional(s"Category '${intoParent.value}' was not found")
+      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      result    <- underlying.move(categoryId, intoParent, optionNewName)
+    } yield result
+  }
+}
+
+// ----- Groups -----------------------------------
+
+class RoTenantNodeGroupRepo(
+    checkTenant: TenantCheckLogic,
+    underlying:  RoNodeGroupRepository
+) extends RoNodeGroupRepository {
+
+  private def filterFNGC(c: FullNodeGroupCategory)(using qc: QueryContext): Option[FullNodeGroupCategory] = {
+    checkTenant
+      .check(c)
+      .map { cat =>
+        cat
+          .modify(_.subCategories)
+          .setTo(cat.subCategories.flatMap(filterFNGC))
+          .modify(_.targetInfos)
+          .setTo(checkTenant.filter(cat.targetInfos))
+      }
+  }
+
+  override def getFullGroupLibrary()(implicit qc: QueryContext): IOResult[FullNodeGroupCategory] = {
+    underlying
+      .getFullGroupLibrary()
+      .map(filterFNGC)
+      .notOptional(s"Root group library category is not visible by '${qc.actor.name}'")
+  }
+
+  override def getNodeGroupOpt(id: NodeGroupId)(implicit qc: QueryContext): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] = {
+    // only the group holds a security tag, the category id does not
+    underlying.getNodeGroupOpt(id).map(_.flatMap { case (g, c) => checkTenant.check(g).map(_ => (g, c)) })
+  }
+
+  override def getAll()(using qc: QueryContext): IOResult[Seq[NodeGroup]] =
+    underlying.getAll().map(checkTenant.filter(_))
+
+  override def getAllByIds(ids: Seq[NodeGroupId])(using qc: QueryContext): IOResult[Seq[NodeGroup]] =
+    underlying.getAllByIds(ids).map(checkTenant.filter(_))
+
+  override def getAllNodeIds()(using qc: QueryContext): IOResult[Map[NodeGroupId, Set[NodeId]]] =
+    underlying.getAll().map(gs => checkTenant.collect(gs)(g => g.id -> g.serverList).toMap)
+
+  override def getAllNodeIdsChunk()(using qc: QueryContext): IOResult[Map[NodeGroupId, Chunk[NodeId]]] =
+    underlying.getAll().map(gs => checkTenant.collect(gs)(g => g.id -> Chunk.fromIterable(g.serverList)).toMap)
+
+  override def getAllGroupCategories(includeSystem: Boolean)(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] =
+    underlying.getAllGroupCategories(includeSystem).map(checkTenant.filter(_))
+
+  override def getAllNonSystemCategories()(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] =
+    underlying.getAllNonSystemCategories().map(checkTenant.filter(_))
+
+  override def getGroupsByCategory(
+      includeSystem: Boolean
+  )(implicit qc: QueryContext): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = {
+    underlying.getGroupsByCategory(includeSystem).map { map =>
+      implicit val o: Ordering[List[NodeGroupCategoryId]] = NodeGroupCategoryOrdering
+      SortedMap(map.collect {
+        case (path, cag) if checkTenant.check(cag.category).isDefined =>
+          path -> cag.modify(_.groups).setTo(checkTenant.filter(cag.groups))
+      }.toSeq*)
+    }
+  }
+
+  override def findGroupWithAnyMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]] = {
+    underlying.findGroupWithAnyMember(nodeIds).flatMap { ids =>
+      ZIO.filter(ids)(id => underlying.getNodeGroupOpt(id).map(_.exists(g => checkTenant.check(g._1).isDefined)))
+    }
+  }
+
+  override def findGroupWithAllMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]] = {
+    underlying.findGroupWithAllMember(nodeIds).flatMap { ids =>
+      ZIO.filter(ids)(id => underlying.getNodeGroupOpt(id).map(_.exists(g => checkTenant.check(g._1).isDefined)))
+    }
+  }
+
+  override def getCategoryHierarchy(using qc: QueryContext): IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = {
+    underlying.getCategoryHierarchy.map { map =>
+      implicit val o: Ordering[List[NodeGroupCategoryId]] = GroupCategoryRepositoryOrdering
+      SortedMap(map.filter { case (_, cat) => checkTenant.check(cat).isDefined }.toSeq*)
+    }
+  }
+
+  override def categoryExists(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean] =
+    underlying.categoryExists(id)
+
+  override def getNodeGroupCategory(id: NodeGroupId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
+    underlying
+      .getNodeGroupCategory(id)
+      .map(checkTenant.check(_))
+      .notOptional(s"'${qc.actor.name}' doesn't have access to the parent category of group '${id.serialize}'")
+  }
+
+  override def getGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
+    underlying
+      .getGroupCategory(id)
+      .map(checkTenant.check(_))
+      .notOptional(s"'${qc.actor.name}' doesn't have access to group category '${id.value}'")
+  }
+
+  override def getParentGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
+    underlying
+      .getParentGroupCategory(id)
+      .map(checkTenant.check(_))
+      .notOptional(s"'${qc.actor.name}' doesn't have access to the parent of group category '${id.value}'")
+  }
+
+  override def getParents_NodeGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[List[NodeGroupCategory]] =
+    underlying.getParents_NodeGroupCategory(id).map(checkTenant.filter(_))
+
+  // deprecated method returning a plain value: the root category is always visible (`Open`), so delegate
+  override def getRootCategory()(using qc: QueryContext): NodeGroupCategory =
+    underlying.getRootCategory()
+
+  override def getRootCategoryPure()(using qc: QueryContext): IOResult[NodeGroupCategory] = {
+    underlying
+      .getRootCategoryPure()
+      .map(checkTenant.check(_))
+      .notOptional(s"'${qc.actor.name}' doesn't have access to the root group category")
+  }
+}
+
+class WoTenantNodeGroupRepo(
+    checkTenant:   TenantCheckLogic,
+    tenantService: TenantService,
+    underlying:    WoNodeGroupRepository,
+    roRepo:        RoNodeGroupRepository
+) extends RoNodeGroupRepository with WoNodeGroupRepository {
+
+  // the read part is just delegated to the (tenant-filtering) `roRepo`
+  export roRepo.*
+
+  override def create(nodeGroup: NodeGroup, into: NodeGroupCategoryId)(implicit cc: ChangeContext): IOResult[AddNodeGroupDiff] = {
+    given QueryContext = cc.toQC
+    for {
+      parentCat <- roRepo.getGroupCategory(into)
+      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      status    <- tenantService.getStatus
+      result    <- checkTenant.manageCreate(nodeGroup, cc, status)(ng => underlying.create(ng, into))
+    } yield result
+  }
+
+  override def update(nodeGroup: NodeGroup)(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]] = {
+    for {
+      existingOpt <- roRepo.getNodeGroupOpt(nodeGroup.id)(using cc.toQC)
+      status      <- tenantService.getStatus
+      result      <- checkTenant.manageUpdate(existingOpt.map(_._1), nodeGroup, cc, status)(ng => underlying.update(ng))
+    } yield result
+  }
+
+  override def updateSystemGroup(nodeGroup: NodeGroup)(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]] = {
+    for {
+      existingOpt <- roRepo.getNodeGroupOpt(nodeGroup.id)(using cc.toQC)
+      status      <- tenantService.getStatus
+      result      <- checkTenant.manageUpdate(existingOpt.map(_._1), nodeGroup, cc, status)(ng => underlying.updateSystemGroup(ng))
+    } yield result
+  }
+
+  override def updateDynGroupNodes(group: NodeGroup)(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]] = {
+    for {
+      existingOpt <- roRepo.getNodeGroupOpt(group.id)(using cc.toQC)
+      status      <- tenantService.getStatus
+      result      <- checkTenant.manageUpdate(existingOpt.map(_._1), group, cc, status)(ng => underlying.updateDynGroupNodes(ng))
+    } yield result
+  }
+
+  override def updateDiffNodes(
+      nodeGroupId: NodeGroupId,
+      add:         List[NodeId],
+      delete:      List[NodeId]
+  )(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]] = {
+    for {
+      existingOpt <- roRepo.getNodeGroupOpt(nodeGroupId)(using cc.toQC)
+      result      <- existingOpt match {
+                       case None           => underlying.updateDiffNodes(nodeGroupId, add, delete)
+                       case Some((old, _)) =>
+                         val newGroup = old.modify(_.serverList).setTo((old.serverList -- delete) ++ add)
+                         for {
+                           status <- tenantService.getStatus
+                           r      <- checkTenant.manageUpdate(Some(old), newGroup, cc, status) { _ =>
+                                       underlying.updateDiffNodes(nodeGroupId, add, delete)
+                                     }
+                         } yield r
+                     }
+    } yield result
+  }
+
+  override def move(nodeGroupId: NodeGroupId, containerId: NodeGroupCategoryId)(implicit
+      cc: ChangeContext
+  ): IOResult[Option[ModifyNodeGroupDiff]] = {
+    given QueryContext = cc.toQC
+    for {
+      existingOpt <- roRepo.getNodeGroupOpt(nodeGroupId)
+      existing    <- existingOpt.map(_._1).notOptional(s"Group ${nodeGroupId.serialize} not found")
+      _           <- cc.accessGrant.canModifyOrFail(existing)(ZIO.unit)
+      destCat     <- roRepo.getGroupCategory(containerId)
+      _           <- cc.accessGrant.canModifyOrFail(destCat)(ZIO.unit)
+      result      <- underlying.move(nodeGroupId, containerId)
+    } yield result
+  }
+
+  override def delete(id: NodeGroupId)(implicit cc: ChangeContext): IOResult[DeleteNodeGroupDiff] = {
+    given QueryContext = cc.toQC
+    for {
+      existingOpt <- roRepo.getNodeGroupOpt(id)
+      existing    <- existingOpt.map(_._1).notOptional(s"Group ${id.serialize} not found")
+      _           <- checkTenant.checkDelete(existing, cc).toIO
+      result      <- underlying.delete(id)
+    } yield result
+  }
+
+  override def addGroupCategoryToCategory(that: NodeGroupCategory, into: NodeGroupCategoryId)(implicit
+      cc: ChangeContext
+  ): IOResult[NodeGroupCategory] = {
+    given QueryContext = cc.toQC
+    for {
+      parent <- roRepo.getGroupCategory(into)
+      _      <- cc.accessGrant.canModifyOrFail(parent)(ZIO.unit)
+      status <- tenantService.getStatus
+      result <- checkTenant.manageUpdate[NodeGroupCategory, NodeGroupCategory, NodeGroupCategory](None, that, cc, status) { cat =>
+                  underlying.addGroupCategoryToCategory(cat, into)
+                }
+    } yield result
+  }
+
+  override def saveGroupCategory(category: NodeGroupCategory)(implicit cc: ChangeContext): IOResult[NodeGroupCategory] = {
+    given QueryContext = cc.toQC
+    for {
+      old    <- roRepo.getGroupCategory(category.id)
+      _      <- cc.accessGrant.canModifyOrFail(old)(ZIO.unit)
+      status <- tenantService.getStatus
+      result <- checkTenant.manageUpdate(Some(old), category, cc, status)(cat => underlying.saveGroupCategory(cat))
+    } yield result
+  }
+
+  override def saveGroupCategory(category: NodeGroupCategory, containerId: NodeGroupCategoryId)(implicit
+      cc: ChangeContext
+  ): IOResult[NodeGroupCategory] =
+    underlying.saveGroupCategory(category, containerId)
+
+  override def delete(id: NodeGroupCategoryId, checkEmpty: Boolean)(implicit
+      cc: ChangeContext
+  ): IOResult[NodeGroupCategoryId] = {
+    given QueryContext = cc.toQC
+    for {
+      catOpt <- roRepo.getGroupCategory(id).option
+      _      <- ZIO.foreach(catOpt)(cat => checkTenant.checkDelete(cat, cc).toIO)
+      result <- underlying.delete(id, checkEmpty)
+    } yield result
+  }
+
+  override def createPolicyServerTarget(target: PolicyServerTarget)(implicit cc: ChangeContext): IOResult[LDIFChangeRecord] =
+    underlying.createPolicyServerTarget(target)
+
+  override def deletePolicyServerTarget(
+      policyServer: PolicyServerTarget
+  )(implicit cc: ChangeContext): IOResult[PolicyServerTarget] =
+    underlying.deletePolicyServerTarget(policyServer)
+}
+
+// ----- Rules -----------------------------------
+
+class RoTenantRuleRepo(
+    checkTenant: TenantCheckLogic,
+    underlying:  RoRuleRepository
+) extends RoRuleRepository {
+
+  override def getOpt(ruleId: RuleId)(using qc: QueryContext): IOResult[Option[Rule]] = {
+    for {
+      r <- underlying.getOpt(ruleId)
+
+      x = checkTenant.flatMap(r)
+    } yield x
+  }
+
+  override def getAll(includeSystem: Boolean)(using qc: QueryContext): IOResult[Seq[Rule]] =
+    underlying.getAll(includeSystem).map(checkTenant.filter(_))
+
+  override def getIds(includeSystem: Boolean)(using qc: QueryContext): IOResult[Set[RuleId]] =
+    getAll(includeSystem).map(_.map(_.id).toSet)
+}
+
+class WoTenantRuleRepo(
+    checkTenant:   TenantCheckLogic,
+    tenantService: TenantService,
+    underlying:    WoRuleRepository,
+    roRepo:        RoRuleRepository
+) extends RoRuleRepository with WoRuleRepository {
+
+  // the read part is just delegated to the (tenant-filtering) `roRepo`
+  export roRepo.*
+
+  override def create(rule: Rule)(using cc: ChangeContext): IOResult[AddRuleDiff] = {
+    for {
+      status <- tenantService.getStatus
+      result <- checkTenant.manageCreate(rule, cc, status)(r => underlying.create(r))
+    } yield result
+  }
+
+  override def update(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]] = {
+    for {
+      existing <- roRepo.getOpt(rule.id)(using cc.toQC)
+      status   <- tenantService.getStatus
+      result   <- checkTenant.manageUpdate(existing, rule, cc, status)(r => underlying.update(r))
+    } yield result
+  }
+
+  override def updateSystem(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]] = {
+    for {
+      existing <- roRepo.getOpt(rule.id)(using cc.toQC)
+      status   <- tenantService.getStatus
+      result   <- checkTenant.manageUpdate(existing, rule, cc, status)(r => underlying.updateSystem(r))
+    } yield result
+  }
+
+  override def load(rule: Rule)(using cc: ChangeContext): IOResult[Unit] = {
+    for {
+      existing <- roRepo.getOpt(rule.id)(using cc.toQC)
+      status   <- tenantService.getStatus
+      result   <- checkTenant.manageUpdate(existing, rule, cc, status)(r => underlying.load(r))
+    } yield result
+  }
+
+  override def unload(ruleId: RuleId)(using cc: ChangeContext): IOResult[Unit] = {
+    for {
+      existing <- roRepo.getOpt(ruleId)(using cc.toQC)
+      _        <- ZIO.foreach(existing)(r => checkTenant.checkDelete(r, cc).toIO)
+      result   <- underlying.unload(ruleId)
+    } yield result
+  }
+
+  override def delete(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
+    for {
+      existing <- roRepo.getOpt(id)(using cc.toQC)
+      _        <- ZIO.foreach(existing)(r => checkTenant.checkDelete(r, cc).toIO)
+      result   <- underlying.delete(id)
+    } yield result
+  }
+
+  override def deleteSystemRule(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
+    for {
+      existing <- roRepo.getOpt(id)(using cc.toQC)
+      _        <- ZIO.foreach(existing)(r => checkTenant.checkDelete(r, cc).toIO)
+      result   <- underlying.deleteSystemRule(id)
+    } yield result
+  }
+
+  override def swapRules(newRules: Seq[Rule]): IOResult[RuleArchiveId] =
+    underlying.swapRules(newRules)
+
+  override def deleteSavedRuleArchiveId(saveId: RuleArchiveId): IOResult[Unit] =
+    underlying.deleteSavedRuleArchiveId(saveId)
+}
+
+// ----- Properties -----------------------------------
+
+class RoTenantParameterRepo(
+    checkTenant: TenantCheckLogic,
+    underlying:  RoParameterRepository
+) extends RoParameterRepository {
+
+  override def getGlobalParameter(parameterName: String)(using qc: QueryContext): IOResult[Option[GlobalParameter]] =
+    underlying.getGlobalParameter(parameterName).map(checkTenant.flatMap(_))
+
+  override def getAllGlobalParameters()(using qc: QueryContext): IOResult[Seq[GlobalParameter]] =
+    underlying.getAllGlobalParameters().map(checkTenant.filter(_))
+}
+
+class WoTenantParameterRepo(
+    checkTenant:   TenantCheckLogic,
+    tenantService: TenantService,
+    underlying:    WoParameterRepository,
+    roRepo:        RoParameterRepository
+) extends RoParameterRepository with WoParameterRepository {
+
+  // the read part is just delegated to the (tenant-filtering) `roRepo`
+  export roRepo.*
+
+  override def saveParameter(parameter: GlobalParameter)(using cc: ChangeContext): IOResult[AddGlobalParameterDiff] = {
+    for {
+      status <- tenantService.getStatus
+      result <- checkTenant.manageCreate(parameter, cc, status)(p => underlying.saveParameter(p))
+    } yield result
+  }
+
+  override def updateParameter(
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): IOResult[Option[ModifyGlobalParameterDiff]] = {
+    for {
+      existing <- roRepo.getGlobalParameter(parameter.name)(using cc.toQC)
+      status   <- tenantService.getStatus
+      result   <- checkTenant.manageUpdate(existing, parameter, cc, status)(p => underlying.updateParameter(p))
+    } yield result
+  }
+
+  override def delete(
+      parameterName: String,
+      provider:      Option[PropertyProvider]
+  )(using cc: ChangeContext): IOResult[Option[DeleteGlobalParameterDiff]] = {
+    for {
+      existing <- roRepo.getGlobalParameter(parameterName)(using cc.toQC)
+      _        <- ZIO.foreach(existing)(p => checkTenant.checkDelete(p, cc).toIO)
+      result   <- underlying.delete(parameterName, provider)
+    } yield result
+  }
+
+  override def swapParameters(newParameters: Seq[GlobalParameter]): IOResult[ParameterArchiveId] =
+    underlying.swapParameters(newParameters)
+
+  override def deleteSavedParametersArchiveId(saveId: ParameterArchiveId): IOResult[Unit] =
+    underlying.deleteSavedParametersArchiveId(saveId)
+}
+
+// ----- Rule categories -----------------------------------
+
+class RoTenantRuleCategoryRepo(
+    checkTenant: TenantCheckLogic,
+    underlying:  RoRuleCategoryRepository
+) extends RoRuleCategoryRepository {
+
+  // recursively prune the children the current security context can not see; the root category
+  // itself is always kept (it is the library root, like the other configuration object libraries).
+  private def filterTree(cat: RuleCategory)(using qc: QueryContext): RuleCategory = {
+    cat.modify(_.childs).setTo(cat.childs.collect { case c if qc.accessGrant.canSee(c.security) => filterTree(c) })
+  }
+
+  override def get(id: RuleCategoryId)(using qc: QueryContext): IOResult[RuleCategory] =
+    underlying.get(id)
+
+  override def getRootCategory()(using qc: QueryContext): IOResult[RuleCategory] =
+    underlying.getRootCategory().map(filterTree)
+}
+
+class WoTenantRuleCategoryRepo(
+    checkTenant:   TenantCheckLogic,
+    tenantService: TenantService,
+    underlying:    WoRuleCategoryRepository,
+    roRepo:        RoRuleCategoryRepository
+) extends RoRuleCategoryRepository with WoRuleCategoryRepository {
+
+  // the read part is just delegated to the (tenant-filtering) `roRepo`
+  export roRepo.*
+
+  override def create(that: RuleCategory, into: RuleCategoryId)(implicit cc: ChangeContext): IOResult[RuleCategory] = {
+    given QueryContext = cc.toQC
+    for {
+      parent <- roRepo.get(into)
+      _      <- cc.accessGrant.canModifyOrFail(parent)(ZIO.unit)
+      status <- tenantService.getStatus
+      result <- checkTenant.manageCreate(that, cc, status)(cat => underlying.create(cat, into))
+    } yield result
+  }
+
+  override def updateAndMove(that: RuleCategory, into: RuleCategoryId)(implicit cc: ChangeContext): IOResult[RuleCategory] = {
+    given QueryContext = cc.toQC
+    for {
+      old    <- roRepo.get(that.id)
+      parent <- roRepo.get(into)
+      _      <- cc.accessGrant.canModifyOrFail(parent)(ZIO.unit)
+      status <- tenantService.getStatus
+      result <- checkTenant.manageUpdate(Some(old), that, cc, status)(cat => underlying.updateAndMove(cat, into))
+    } yield result
+  }
+
+  override def delete(category: RuleCategoryId, checkEmpty: Boolean)(implicit cc: ChangeContext): IOResult[RuleCategoryId] = {
+    given QueryContext = cc.toQC
+    for {
+      old    <- roRepo.get(category).option
+      _      <- ZIO.foreach(old)(cat => checkTenant.checkDelete(cat, cc).toIO)
+      result <- underlying.delete(category, checkEmpty)
+    } yield result
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
@@ -62,6 +62,19 @@ import zio.*
  *       - then we check for see, and for write
  */
 
+/*
+ * Note on authorization: repositories never reach into `cc.accessGrant.*` directly. All tenant and system
+ * authorization decisions go through the `TenantCheckLogic` service (`checkTenant`):
+ *   - `checkModify(obj, cc)`      : the actor may change/move `obj` (tenant write-visibility + system-admin-only),
+ *   - `checkWriteInto(cont, cc)`  : the actor may create/move children under container `cont` (tenant
+ *                                   write-visibility only - NOT system-gated, so objects can be created under
+ *                                   the shared/system root categories),
+ *   - `checkAdmin(cc)`            : admin-only operations that have no object to check (e.g. policy server targets),
+ *   - `manageCreate`/`manageUpdate`/`checkDelete` : the create/update/delete logic, which also enforce the
+ *     system-object admin-only rule (a system object can only be managed by an all-tenants grant, because a
+ *     change to a shared/global object can affect other tenants).
+ */
+
 // ----- Directives -----------------------------------
 
 class RoTenantDirectiveRepo(
@@ -215,7 +228,7 @@ class WoTenantDirectiveRepo(
       parentAt <- roRepo
                     .getActiveTechniqueByActiveTechnique(inActiveTechniqueId)
                     .notOptional(s"Can not find active technique with id '${inActiveTechniqueId.value}'")
-      _        <- cc.accessGrant.canModifyOrFail(parentAt)(ZIO.unit)
+      _        <- checkTenant.checkWriteInto(parentAt, cc)
       oldDir   <- roRepo.getActiveTechniqueAndDirective(DirectiveId(directive.id.uid))
       status   <- tenantService.getStatus
       result   <- checkTenant.manageUpdate(oldDir.map(_._2), directive, cc, status) { dir =>
@@ -239,8 +252,12 @@ class WoTenantDirectiveRepo(
     given QueryContext = cc.toQC
     for {
       existing <- roRepo.getActiveTechniqueAndDirective(DirectiveId(id))
-      _        <- ZIO.foreach(existing)(p => checkTenant.checkDelete(p._2, cc).toIO)
-      result   <- underlying.delete(id)
+      // fail-closed: `roRepo` is tenant-filtered, so a `None` means the object is absent OR invisible to the
+      // actor. In both cases we must not delete through the underlying repo.
+      result   <- existing match {
+                    case None    => ZIO.none
+                    case Some(p) => checkTenant.checkDelete(p._2, cc).toIO *> underlying.delete(id)
+                  }
     } yield result
   }
 
@@ -248,8 +265,10 @@ class WoTenantDirectiveRepo(
     given QueryContext = cc.toQC
     for {
       existing <- roRepo.getActiveTechniqueAndDirective(DirectiveId(id))
-      _        <- ZIO.foreach(existing)(p => checkTenant.checkDelete(p._2, cc).toIO)
-      result   <- underlying.deleteSystemDirective(id)
+      result   <- existing match {
+                    case None    => ZIO.none
+                    case Some(p) => checkTenant.checkDelete(p._2, cc).toIO *> underlying.deleteSystemDirective(id)
+                  }
     } yield result
   }
 
@@ -269,7 +288,7 @@ class WoTenantDirectiveRepo(
     )
     for {
       parentCat <- roRepo.getActiveTechniqueCategory(categoryId).notOptional(s"Category '${categoryId.value}' was not found")
-      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      _         <- checkTenant.checkWriteInto(parentCat, cc)
       status    <- tenantService.getStatus
       result    <- checkTenant.manageCreate(probe, cc, status) { _ =>
                      underlying.addTechniqueInUserLibrary(categoryId, techniqueName, versions, policyTypes)
@@ -283,9 +302,9 @@ class WoTenantDirectiveRepo(
     given QueryContext = cc.toQC
     for {
       at      <- roRepo.getActiveTechniqueByActiveTechnique(id).notOptional(s"Active technique '${id.value}' was not found")
-      _       <- cc.accessGrant.canModifyOrFail(at)(ZIO.unit)
+      _       <- checkTenant.checkModify(at, cc)
       destCat <- roRepo.getActiveTechniqueCategory(newCategoryId).notOptional(s"Category '${newCategoryId.value}' was not found")
-      _       <- cc.accessGrant.canModifyOrFail(destCat)(ZIO.unit)
+      _       <- checkTenant.checkWriteInto(destCat, cc)
       result  <- underlying.move(id, newCategoryId)
     } yield result
   }
@@ -294,7 +313,7 @@ class WoTenantDirectiveRepo(
     given QueryContext = cc.toQC
     for {
       at     <- roRepo.getActiveTechniqueByActiveTechnique(id).notOptional(s"Active technique '${id.value}' was not found")
-      _      <- cc.accessGrant.canModifyOrFail(at)(ZIO.unit)
+      _      <- checkTenant.checkModify(at, cc)
       result <- underlying.changeStatus(id, status)
     } yield result
   }
@@ -305,7 +324,7 @@ class WoTenantDirectiveRepo(
     given QueryContext = cc.toQC
     for {
       at     <- roRepo.getActiveTechniqueByActiveTechnique(id).notOptional(s"Active technique '${id.value}' was not found")
-      _      <- cc.accessGrant.canModifyOrFail(at)(ZIO.unit)
+      _      <- checkTenant.checkModify(at, cc)
       result <- underlying.setAcceptationDatetimes(id, datetimes)
     } yield result
   }
@@ -313,8 +332,9 @@ class WoTenantDirectiveRepo(
   override def deleteActiveTechnique(id: ActiveTechniqueId)(using cc: ChangeContext): IOResult[ActiveTechniqueId] = {
     given QueryContext = cc.toQC
     for {
-      existing <- roRepo.getActiveTechniqueByActiveTechnique(id)
-      _        <- ZIO.foreach(existing)(at => checkTenant.checkDelete(at, cc).toIO)
+      // fail-closed: refuse to delete an active technique the actor can't see (`roRepo` is tenant-filtered)
+      existing <- roRepo.getActiveTechniqueByActiveTechnique(id).notOptional(s"Active technique '${id.value}' was not found")
+      _        <- checkTenant.checkDelete(existing, cc).toIO
       result   <- underlying.deleteActiveTechnique(id)
     } yield result
   }
@@ -325,7 +345,7 @@ class WoTenantDirectiveRepo(
     given QueryContext = cc.toQC
     for {
       parentCat <- roRepo.getActiveTechniqueCategory(into).notOptional(s"Category '${into.value}' was not found")
-      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      _         <- checkTenant.checkWriteInto(parentCat, cc)
       status    <- tenantService.getStatus
       result    <- checkTenant.manageCreate(that, cc, status)(cat => underlying.addActiveTechniqueCategory(cat, into))
     } yield result
@@ -347,8 +367,9 @@ class WoTenantDirectiveRepo(
   ): IOResult[ActiveTechniqueCategoryId] = {
     given QueryContext = cc.toQC
     for {
-      existing <- roRepo.getActiveTechniqueCategory(id)
-      _        <- ZIO.foreach(existing)(cat => checkTenant.checkDelete(cat, cc).toIO)
+      // fail-closed: refuse to delete a category the actor can't see (`roRepo` is tenant-filtered)
+      existing <- roRepo.getActiveTechniqueCategory(id).notOptional(s"Category '${id.value}' was not found")
+      _        <- checkTenant.checkDelete(existing, cc).toIO
       result   <- underlying.deleteCategory(id, checkEmpty)
     } yield result
   }
@@ -361,9 +382,9 @@ class WoTenantDirectiveRepo(
     given QueryContext = cc.toQC
     for {
       cat       <- roRepo.getActiveTechniqueCategory(categoryId).notOptional(s"Category '${categoryId.value}' was not found")
-      _         <- cc.accessGrant.canModifyOrFail(cat)(ZIO.unit)
+      _         <- checkTenant.checkModify(cat, cc)
       parentCat <- roRepo.getActiveTechniqueCategory(intoParent).notOptional(s"Category '${intoParent.value}' was not found")
-      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      _         <- checkTenant.checkWriteInto(parentCat, cc)
       result    <- underlying.move(categoryId, intoParent, optionNewName)
     } yield result
   }
@@ -502,7 +523,7 @@ class WoTenantNodeGroupRepo(
     given QueryContext = cc.toQC
     for {
       parentCat <- roRepo.getGroupCategory(into)
-      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      _         <- checkTenant.checkWriteInto(parentCat, cc)
       status    <- tenantService.getStatus
       result    <- checkTenant.manageCreate(nodeGroup, cc, status)(ng => underlying.create(ng, into))
     } yield result
@@ -560,9 +581,9 @@ class WoTenantNodeGroupRepo(
     for {
       existingOpt <- roRepo.getNodeGroupOpt(nodeGroupId)
       existing    <- existingOpt.map(_._1).notOptional(s"Group ${nodeGroupId.serialize} not found")
-      _           <- cc.accessGrant.canModifyOrFail(existing)(ZIO.unit)
+      _           <- checkTenant.checkModify(existing, cc)
       destCat     <- roRepo.getGroupCategory(containerId)
-      _           <- cc.accessGrant.canModifyOrFail(destCat)(ZIO.unit)
+      _           <- checkTenant.checkWriteInto(destCat, cc)
       result      <- underlying.move(nodeGroupId, containerId)
     } yield result
   }
@@ -583,7 +604,7 @@ class WoTenantNodeGroupRepo(
     given QueryContext = cc.toQC
     for {
       parent <- roRepo.getGroupCategory(into)
-      _      <- cc.accessGrant.canModifyOrFail(parent)(ZIO.unit)
+      _      <- checkTenant.checkWriteInto(parent, cc)
       status <- tenantService.getStatus
       result <- checkTenant.manageUpdate[NodeGroupCategory, NodeGroupCategory, NodeGroupCategory](None, that, cc, status) { cat =>
                   underlying.addGroupCategoryToCategory(cat, into)
@@ -595,7 +616,6 @@ class WoTenantNodeGroupRepo(
     given QueryContext = cc.toQC
     for {
       old    <- roRepo.getGroupCategory(category.id)
-      _      <- cc.accessGrant.canModifyOrFail(old)(ZIO.unit)
       status <- tenantService.getStatus
       result <- checkTenant.manageUpdate(Some(old), category, cc, status)(cat => underlying.saveGroupCategory(cat))
     } yield result
@@ -603,27 +623,31 @@ class WoTenantNodeGroupRepo(
 
   override def saveGroupCategory(category: NodeGroupCategory, containerId: NodeGroupCategoryId)(implicit
       cc: ChangeContext
-  ): IOResult[NodeGroupCategory] =
-    underlying.saveGroupCategory(category, containerId)
+  ): IOResult[NodeGroupCategory] = {
+    checkTenant.checkModify(category, cc) *> underlying.saveGroupCategory(category, containerId)
+  }
 
   override def delete(id: NodeGroupCategoryId, checkEmpty: Boolean)(implicit
       cc: ChangeContext
   ): IOResult[NodeGroupCategoryId] = {
     given QueryContext = cc.toQC
     for {
-      catOpt <- roRepo.getGroupCategory(id).option
-      _      <- ZIO.foreach(catOpt)(cat => checkTenant.checkDelete(cat, cc).toIO)
+      // fail-closed: `getGroupCategory` (tenant-filtered) fails if the category is absent or invisible,
+      // so we never delete a category the actor can't see
+      cat    <- roRepo.getGroupCategory(id)
+      _      <- checkTenant.checkDelete(cat, cc).toIO
       result <- underlying.delete(id, checkEmpty)
     } yield result
   }
 
+  // a policy server target is a system topology object: only an administrator may create or delete it
   override def createPolicyServerTarget(target: PolicyServerTarget)(implicit cc: ChangeContext): IOResult[LDIFChangeRecord] =
-    underlying.createPolicyServerTarget(target)
+    checkTenant.checkAdmin(cc) *> underlying.createPolicyServerTarget(target)
 
   override def deletePolicyServerTarget(
       policyServer: PolicyServerTarget
   )(implicit cc: ChangeContext): IOResult[PolicyServerTarget] =
-    underlying.deletePolicyServerTarget(policyServer)
+    checkTenant.checkAdmin(cc) *> underlying.deletePolicyServerTarget(policyServer)
 }
 
 // ----- Rules -----------------------------------
@@ -664,7 +688,7 @@ class WoTenantRuleRepo(
     for {
       // an object can only be created in a category the user can see and modify
       parentCat <- roRuleCategory.get(rule.categoryId)
-      _         <- cc.accessGrant.canModifyOrFail(parentCat)(ZIO.unit)
+      _         <- checkTenant.checkWriteInto(parentCat, cc)
       status    <- tenantService.getStatus
       result    <- checkTenant.manageCreate(rule, cc, status)(r => underlying.create(r))
     } yield result
@@ -697,23 +721,27 @@ class WoTenantRuleRepo(
   override def unload(ruleId: RuleId)(using cc: ChangeContext): IOResult[Unit] = {
     for {
       existing <- roRepo.getOpt(ruleId)(using cc.toQC)
-      _        <- ZIO.foreach(existing)(r => checkTenant.checkDelete(r, cc).toIO)
-      result   <- underlying.unload(ruleId)
+      // fail-closed: `roRepo` is tenant-filtered, so `None` means absent or invisible - do not touch storage
+      result   <- existing match {
+                    case None    => ZIO.unit
+                    case Some(r) => checkTenant.checkDelete(r, cc).toIO *> underlying.unload(ruleId)
+                  }
     } yield result
   }
 
   override def delete(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
     for {
-      existing <- roRepo.getOpt(id)(using cc.toQC)
-      _        <- ZIO.foreach(existing)(r => checkTenant.checkDelete(r, cc).toIO)
+      // fail-closed: refuse to delete a rule the actor can't see (`roRepo` is tenant-filtered)
+      existing <- roRepo.getOpt(id)(using cc.toQC).notOptional(s"Rule '${id.serialize}' was not found")
+      _        <- checkTenant.checkDelete(existing, cc).toIO
       result   <- underlying.delete(id)
     } yield result
   }
 
   override def deleteSystemRule(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
     for {
-      existing <- roRepo.getOpt(id)(using cc.toQC)
-      _        <- ZIO.foreach(existing)(r => checkTenant.checkDelete(r, cc).toIO)
+      existing <- roRepo.getOpt(id)(using cc.toQC).notOptional(s"Rule '${id.serialize}' was not found")
+      _        <- checkTenant.checkDelete(existing, cc).toIO
       result   <- underlying.deleteSystemRule(id)
     } yield result
   }
@@ -772,8 +800,11 @@ class WoTenantParameterRepo(
   )(using cc: ChangeContext): IOResult[Option[DeleteGlobalParameterDiff]] = {
     for {
       existing <- roRepo.getGlobalParameter(parameterName)(using cc.toQC)
-      _        <- ZIO.foreach(existing)(p => checkTenant.checkDelete(p, cc).toIO)
-      result   <- underlying.delete(parameterName, provider)
+      // fail-closed: `roRepo` is tenant-filtered, so `None` means absent or invisible - do not touch storage
+      result   <- existing match {
+                    case None    => ZIO.none
+                    case Some(p) => checkTenant.checkDelete(p, cc).toIO *> underlying.delete(parameterName, provider)
+                  }
     } yield result
   }
 
@@ -818,7 +849,7 @@ class WoTenantRuleCategoryRepo(
     given QueryContext = cc.toQC
     for {
       parent <- roRepo.get(into)
-      _      <- cc.accessGrant.canModifyOrFail(parent)(ZIO.unit)
+      _      <- checkTenant.checkWriteInto(parent, cc)
       status <- tenantService.getStatus
       result <- checkTenant.manageCreate(that, cc, status)(cat => underlying.create(cat, into))
     } yield result
@@ -828,8 +859,10 @@ class WoTenantRuleCategoryRepo(
     given QueryContext = cc.toQC
     for {
       old    <- roRepo.get(that.id)
+      // guard on both the existing and the submitted category, so a system category can't be edited nor
+      // turned into/out of a system one by a non-admin
       parent <- roRepo.get(into)
-      _      <- cc.accessGrant.canModifyOrFail(parent)(ZIO.unit)
+      _      <- checkTenant.checkWriteInto(parent, cc)
       status <- tenantService.getStatus
       result <- checkTenant.manageUpdate(Some(old), that, cc, status)(cat => underlying.updateAndMove(cat, into))
     } yield result
@@ -838,8 +871,9 @@ class WoTenantRuleCategoryRepo(
   override def delete(category: RuleCategoryId, checkEmpty: Boolean)(implicit cc: ChangeContext): IOResult[RuleCategoryId] = {
     given QueryContext = cc.toQC
     for {
-      old    <- roRepo.get(category).option
-      _      <- ZIO.foreach(old)(cat => checkTenant.checkDelete(cat, cc).toIO)
+      // fail-closed: `get` fails if the category does not exist, and `checkDelete` gates on tenant + system
+      old    <- roRepo.get(category)
+      _      <- checkTenant.checkDelete(old, cc).toIO
       result <- underlying.delete(category, checkEmpty)
     } yield result
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
@@ -47,8 +47,6 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.inventory.ldap.core.LDAPConstants.A_NAME
 import com.normation.inventory.ldap.core.LDAPConstants.A_OC
 import com.normation.inventory.ldap.core.LDAPConstants.A_REV_ID
@@ -72,6 +70,8 @@ import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.WoDirectiveRepository
 import com.normation.rudder.services.user.PersonIdentService
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
+import com.softwaremill.quicklens.*
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Filter
 import java.time.Instant
@@ -123,7 +123,7 @@ class RoLDAPDirectiveRepository(
    * Full((parent,directive)) : found the directive (directive.id == directiveId) in given parent
    *.fail => an error happened.
    */
-  override def getDirective(id: DirectiveUid): IOResult[Option[Directive]] = {
+  override def getDirective(id: DirectiveUid)(using qc: QueryContext): IOResult[Option[Directive]] = {
     userLibMutex.readLock(for {
       con       <- ldap
       optEntry  <- getDirectiveEntry(con, DirectiveId(id))
@@ -141,7 +141,9 @@ class RoLDAPDirectiveRepository(
     })
   }
 
-  override def getDirectiveWithContext(id: DirectiveUid): IOResult[Option[(Technique, ActiveTechnique, Directive)]] = {
+  override def getDirectiveWithContext(
+      id: DirectiveUid
+  )(using qc: QueryContext): IOResult[Option[(Technique, ActiveTechnique, Directive)]] = {
     this
       .getActiveTechniqueAndDirective(DirectiveId(id))
       .chainError(s"Error when retrieving directive with ID ${id.value}''")
@@ -188,7 +190,9 @@ class RoLDAPDirectiveRepository(
    * Return empty if no such directive is known,
    * fails if no active technique match the directive.
    */
-  override def getActiveTechniqueAndDirective(id: DirectiveId): IOResult[Option[(ActiveTechnique, Directive)]] = {
+  override def getActiveTechniqueAndDirective(
+      id: DirectiveId
+  )(using qc: QueryContext): IOResult[Option[(ActiveTechnique, Directive)]] = {
     getActiveTechniqueAndDirectiveEntries(id).chainError("Can not find Active Technique entry in LDAP").flatMap {
       case None                      => None.succeed
       case Some((uptEntry, piEntry)) =>
@@ -212,7 +216,9 @@ class RoLDAPDirectiveRepository(
    * Get directives for given technique.
    * A not known technique id is a.fail.
    */
-  override def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean = false): IOResult[Seq[Directive]] = {
+  override def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean = false)(using
+      qc: QueryContext
+  ): IOResult[Seq[Directive]] = {
     userLibMutex.readLock(for {
       con        <- ldap
       entries    <- getUPTEntry(con, activeTechniqueId, "1.1").flatMap {
@@ -250,7 +256,7 @@ class RoLDAPDirectiveRepository(
   /**
    * Root user categories
    */
-  def getActiveTechniqueLibrary: IOResult[ActiveTechniqueCategory] = {
+  def getActiveTechniqueLibrary(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
     userLibMutex.readLock(for {
       con               <- ldap
       rootCategoryEntry <- con
@@ -275,7 +281,9 @@ class RoLDAPDirectiveRepository(
    * Return all categories (lightweight version, with no children)
    * @return
    */
-  def getAllActiveTechniqueCategories(includeSystem: Boolean = false): IOResult[Seq[ActiveTechniqueCategory]] = {
+  def getAllActiveTechniqueCategories(includeSystem: Boolean = false)(using
+      qc: QueryContext
+  ): IOResult[Seq[ActiveTechniqueCategory]] = {
     userLibMutex.readLock(for {
       con               <- ldap
       rootCategoryEntry <-
@@ -304,7 +312,9 @@ class RoLDAPDirectiveRepository(
   /**
    * Get an active technique by its ID
    */
-  def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[Option[ActiveTechniqueCategory]] = {
+  def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[Option[ActiveTechniqueCategory]] = {
     userLibMutex.readLock(for {
       con      <- ldap
       optEntry <- getCategoryEntry(con, id)
@@ -318,9 +328,9 @@ class RoLDAPDirectiveRepository(
                   .entry2ActiveTechniqueCategory(categoryEntry)
                   .chainError("Error when transforming LDAP entry %s into an active technique category".format(categoryEntry)))
                   .toIO
-              added    <- addSubEntries(category, categoryEntry.dn, con)
+              res      <- addSubEntries(category, categoryEntry.dn, con).map(Some(_))
             } yield {
-              Some(added)
+              res
             }
         }
     } yield {
@@ -374,7 +384,9 @@ class RoLDAPDirectiveRepository(
    * Return empty for root of the hierarchy, fails if the category
    * is not in the repository
    */
-  def getParentActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[ActiveTechniqueCategory] = {
+  def getParentActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[ActiveTechniqueCategory] = {
     userLibMutex.readLock(for {
       con                 <- ldap
       categoryEntry       <- getCategoryEntry(con, id, "1.1").notOptional(s"Entry with ID '${id.value}' was not found")
@@ -397,7 +409,9 @@ class RoLDAPDirectiveRepository(
    * The the last parent is not the root of the library, return a.fail.
    * Also return a.fail if the path to top is broken in any way.
    */
-  def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[List[ActiveTechniqueCategory]] = {
+  def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+      qc: QueryContext
+  ): IOResult[List[ActiveTechniqueCategory]] = {
     userLibMutex.readLock(
       // TODO : LDAPify that, we can have the list of all DN from id to root at the begining (just dn.getParent until rudderDit.ACTIVE_TECHNIQUES_LIB.dn)
       getActiveTechniqueLibrary.flatMap { root =>
@@ -411,7 +425,7 @@ class RoLDAPDirectiveRepository(
     )
   }
 
-  def getParentsForActiveTechnique(id: ActiveTechniqueId): IOResult[ActiveTechniqueCategory] = {
+  def getParentsForActiveTechnique(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
     userLibMutex.readLock(for {
       con        <- ldap
       uptEntries <- con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, EQ(A_ACTIVE_TECHNIQUE_UUID, id.value))
@@ -422,9 +436,10 @@ class RoLDAPDirectiveRepository(
                         s"Found more than one active technique with id '${id.value}' : ${uptEntries.map(_.dn).mkString("; ")}".fail
                     }
       category   <-
-        getActiveTechniqueCategory(mapper.dn2ActiveTechniqueCategoryId(uptEntry.dn.getParent)).notOptional(
-          s"Category '${id.toString}' but we can't find its parent. If it wasn't deleted, please report the problem to Rudder project."
-        )
+        getActiveTechniqueCategory(mapper.dn2ActiveTechniqueCategoryId(uptEntry.dn.getParent))
+          .notOptional(
+            s"Category '${id.toString}' but we can't find its parent. If it wasn't deleted, please report the problem to Rudder project."
+          )
     } yield {
       category
     })
@@ -432,37 +447,36 @@ class RoLDAPDirectiveRepository(
 
   def getActiveTechniqueByCategory(
       includeSystem: Boolean = false
-  ): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = {
+  )(using qc: QueryContext): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = {
     userLibMutex.readLock(for {
       allCats     <- getAllActiveTechniqueCategories(includeSystem)
-      catsWithUPs <- ZIO.foreach(allCats) { lightCat =>
-                       for {
-                         category <- getActiveTechniqueCategory(lightCat.id).notOptional(
-                                       s"Impossible to retrieve category '${lightCat.id.toString}' which was previously listed"
-                                     )
-                         parents  <- getParentsForActiveTechniqueCategory(category.id)
-                         upts     <- ZIO.foreach(category.items) { uactiveTechniqueId =>
-                                       getActiveTechniqueByActiveTechnique(uactiveTechniqueId).notOptional(
-                                         s"Missing active technique ${uactiveTechniqueId.value}"
-                                       )
-                                     }
-                       } yield {
-                         ((category.id :: parents.map(_.id)).reverse, CategoryWithActiveTechniques(category, upts.toSet))
-                       }
-                     }
+      catsWithUPs <-
+        ZIO.foreach(allCats) { lightCat =>
+          for {
+            category <- getActiveTechniqueCategory(lightCat.id).notOptional(
+                          s"Impossible to retrieve category '${lightCat.id.toString}' which was previously listed"
+                        )
+            parents  <- getParentsForActiveTechniqueCategory(category.id)
+            upts     <- ZIO
+                          .foreach(category.items)(uactiveTechniqueId => getActiveTechniqueByActiveTechnique(uactiveTechniqueId))
+                          .map(_.flatten)
+          } yield {
+            ((category.id :: parents.map(_.id)).reverse, CategoryWithActiveTechniques(category, upts.toSet))
+          }
+        }
     } yield {
       implicit val ordering = ActiveTechniqueCategoryOrdering
       SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]() ++ catsWithUPs
     })
   }
 
-  def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId): IOResult[Option[ActiveTechnique]] = {
+  def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = {
     userLibMutex.readLock {
       getActiveTechnique[ActiveTechniqueId](id, id => EQ(A_ACTIVE_TECHNIQUE_UUID, id.value))
     }
   }
 
-  def getActiveTechnique(name: TechniqueName): IOResult[Option[ActiveTechnique]] = {
+  def getActiveTechnique(name: TechniqueName)(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = {
     userLibMutex.readLock {
       this.getActiveTechnique[TechniqueName](name, name => EQ(A_TECHNIQUE_UUID, name.value))
     }
@@ -495,9 +509,9 @@ class RoLDAPDirectiveRepository(
                               .entry2ActiveTechnique(uptEntries(0))
                               .chainError("Error when mapping active technique entry to its entity. Entry: %s".format(uptEntries(0)))
                               .toIO
-                          added           <- addDirectives(activeTechnique, uptEntries(0).dn, con)
+                          res             <- addDirectives(activeTechnique, uptEntries(0).dn, con).map(Some(_))
                         } yield {
-                          Some(added)
+                          res
                         }
                       case _ =>
                         s"Error, the directory contains multiple occurrence of active technique with ID '${id}'. DNs involved: ${uptEntries
@@ -544,7 +558,7 @@ class RoLDAPDirectiveRepository(
     }
   }
 
-  def activeTechniqueBreadCrump(id: ActiveTechniqueId): IOResult[List[ActiveTechniqueCategory]] = {
+  def activeTechniqueBreadCrump(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = {
     // find the active technique entry for that id, and from that, build the parent bread crump
     userLibMutex.readLock {
       for {
@@ -556,7 +570,7 @@ class RoLDAPDirectiveRepository(
     }
   }
 
-  def getFullDirectiveLibrary(): IOResult[FullActiveTechniqueCategory] = {
+  def getFullDirectiveLibrary()(using qc: QueryContext): IOResult[FullActiveTechniqueCategory] = {
     // data structure to holds all relation between objects
     final case class AllMaps(
         categories:                  Map[ActiveTechniqueCategoryId, ActiveTechniqueCategory],
@@ -619,11 +633,11 @@ class RoLDAPDirectiveRepository(
     val emptyAll = AllMaps(Map(), Map(), Map(), Map(), Map())
     import rudderDit.ACTIVE_TECHNIQUES_LIB.*
 
-    def mappingError(current: AllMaps, e: LDAPEntry, err: RudderError): AllMaps = {
+    // mapping error are just logged, the entry is ignored
+    def mappingError(current: AllMaps, e: LDAPEntry, err: RudderError): UIO[AllMaps] = {
       val error = Chained(s"Error when mapping entry with DN '${e.dn.toString}' from directive library", err)
 
-      logEffect.warn(error.fullMsg)
-      current
+      logPure.warn(error.fullMsg).as(current)
     }
 
     userLibMutex
@@ -638,8 +652,8 @@ class RoLDAPDirectiveRepository(
               )
         } yield entries
       )
-      .map { entries =>
-        val allMaps = entries.toSeq.foldLeft(emptyAll) {
+      .flatMap { entries =>
+        ZIO.foldLeft(entries.toSeq)(emptyAll) {
           case (current, e) =>
             if (isACategory(e)) {
               mapper.entry2ActiveTechniqueCategory(e) match {
@@ -653,10 +667,12 @@ class RoLDAPDirectiveRepository(
                     val subCats = category.id :: current.categoriesByCategory.getOrElse(catId, Nil)
                     current.categoriesByCategory + (catId -> subCats)
                   }
-                  current.copy(
-                    categories = current.categories + (category.id -> category),
-                    categoriesByCategory = updatedSubCats
-                  )
+                  current
+                    .modify(_.categories)
+                    .setTo(current.categories + (category.id -> category))
+                    .modify(_.categoriesByCategory)
+                    .setTo(updatedSubCats)
+                    .succeed
                 case Left(err)       => mappingError(current, e, err)
               }
             } else if (isAnActiveTechnique(e)) {
@@ -664,10 +680,12 @@ class RoLDAPDirectiveRepository(
                 case Right(at) =>
                   val catId       = mapper.dn2ActiveTechniqueCategoryId(e.dn.getParent)
                   val atsForCatId = at.id :: current.activeTechniquesByCategory.getOrElse(catId, Nil)
-                  current.copy(
-                    activeTechiques = current.activeTechiques + (at.id                       -> at),
-                    activeTechniquesByCategory = current.activeTechniquesByCategory + (catId -> atsForCatId)
-                  )
+                  current
+                    .modify(_.activeTechiques)
+                    .setTo(current.activeTechiques + (at.id -> at))
+                    .modify(_.activeTechniquesByCategory)
+                    .setTo(current.activeTechniquesByCategory + (catId -> atsForCatId))
+                    .succeed
                 case Left(err) => mappingError(current, e, err)
               }
             } else if (isADirective(e)) {
@@ -675,20 +693,23 @@ class RoLDAPDirectiveRepository(
                 case Right(dir) =>
                   val atId      = mapper.dn2ActiveTechniqueId(e.dn.getParent)
                   val dirsForAt = dir :: current.directivesByActiveTechnique.getOrElse(atId, Nil)
-                  current.copy(
-                    directivesByActiveTechnique = current.directivesByActiveTechnique + (atId -> dirsForAt)
-                  )
+                  current
+                    .modify(_.directivesByActiveTechnique)
+                    .setTo(current.directivesByActiveTechnique + (atId -> dirsForAt))
+                    .succeed
                 case Left(err)  => mappingError(current, e, err)
               }
             } else {
               // log error, continue
-              logEffect.warn(
-                s"Entry with DN '${e.dn}' was ignored because it is of an unknow type. Known types are categories, active techniques, directives"
-              )
-              current
+              logPure
+                .warn(
+                  s"Entry with DN '${e.dn}' was ignored because it is of an unknow type. Known types are categories, active techniques, directives"
+                )
+                .as(current)
             }
         }
-
+      }
+      .map { allMaps =>
         val fullActiveTechniques = allMaps.activeTechiques.map { case (id, at) => (id -> fromActiveTechnique(at, allMaps)) }.toMap
 
         fromCategory(ActiveTechniqueCategoryId(rudderDit.ACTIVE_TECHNIQUES_LIB.rdnValue._1), allMaps, fullActiveTechniques.toMap)
@@ -711,6 +732,10 @@ class WoLDAPDirectiveRepository(
 
   import roDirectiveRepos.*
 
+  // internal navigation reads (find parents, breadcrumbs, look-up existing items, archiving) need a query
+  // context; this backend does not do any tenant filtering, so a system context is used.
+  private given systemReadQC: QueryContext = QueryContext.systemQC
+
   override def loggerName: String = this.getClass.getName
 
   /**
@@ -726,26 +751,31 @@ class WoLDAPDirectiveRepository(
   private def internalSaveDirective(
       inActiveTechniqueId: ActiveTechniqueId,
       directive:           Directive,
-      modId:               ModificationId,
-      actor:               EventActor,
-      reason:              Option[String],
       systemCall:          Boolean
-  ): IOResult[Option[DirectiveSaveDiff]] = {
+  )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = {
     userLibMutex.writeLock(for {
-      con              <- ldap
-      uptEntry         <-
+      con                   <- ldap
+      uptEntry              <-
         getUPTEntry(con, inActiveTechniqueId, "1.1").notOptional(
           s"Can not find the active technique with id '${inActiveTechniqueId.value}' to add directive '${directive.id.uid.value}'"
         )
-      canAdd           <-
+      parentActiveTechnique <-
+        getActiveTechniqueByActiveTechnique(inActiveTechniqueId).notOptional(
+          s"Can not find active technique Entry with id '${inActiveTechniqueId.value}' to add directive '${directive.id.uid.value}'"
+        )
+      // load the existing directive for the old root section used in the event log
+      oldAtAndDir           <- getActiveTechniqueAndDirective(DirectiveId(directive.id.uid))
+      canAdd                <-
         getDirectiveEntry(con, directive.id).flatMap { // check if the directive already exists elsewhere
           case None          => None.succeed
           case Some(otherPi) =>
             if (otherPi.dn.getParent == uptEntry.dn) {
               mapper.entry2Directive(otherPi).toIO.flatMap { x =>
                 (x.isSystem, systemCall) match {
-                  case (true, false) => Unexpected(s"System directive '${x.name}' (${x.id.uid.value}) can't be updated").fail
-                  case (false, true) => Inconsistency("Non-system directive can not be updated with that method").fail
+                  case (true, false) =>
+                    Unexpected(s"System directive '${x.name}' (${x.id.uid.value}) can't be updated").fail
+                  case (false, true) =>
+                    Inconsistency("Non-system directive can not be updated with that method").fail
                   case _             => Some(otherPi).succeed
                 }
               }
@@ -756,72 +786,67 @@ class WoLDAPDirectiveRepository(
             }
         }
       // We have to keep the old rootSection to generate the event log
-      oldRootSection   <- getActiveTechniqueAndDirective(DirectiveId(directive.id.uid)).map {
-                            // Directory did not exist before, this is a Rule addition.
-                            case None                                     => None
-                            case Some((oldActiveTechnique, oldDirective)) =>
-                              val oldTechniqueId = TechniqueId(oldActiveTechnique.techniqueName, oldDirective.techniqueVersion)
-                              techniqueRepository.get(oldTechniqueId).map(_.rootSection)
-                          }
-      exists           <- directiveNameExists(con, directive.name, directive.id.uid)
-      nameIsAvailable  <- ZIO.when(exists) {
-                            Inconsistency(
-                              s"Cannot set directive with name '${directive.name}' : this name is already in use."
-                            ).fail
-                          }
-      piEntry           = mapper.userDirective2Entry(directive, uptEntry.dn)
-      result           <- con.save(piEntry, removeMissingAttributes = true)
-      // for log event - perhaps put that elsewhere ?
-      activeTechnique  <-
-        getActiveTechniqueByActiveTechnique(inActiveTechniqueId).notOptional(
-          s"Can not find active technique Entry with id '${inActiveTechniqueId.value}' to add directive '${directive.id.uid.value}'"
-        )
-      activeTechniqueId = TechniqueId(activeTechnique.techniqueName, directive.techniqueVersion)
-      technique        <- techniqueRepository
-                            .get(activeTechniqueId)
-                            .notOptional(s"Can not find the technique with ID '${activeTechniqueId.debugString}'")
-      optDiff          <- (diffMapper
-                            .modChangeRecords2DirectiveSaveDiff(
-                              technique.id.name,
-                              technique.rootSection,
-                              piEntry.dn,
-                              canAdd,
-                              result,
-                              oldRootSection
-                            )
-                            .toIO
-                            .chainError("Error when processing saved modification to log them"))
-      eventLogged      <- (optDiff match {
-                            case None                            => ZIO.unit
-                            case Some(diff: AddDirectiveDiff)    =>
-                              actionLogger.saveAddDirective(
-                                modId,
-                                principal = actor,
-                                addDiff = diff,
-                                varsRootSectionSpec = technique.rootSection,
-                                reason = reason
-                              )
-                            case Some(diff: ModifyDirectiveDiff) =>
-                              actionLogger.saveModifyDirective(
-                                modId,
-                                principal = actor,
-                                modifyDiff = diff,
-                                reason = reason
-                              )
-                          })
-      autoArchive      <- ZIO.when(autoExportOnModify && optDiff.isDefined && !directive.isSystem) {
-                            for {
-                              parents  <- activeTechniqueBreadCrump(activeTechnique.id)
-                              commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                              archived <- gitPiArchiver.archiveDirective(
-                                            directive,
-                                            technique.id.name,
-                                            parents.map(_.id),
-                                            technique.rootSection,
-                                            Some((modId, commiter, reason))
-                                          )
-                            } yield archived
-                          }
+      oldRootSection         = oldAtAndDir match {
+                                 case None                                     => None
+                                 case Some((oldActiveTechnique, oldDirective)) =>
+                                   val oldTechniqueId =
+                                     TechniqueId(oldActiveTechnique.techniqueName, oldDirective.techniqueVersion)
+                                   techniqueRepository.get(oldTechniqueId).map(_.rootSection)
+                               }
+      exists                <- directiveNameExists(con, directive.name, directive.id.uid)
+      nameIsAvailable       <- ZIO.when(exists) {
+                                 Inconsistency(
+                                   s"Cannot set directive with name '${directive.name}' : this name is already in use."
+                                 ).fail
+                               }
+      piEntry                = mapper.userDirective2Entry(directive, uptEntry.dn)
+      result                <- con.save(piEntry, removeMissingAttributes = true)
+      activeTechniqueId      = TechniqueId(parentActiveTechnique.techniqueName, directive.techniqueVersion)
+      technique             <- techniqueRepository
+                                 .get(activeTechniqueId)
+                                 .notOptional(s"Can not find the technique with ID '${activeTechniqueId.debugString}'")
+      optDiff               <- (diffMapper
+                                 .modChangeRecords2DirectiveSaveDiff(
+                                   technique.id.name,
+                                   technique.rootSection,
+                                   piEntry.dn,
+                                   canAdd,
+                                   result,
+                                   oldRootSection
+                                 )
+                                 .toIO
+                                 .chainError("Error when processing saved modification to log them"))
+      eventLogged           <- (optDiff match {
+                                 case None                            => ZIO.unit
+                                 case Some(diff: AddDirectiveDiff)    =>
+                                   actionLogger.saveAddDirective(
+                                     cc.modId,
+                                     principal = cc.actor,
+                                     addDiff = diff,
+                                     varsRootSectionSpec = technique.rootSection,
+                                     reason = cc.message
+                                   )
+                                 case Some(diff: ModifyDirectiveDiff) =>
+                                   actionLogger.saveModifyDirective(
+                                     cc.modId,
+                                     principal = cc.actor,
+                                     modifyDiff = diff,
+                                     reason = cc.message
+                                   )
+                               })
+      autoArchive           <- ZIO.when(autoExportOnModify && optDiff.isDefined && !directive.isSystem) {
+                                 for {
+                                   parents  <- activeTechniqueBreadCrump(parentActiveTechnique.id)
+                                   commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                                   archived <- gitPiArchiver.archiveDirective(
+                                                 directive,
+                                                 technique.id.name,
+                                                 parents.map(_.id),
+                                                 technique.rootSection,
+                                                 Some((cc.modId, commiter, cc.message))
+                                               )
+                                 } yield archived
+                               }
     } yield {
       optDiff
     })
@@ -829,22 +854,16 @@ class WoLDAPDirectiveRepository(
 
   override def saveDirective(
       inActiveTechniqueId: ActiveTechniqueId,
-      directive:           Directive,
-      modId:               ModificationId,
-      actor:               EventActor,
-      reason:              Option[String]
-  ): IOResult[Option[DirectiveSaveDiff]] = {
-    internalSaveDirective(inActiveTechniqueId, directive, modId, actor, reason, systemCall = false)
+      directive:           Directive
+  )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = {
+    internalSaveDirective(inActiveTechniqueId, directive, systemCall = false)
   }
 
   override def saveSystemDirective(
       inActiveTechniqueId: ActiveTechniqueId,
-      directive:           Directive,
-      modId:               ModificationId,
-      actor:               EventActor,
-      reason:              Option[String]
-  ): IOResult[Option[DirectiveSaveDiff]] = {
-    internalSaveDirective(inActiveTechniqueId, directive, modId, actor, reason, systemCall = true)
+      directive:           Directive
+  )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = {
+    internalSaveDirective(inActiveTechniqueId, directive, systemCall = true)
   }
 
   private def directiveNameExists(con: RoLDAPConnection, name: String, id: DirectiveUid): IOResult[Boolean] = {
@@ -867,12 +886,9 @@ class WoLDAPDirectiveRepository(
    * If no directive has such id, return a success.
    */
   override def deleteSystemDirective(
-      id:     DirectiveUid,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[Option[DeleteDirectiveDiff]] = {
-    internalDeleteDirective(id, modId, actor, reason, callSystem = true)
+      id: DirectiveUid
+  )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = {
+    internalDeleteDirective(id, callSystem = true)
   }
 
   /**
@@ -882,21 +898,15 @@ class WoLDAPDirectiveRepository(
    * hand if you want.
    */
   override def delete(
-      id:     DirectiveUid,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[Option[DeleteDirectiveDiff]] = {
-    internalDeleteDirective(id, modId, actor, reason, callSystem = false)
+      id: DirectiveUid
+  )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = {
+    internalDeleteDirective(id, callSystem = false)
   }
 
   private def internalDeleteDirective(
       id:         DirectiveUid,
-      modId:      ModificationId,
-      actor:      EventActor,
-      reason:     Option[String],
       callSystem: Boolean
-  ): IOResult[Option[DeleteDirectiveDiff]] = {
+  )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = {
     userLibMutex.writeLock(getActiveTechniqueAndDirectiveEntries(DirectiveId(id)).flatMap {
       case None                    => // directive already deleted, do nothing
         None.succeed
@@ -924,22 +934,22 @@ class WoLDAPDirectiveRepository(
           loggedAction    <- { // we can have a missing technique if the technique was deleted but not its directive. In that case, make a fake root section
             val rootSection = technique.map(_.rootSection).getOrElse(SectionSpec("Missing technique information"))
             actionLogger.saveDeleteDirective(
-              modId,
-              principal = actor,
+              cc.modId,
+              principal = cc.actor,
               deleteDiff = diff,
               varsRootSectionSpec = rootSection,
-              reason = reason
+              reason = cc.message
             )
           }
           autoArchive     <- ZIO.when(autoExportOnModify && deleted.size > 0 && !directive.isSystem) {
                                for {
                                  parents  <- activeTechniqueBreadCrump(activeTechnique.id)
-                                 commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
+                                 commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
                                  archived <- gitPiArchiver.deleteDirective(
                                                directive.id.uid,
                                                activeTechnique.techniqueName,
                                                parents.map(_.id),
-                                               Some((modId, commiter, reason))
+                                               Some((cc.modId, commiter, cc.message))
                                              )
                                } yield archived
                              }
@@ -984,28 +994,32 @@ class WoLDAPDirectiveRepository(
       categoryEntry        = mapper.activeTechniqueCategory2ldap(that, parentCategoryEntry.dn)
       exists              <- existsByName(con, parentCategoryEntry.dn, that.name, that.id.value)
       canAddByName        <- if (exists) {
-                               s"A category with name '${that.name}' already exists in category '${parentCategoryEntry(A_NAME).getOrElse("UNKNOWN")}': category names must be unique for a given level".fail
+                               s"A category with name '${that.name}' already exists in category '${parentCategoryEntry(A_NAME)
+                                   .getOrElse("UNKNOWN")}': category names must be unique for a given level".fail
                              } else {
                                "Can add, no sub categorie with that name".succeed
                              }
       result              <- con.save(categoryEntry, removeMissingAttributes = true)
-      autoArchive         <- ZIO.when(autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !that.isSystem) {
-                               for {
-                                 parents  <- getParentsForActiveTechniqueCategory(that.id)
-                                 commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
-                                 archive  <-
-                                   gitCatArchiver.archiveActiveTechniqueCategory(
-                                     that,
-                                     parents.map(_.id),
-                                     Some((cc.modId, commiter, cc.message))
-                                   )
-                               } yield archive
-                             }
-      parentEntry         <- getCategoryEntry(con, into).chainError(s"Entry with ID '${into.value}' was not found")
-      updatedParent       <- mapper
-                               .entry2ActiveTechniqueCategory(categoryEntry)
-                               .chainError(s"Error when transforming LDAP entry '${categoryEntry}' into an active technique category")
-                               .toIO
+      autoArchive         <-
+        ZIO.when(autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !that.isSystem) {
+          for {
+            parents  <- getParentsForActiveTechniqueCategory(that.id)
+            commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+            archive  <-
+              gitCatArchiver.archiveActiveTechniqueCategory(
+                that,
+                parents.map(_.id),
+                Some((cc.modId, commiter, cc.message))
+              )
+          } yield archive
+        }
+      updatedParent       <-
+        mapper
+          .entry2ActiveTechniqueCategory(categoryEntry)
+          .chainError(
+            s"Error when transforming LDAP entry '${categoryEntry}' into an active technique category"
+          )
+          .toIO
     } yield {
       updatedParent
     })
@@ -1034,17 +1048,18 @@ class WoLDAPDirectiveRepository(
       updated          <- getActiveTechniqueCategory(category.id).notOptional(
                             s"Error: can not find back just saved category '${category.id.toString}'"
                           )
-      autoArchive      <- ZIO.when(autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !category.isSystem) {
-                            for {
-                              parents  <- getParentsForActiveTechniqueCategory(category.id)
-                              commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
-                              archive  <- gitCatArchiver.archiveActiveTechniqueCategory(
-                                            updated,
-                                            parents.map(_.id),
-                                            Some((cc.modId, commiter, cc.message))
-                                          )
-                            } yield archive
-                          }
+      autoArchive      <-
+        ZIO.when(autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !category.isSystem) {
+          for {
+            parents  <- getParentsForActiveTechniqueCategory(category.id)
+            commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+            archive  <- gitCatArchiver.archiveActiveTechniqueCategory(
+                          updated,
+                          parents.map(_.id),
+                          Some((cc.modId, commiter, cc.message))
+                        )
+          } yield archive
+        }
     } yield {
       updated
     })
@@ -1106,9 +1121,10 @@ class WoLDAPDirectiveRepository(
       oldParents     <- if (autoExportOnModify) {
                           getParentsForActiveTechniqueCategory(categoryId)
                         } else Nil.succeed
-      categoryEntry  <- getCategoryEntry(con, categoryId, A_NAME).notOptional(s"Category was not found")
+      categoryEntry  <- getCategoryEntry(con, categoryId).notOptional(s"Category was not found")
       newParentEntry <-
-        getCategoryEntry(con, intoParent, "1.1").notOptional(s"New destination category '${intoParent.value}' was not found")
+        getCategoryEntry(con, intoParent).notOptional(s"New destination category '${intoParent.value}' was not found")
+      // a category can be moved only if the current security context can see both it and the destination
       moveAuthorised <- if (newParentEntry.dn.isDescendantOf(categoryEntry.dn, true)) {
                           "Can not move a category to itself or one of its children".fail
                         } else "Succes".succeed
@@ -1176,11 +1192,11 @@ class WoLDAPDirectiveRepository(
                              techniqueName,
                              AcceptationDateTime(versions.map(x => x -> now).toMap),
                              policyTypes = policyTypes,
-                             security = cc.accessGrant.toSecurityTag
+                             security = None
                            )
       uptEntry           = mapper.activeTechnique2Entry(newActiveTechnique, categoryEntry.dn)
       result            <- con.save(uptEntry, removeMissingAttributes = true)
-      // a new active technique is never system, see constructor call, using defvault value,
+      // a new active technique is never system, see constructor call, using default value,
       // maybe we should check in its caller is the technique is system or not
       autoArchive       <- ZIO.when(autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord]) {
                              for {
@@ -1213,11 +1229,11 @@ class WoLDAPDirectiveRepository(
       oldParents           <- if (autoExportOnModify) {
                                 activeTechniqueBreadCrump(uactiveTechniqueId)
                               } else Nil.succeed
-      activeTechnique      <- getUPTEntry(con, uactiveTechniqueId, "1.1").notOptional(
+      activeTechnique      <- getUPTEntry(con, uactiveTechniqueId).notOptional(
                                 s"Can not move non existing template in use library with ID '${uactiveTechniqueId.value}"
                               )
       newCategory          <-
-        getCategoryEntry(con, newCategoryId, "1.1").notOptional(
+        getCategoryEntry(con, newCategoryId).notOptional(
           s"Can not move template with ID '${uactiveTechniqueId.value}' into non existing category of user library ${newCategoryId.value}"
         )
       moved                <- con
@@ -1302,7 +1318,7 @@ class WoLDAPDirectiveRepository(
   )(implicit cc: ChangeContext): IOResult[ActiveTechniqueId] = {
     userLibMutex.writeLock(for {
       con                <- ldap
-      activeTechnique    <- getUPTEntry(con, uactiveTechniqueId, A_ACCEPTATION_DATETIME).notOptional(
+      activeTechnique    <- getUPTEntry(con, uactiveTechniqueId).notOptional(
                               s"Active technique with id '${uactiveTechniqueId.value}' was not found"
                             )
       oldAcceptations    <-
@@ -1338,11 +1354,8 @@ class WoLDAPDirectiveRepository(
    * If no such element exists, it is a.succeed.
    */
   override def deleteActiveTechnique(
-      uactiveTechniqueId: ActiveTechniqueId,
-      modId:              ModificationId,
-      actor:              EventActor,
-      reason:             Option[String]
-  ): IOResult[ActiveTechniqueId] = {
+      uactiveTechniqueId: ActiveTechniqueId
+  )(using cc: ChangeContext): IOResult[ActiveTechniqueId] = {
     userLibMutex.writeLock(for {
       con  <- ldap
       done <- getUPTEntry(con, uactiveTechniqueId).flatMap {
@@ -1356,7 +1369,8 @@ class WoLDAPDirectiveRepository(
                     oldTechnique <- mapper.entry2ActiveTechnique(ldapEntryTechnique).toIO
                     deleted      <- con.delete(activeTechnique.dn, recurse = false)
                     diff          = DeleteTechniqueDiff(oldTechnique)
-                    loggedAction <- actionLogger.saveDeleteTechnique(modId, principal = actor, deleteDiff = diff, reason = reason)
+                    loggedAction <-
+                      actionLogger.saveDeleteTechnique(cc.modId, principal = cc.actor, deleteDiff = diff, reason = cc.message)
                     _            <- ZIO
                                       .when(autoExportOnModify && deleted.size > 0 && !oldTechnique.policyTypes.isSystem) {
                                         for {
@@ -1364,11 +1378,11 @@ class WoLDAPDirectiveRepository(
                                                         case None    => Inconsistency("Missing required reference technique name").fail
                                                         case Some(x) => x.succeed
                                                       }
-                                          commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
+                                          commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
                                           res      <- gitATArchiver.deleteActiveTechnique(
                                                         TechniqueName(ptName),
                                                         oldParents.map(_.id),
-                                                        Some((modId, commiter, reason))
+                                                        Some((cc.modId, commiter, cc.message))
                                                       )
                                         } yield res
                                       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -848,7 +848,10 @@ class LDAPEntityMapper(
         name       <- e.required(A_NAME)
         description = e(A_DESCRIPTION).getOrElse("")
         isSystem    = e.getAsBoolean(A_IS_SYSTEM).getOrElse(false)
-        security    = e(A_SECURITY_TAG).flatMap(_.fromJson[SecurityTag].toOption)
+        // the root rule category must be open, like the group and active technique library roots,
+        // so that any user can create objects below it
+        security    = if (e.dn == rudderDit.RULECATEGORY.dn) Some(SecurityTag.Open)
+                      else e(A_SECURITY_TAG).flatMap(_.fromJson[SecurityTag].toOption)
       } yield {
         RuleCategory(RuleCategoryId(id), name, description, Nil, isSystem, security)
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -485,7 +485,9 @@ class LDAPEntityMapper(
         name       <- e.required(A_NAME)
         description = e(A_DESCRIPTION).getOrElse("")
         isSystem    = e.getAsBoolean(A_IS_SYSTEM).getOrElse(false)
-        security    = e(A_SECURITY_TAG).flatMap(_.fromJson[SecurityTag].toOption)
+        // we have a special case for the root active technique category, that needs to be open
+        security    = if (e.dn == rudderDit.ACTIVE_TECHNIQUES_LIB.dn) Some(SecurityTag.Open)
+                      else e(A_SECURITY_TAG).flatMap(_.fromJson[SecurityTag].toOption)
       } yield {
         ActiveTechniqueCategory(ActiveTechniqueCategoryId(id), name, description, Nil, Nil, isSystem, security)
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -81,8 +81,7 @@ import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.services.user.PersonIdentService
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
-import com.normation.rudder.tenants.TenantCheckLogic
-import com.normation.rudder.tenants.TenantService
+import com.softwaremill.quicklens.*
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Filter
 import com.unboundid.ldif.LDIFChangeRecord
@@ -189,7 +188,8 @@ class RoLDAPNodeGroupRepository(
                                             .foreach(category.items) { targetInfo =>
                                               targetInfo.target match {
                                                 case group: GroupTarget =>
-                                                  this.getNodeGroup(group.groupId).map { case (g, catId) => Some(g) }
+                                                  // getNodeGroupOpt already filters by tenant: invisible groups are dropped
+                                                  this.getNodeGroupOpt(group.groupId).map(_.map(_._1))
                                                 // just ignore other target type
                                                 case _ => None.succeed
                                               }
@@ -221,7 +221,7 @@ class RoLDAPNodeGroupRepository(
                                      .chainError(s"Error when mapping server group entry to its entity. Entry: ${sgEntry}")
                        allNodes <- nodeFactRepo.getAll()
                        nodeIds   = g.serverList.intersect(allNodes.keySet.toSet)
-                       y         = g.copy(serverList = nodeIds)
+                       y         = g.modify(_.serverList).setTo(nodeIds)
                      } yield Some((y, mapper.dn2NodeGroupCategoryId(x.dn.getParent)))
                  }
     } yield {
@@ -229,7 +229,7 @@ class RoLDAPNodeGroupRepository(
     })
   }
 
-  def getAllGroupCategories(includeSystem: Boolean = false): IOResult[Seq[NodeGroupCategory]] = {
+  def getAllGroupCategories(includeSystem: Boolean = false)(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] = {
     groupLibMutex.readLock {
       for {
         con             <- ldap
@@ -248,14 +248,14 @@ class RoLDAPNodeGroupRepository(
    * (see for ex: #18983)
    * Kept only for backward compatibility.
    */
-  def getRootCategory(): NodeGroupCategory = {
+  def getRootCategory()(using qc: QueryContext): NodeGroupCategory = {
     com.normation.zio.ZioRuntime.runNow(getRootCategoryPure().either) match {
       case Right(root) => root
       case Left(e)     => throw new RuntimeException(e.msg)
     }
   }
 
-  def getRootCategoryPure(): IOResult[NodeGroupCategory] = {
+  def getRootCategoryPure()(using qc: QueryContext): IOResult[NodeGroupCategory] = {
     for {
       con               <- ldap
       rootCategoryEntry <-
@@ -283,13 +283,15 @@ class RoLDAPNodeGroupRepository(
    * The last parent is not the root of the library, return a Failure.
    * Also return a failure if the path to top is broken in any way.
    */
-  def getParentsForCategory(id: NodeGroupCategoryId, root: NodeGroupCategory): IOResult[List[NodeGroupCategory]] = {
+  def getParentsForCategory(id: NodeGroupCategoryId, root: NodeGroupCategory)(using
+      qc: QueryContext
+  ): IOResult[List[NodeGroupCategory]] = {
     // TODO : LDAPify that, we can have the list of all DN from id to root at the begining
     if (id == root.id) Nil.succeed
     else getParentGroupCategory(id).flatMap(parent => getParentsForCategory(parent.id, root).map(parents => parent :: parents))
   }
 
-  override def categoryExists(id: NodeGroupCategoryId): IOResult[Boolean] = {
+  override def categoryExists(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean] = {
     for {
       con           <- ldap
       categoryEntry <- groupLibMutex.readLock(getCategoryEntry(con, id, "dn"))
@@ -299,7 +301,7 @@ class RoLDAPNodeGroupRepository(
   /**
    * Get a group category by its id
    * */
-  def getGroupCategory(id: NodeGroupCategoryId): IOResult[NodeGroupCategory] = {
+  def getGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
     for {
       con           <- ldap
       categoryEntry <- groupLibMutex.readLock {
@@ -319,7 +321,7 @@ class RoLDAPNodeGroupRepository(
    * Get the direct parent of the given category.
    * Fails if the category is not in the repository or for root category
    */
-  def getParentGroupCategory(id: NodeGroupCategoryId): IOResult[NodeGroupCategory] = {
+  def getParentGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
     groupLibMutex.readLock {
       for {
         con                 <- ldap
@@ -338,7 +340,7 @@ class RoLDAPNodeGroupRepository(
     }
   }
 
-  def getParents_NodeGroupCategory(id: NodeGroupCategoryId): IOResult[List[NodeGroupCategory]] = {
+  def getParents_NodeGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[List[NodeGroupCategory]] = {
     // TODO : LDAPify that, we can have the list of all DN from id to root at the begining (just dn.getParent until rudderDit.NOE_GROUP.dn)
     for {
       root <- getRootCategoryPure()
@@ -355,7 +357,7 @@ class RoLDAPNodeGroupRepository(
    * Returns all non system categories + the root category
    * Caution, they are "lightweight" group categories (no children)
    */
-  def getAllNonSystemCategories(): IOResult[Seq[NodeGroupCategory]] = {
+  def getAllNonSystemCategories()(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] = {
     groupLibMutex.readLock {
       for {
         con               <- ldap
@@ -385,7 +387,7 @@ class RoLDAPNodeGroupRepository(
    *   "/cat2"       -> [/cat2_details]
    *   ...
    */
-  def getCategoryHierarchy: IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = {
+  def getCategoryHierarchy(using qc: QueryContext): IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = {
     for {
       allCats     <- getAllNonSystemCategories()
       rootCat     <- getRootCategoryPure()
@@ -409,7 +411,7 @@ class RoLDAPNodeGroupRepository(
    * @param id
    * @return
    */
-  def getNodeGroupCategory(id: NodeGroupId): IOResult[NodeGroupCategory] = {
+  def getNodeGroupCategory(id: NodeGroupId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
     groupLibMutex.readLock {
       for {
         con                 <- ldap
@@ -427,7 +429,7 @@ class RoLDAPNodeGroupRepository(
     }
   }
 
-  def getAll(): IOResult[Seq[NodeGroup]] = {
+  def getAll()(using qc: QueryContext): IOResult[Seq[NodeGroup]] = {
     for {
       con     <- ldap
       // for each directive entry, map it. if one fails, all fails
@@ -443,7 +445,7 @@ class RoLDAPNodeGroupRepository(
     }
   }
 
-  def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[NodeGroup]] = {
+  def getAllByIds(ids: Seq[NodeGroupId])(using qc: QueryContext): IOResult[Seq[NodeGroup]] = {
     for {
       con     <- ldap
       // for each directive entry, map it. if one fails, all fails
@@ -460,7 +462,7 @@ class RoLDAPNodeGroupRepository(
     }
   }
 
-  def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] = {
+  def getAllNodeIds()(using qc: QueryContext): IOResult[Map[NodeGroupId, Set[NodeId]]] = {
     for {
       con     <- ldap
       // for each directive entry, map it. if one fails, all fails
@@ -476,7 +478,7 @@ class RoLDAPNodeGroupRepository(
     }
   }
 
-  def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
+  def getAllNodeIdsChunk()(using qc: QueryContext): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
     for {
       con     <- ldap
       // for each directive entry, map it. if one fails, all fails
@@ -496,7 +498,7 @@ class RoLDAPNodeGroupRepository(
     groupLibMutex.readLock {
       for {
         con      <- ldap
-        entries  <- con.searchSub(rudderDit.GROUP.dn, filter, "1.1")
+        entries  <- con.searchSub(rudderDit.GROUP.dn, filter)
         groupIds <- ZIO.foreach(entries) { entry =>
                       rudderDit.GROUP
                         .getGroupId(entry.dn)
@@ -516,7 +518,7 @@ class RoLDAPNodeGroupRepository(
    * @param nodeIds
    * @return
    */
-  def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = {
+  def findGroupWithAnyMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]] = {
     val filter = AND(
       IS(OC_RUDDER_NODE_GROUP),
       OR(nodeIds.distinct.map(nodeId => EQ(LDAPConstants.A_NODE_UUID, nodeId.value))*)
@@ -530,7 +532,7 @@ class RoLDAPNodeGroupRepository(
    * @param nodeIds
    * @return
    */
-  def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = {
+  def findGroupWithAllMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]] = {
     val filter = AND(
       IS(OC_RUDDER_NODE_GROUP),
       AND(nodeIds.distinct.map(nodeId => EQ(LDAPConstants.A_NODE_UUID, nodeId.value))*)
@@ -546,10 +548,9 @@ class RoLDAPNodeGroupRepository(
   def getFullGroupLibrary()(implicit qc: QueryContext): IOResult[FullNodeGroupCategory] = {
 
     /*
-     * Map from LDAP results to `FullNodeGroupCategory`/`FullRuleTargetInfo`, filtering
-     * out items based on tenants along the way.
+     * Map from LDAP results to `FullNodeGroupCategory`/`FullRuleTargetInfo`.
      */
-    def fromCategory(catId: NodeGroupCategoryId, maps: AllMaps)(implicit qc: QueryContext): FullNodeGroupCategory = {
+    def fromCategory(catId: NodeGroupCategoryId, maps: AllMaps): FullNodeGroupCategory = {
       def getCat(id: NodeGroupCategoryId) = maps.categories.getOrElse(
         id,
         throw new IllegalArgumentException(s"Missing categories with id ${catId} in the list of available categories")
@@ -572,10 +573,6 @@ class RoLDAPNodeGroupRepository(
      * strategy: load the full subtree from the root category id,
      * then process entrie mapping them to their light version,
      * then call fromCategory on the root (we know its id).
-     *
-     * Tenants are not filtered in the LDAP `getTree` request (we don't have the tooling
-     * to do it at that level in a consistent way), but on the translation to
-     * `FullNodeGroupCategory`.
      */
 
     groupLibMutex
@@ -666,8 +663,6 @@ class WoLDAPNodeGroupRepository(
     actionLogEffect:    EventLogRepository,
     gitArchiver:        GitNodeGroupArchiver,
     personIdentService: PersonIdentService,
-    tenantService:      TenantCheckLogic,
-    tenantRepo:         TenantService,
     autoExportOnModify: Boolean
 ) extends WoNodeGroupRepository with Loggable {
   repo =>
@@ -777,59 +772,36 @@ class WoLDAPNodeGroupRepository(
   override def addGroupCategoryToCategory(that: NodeGroupCategory, into: NodeGroupCategoryId)(implicit
       cc: ChangeContext
   ): IOResult[NodeGroupCategory] = {
+    given QueryContext = cc.toQC
     groupLibMutex.writeLock(for {
       con                 <- ldap
       parentCategoryEntry <-
         getCategoryEntry(con, into).notOptional(s"The parent category '${into}' was not found, can not add")
-      parent              <- mapper.entry2NodeGroupCategory(parentCategoryEntry).toIO
-      // you can add to a category only if you can see its parent
-      newCategory         <- cc.accessGrant.canSeeOrFail(parent) {
-                               for {
-                                 exists       <- categoryExists(con, that.name, parentCategoryEntry.dn)
-                                 // this will need to be updated in a full multi-tenants environment because it leaks info about existing categories
-                                 canAddByName <-
-                                   if (exists)
-                                     s"Cannot create the Node Group Category with name '${that.name}': a category with the same name exists at the same level".fail
-                                   else "OK, can add".succeed
-                                 tenantStatus <- tenantRepo.getStatus
-                                 newCategory  <-
-                                   tenantService.manageUpdate[NodeGroupCategory, NodeGroupCategory, NodeGroupCategory](
-                                     None,
-                                     that,
-                                     cc,
-                                     tenantStatus
-                                   ) { newCat =>
-                                     val categoryEntry = mapper.nodeGroupCategory2ldap(
-                                       that.updateFromChangeContext,
-                                       parentCategoryEntry.dn
-                                     )
-                                     for {
-                                       result      <- con.save(categoryEntry, removeMissingAttributes = true)
-                                       autoArchive <-
-                                         (if (autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !that.isSystem) {
-                                            for {
-                                              parents  <- getParents_NodeGroupCategory(that.id)
-                                              commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
-                                              archive  <-
-                                                gitArchiver.archiveNodeGroupCategory(
-                                                  that,
-                                                  parents.map(_.id),
-                                                  Some((cc.modId, commiter, cc.message))
-                                                )
-                                            } yield archive
-                                          } else ZIO.unit)
-                                       newCategory <-
-                                         getGroupCategory(that.id).chainError(
-                                           s"The newly created category '${that.id.value}' was not found"
-                                         )
-                                     } yield {
-                                       newCategory
-                                     }
-                                   }
-                               } yield {
-                                 newCategory
-                               }
-                             }
+      exists              <- categoryExists(con, that.name, parentCategoryEntry.dn)
+      // this will need to be updated in a full multi-tenants environment because it leaks info about existing categories
+      _                   <-
+        ZIO.when(exists) {
+          s"Cannot create the Node Group Category with name '${that.name}': a category with the same name exists at the same level".fail
+        }
+      categoryEntry        = mapper.nodeGroupCategory2ldap(that, parentCategoryEntry.dn)
+      result              <- con.save(categoryEntry, removeMissingAttributes = true)
+      autoArchive         <-
+        (if (autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !that.isSystem) {
+           for {
+             parents  <- getParents_NodeGroupCategory(that.id)
+             commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+             archive  <-
+               gitArchiver.archiveNodeGroupCategory(
+                 that,
+                 parents.map(_.id),
+                 Some((cc.modId, commiter, cc.message))
+               )
+           } yield archive
+         } else ZIO.unit)
+      newCategory         <-
+        getGroupCategory(that.id).chainError(
+          s"The newly created category '${that.id.value}' was not found"
+        )
     } yield {
       newCategory
     })
@@ -839,50 +811,35 @@ class WoLDAPNodeGroupRepository(
    * Update an existing group category
    */
   override def saveGroupCategory(category: NodeGroupCategory)(implicit cc: ChangeContext): IOResult[NodeGroupCategory] = {
+    given QueryContext = cc.toQC
     groupLibMutex.writeLock(
       for {
         con              <- ldap
         oldCategoryEntry <-
           getCategoryEntry(con, category.id, "1.1").notOptional(s"Entry with ID '${category.id.value}' was not found")
-        oldCategory      <- mapper.entry2NodeGroupCategory(oldCategoryEntry).toIO
-        updated          <- cc.accessGrant.canSeeOrFail(oldCategory) {
-                              for {
-                                exists       <- categoryExists(con, category.name, oldCategoryEntry.dn.getParent, category.id)
-                                canAddByName <-
-                                  if (exists)
-                                    s"Cannot update the Node Group Category with name '${category.name}': a category with the same name exists at the same level".fail
-                                  else ZIO.unit
-                                // check & update security content
-                                tenantStatus <- tenantRepo.getStatus
-                                updated      <-
-                                  tenantService.manageUpdate(Some(oldCategory), category, cc, tenantStatus) { newCat =>
-                                    val categoryEntry = mapper.nodeGroupCategory2ldap(category, oldCategoryEntry.dn.getParent)
-                                    for {
-                                      result      <- con.save(categoryEntry, removeMissingAttributes = true)
-                                      updated     <- getGroupCategory(category.id)
-                                      // Maybe we have to check if the parents are system or not too
-                                      autoArchive <-
-                                        (if (autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !category.isSystem) {
-                                           for {
-                                             parents  <- getParents_NodeGroupCategory(category.id)
-                                             commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
-                                             archive  <-
-                                               gitArchiver
-                                                 .archiveNodeGroupCategory(
-                                                   updated,
-                                                   parents.map(_.id),
-                                                   Some((cc.modId, commiter, cc.message))
-                                                 )
-                                           } yield archive
-                                         } else ZIO.unit)
-                                    } yield {
-                                      updated
-                                    }
-                                  }
-                              } yield {
-                                updated
-                              }
-                            }
+        exists           <- categoryExists(con, category.name, oldCategoryEntry.dn.getParent, category.id)
+        _                <-
+          ZIO.when(exists) {
+            s"Cannot update the Node Group Category with name '${category.name}': a category with the same name exists at the same level".fail
+          }
+        categoryEntry     = mapper.nodeGroupCategory2ldap(category, oldCategoryEntry.dn.getParent)
+        result           <- con.save(categoryEntry, removeMissingAttributes = true)
+        updated          <- getGroupCategory(category.id)
+        // Maybe we have to check if the parents are system or not too
+        autoArchive      <-
+          (if (autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !category.isSystem) {
+             for {
+               parents  <- getParents_NodeGroupCategory(category.id)
+               commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+               archive  <-
+                 gitArchiver
+                   .archiveNodeGroupCategory(
+                     updated,
+                     parents.map(_.id),
+                     Some((cc.modId, commiter, cc.message))
+                   )
+             } yield archive
+           } else ZIO.unit)
       } yield {
         updated
       }
@@ -895,6 +852,7 @@ class WoLDAPNodeGroupRepository(
   override def saveGroupCategory(category: NodeGroupCategory, containerId: NodeGroupCategoryId)(implicit
       cc: ChangeContext
   ): IOResult[NodeGroupCategory] = {
+    given QueryContext = cc.toQC
     groupLibMutex.writeLock(for {
       con              <- ldap
       oldParents       <- if (autoExportOnModify) {
@@ -951,6 +909,7 @@ class WoLDAPNodeGroupRepository(
   override def delete(id: NodeGroupCategoryId, checkEmpty: Boolean = true)(implicit
       cc: ChangeContext
   ): IOResult[NodeGroupCategoryId] = {
+    given QueryContext = cc.toQC
     groupLibMutex.writeLock(for {
       con     <- ldap
       deleted <- getCategoryEntry(con, id).flatMap {
@@ -994,6 +953,7 @@ class WoLDAPNodeGroupRepository(
    * The id used to save it will be the id provided by the nodeGroup
    */
   override def create(nodeGroup: NodeGroup, into: NodeGroupCategoryId)(implicit cc: ChangeContext): IOResult[AddNodeGroupDiff] = {
+    given QueryContext = cc.toQC
     groupLibMutex.writeLock(for {
       con           <- ldap
       exists        <- checkNodeGroupExists(con, nodeGroup)
@@ -1003,34 +963,24 @@ class WoLDAPNodeGroupRepository(
                          ).fail
                        }
       categoryEntry <- getCategoryEntry(con, into).notOptional(s"Entry with ID '${into.value}' was not found")
-      category      <- mapper.entry2NodeGroupCategory(categoryEntry).toIO
-      diff          <- cc.accessGrant.canSeeOrFail(category) {
-                         for {
-                           status <- tenantRepo.getStatus
-                           diff   <- tenantService.manageCreate(nodeGroup, cc, status) { ng =>
-                                       val entry = mapper.nodeGroupToLdap(ng, categoryEntry.dn)
-                                       for {
-                                         result       <- con.save(entry, removeMissingAttributes = true)
-                                         diff         <- diffMapper.addChangeRecords2NodeGroupDiff(entry.dn, result).toIO
-                                         loggedAction <- actionLogEffect.saveAddNodeGroup(diff)
-                                         // We don't want to check if this is a system group or not, because new groups are not systems (see constructor)
-                                         autoArchive  <- (if (autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord]) {
-                                                            for {
-                                                              parents  <- getParents_NodeGroupCategory(into)
-                                                              commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
-                                                              archived <-
-                                                                gitArchiver
-                                                                  .archiveNodeGroup(
-                                                                    nodeGroup,
-                                                                    into :: (parents.map(_.id)),
-                                                                    Some((cc.modId, commiter, cc.message))
-                                                                  )
-                                                            } yield archived
-                                                          } else ZIO.unit)
-                                       } yield diff
-                                     }
-                         } yield diff
-                       }
+      entry          = mapper.nodeGroupToLdap(nodeGroup, categoryEntry.dn)
+      result        <- con.save(entry, removeMissingAttributes = true)
+      diff          <- diffMapper.addChangeRecords2NodeGroupDiff(entry.dn, result).toIO
+      loggedAction  <- actionLogEffect.saveAddNodeGroup(diff)
+      // We don't want to check if this is a system group or not, because new groups are not systems (see constructor)
+      autoArchive   <- (if (autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord]) {
+                          for {
+                            parents  <- getParents_NodeGroupCategory(into)
+                            commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                            archived <-
+                              gitArchiver
+                                .archiveNodeGroup(
+                                  nodeGroup,
+                                  into :: (parents.map(_.id)),
+                                  Some((cc.modId, commiter, cc.message))
+                                )
+                          } yield archived
+                        } else ZIO.unit)
     } yield {
       diff
     })
@@ -1095,41 +1045,37 @@ class WoLDAPNodeGroupRepository(
         result   <- if (oldGroup.equals(nodeGroup)) {
                       None.succeed
                     } else {
-                      tenantRepo.getStatus.flatMap { status =>
-                        tenantService.manageUpdate(Some(oldGroup), nodeGroup, cc, status) { ng =>
-                          for {
-                            systemCheck <- if (onlyUpdateNodes) {
-                                             oldGroup.succeed
-                                           } else {
-                                             (oldGroup.isSystem, systemCall) match {
-                                               case (true, false) =>
-                                                 s"System group '${oldGroup.name}' (${oldGroup.id.serialize}) can not be modified".fail
-                                               case (false, true) =>
-                                                 s"You can not modify a non system group (${oldGroup.name}) with that method".fail
-                                               case _             => oldGroup.succeed
-                                             }
-                                           }
-                            name        <- checkNameAlreadyInUse(con, ng.name, ng.id)
-                            exists      <- ZIO.when(name && !onlyUpdateNodes) {
-                                             s"Cannot change the group name to ${ng.name} : there is already a group with the same name".fail
-                                           }
-                            onlyNodes   <- if (!onlyUpdateNodes) {
-                                             ZIO.unit
-                                           } else { // check that nothing but the node list changed
-                                             if (ng.copy(serverList = oldGroup.serverList) == oldGroup) {
-                                               ZIO.unit
-                                             } else {
-                                               logPure.debug(
-                                                 s"Inconsistency when modifying node lists for ng ${ng.name}: previous content was ${oldGroup}, new is ${ng} - only the node list should change"
-                                               ) *>
-                                               "The group configuration changed compared to the reference group you want to change the node list for. Aborting to preserve consistency".fail
-                                             }
-                                           }
-                            change      <- saveModifyNodeGroupDiff(existing, con, ng)
-                          } yield {
-                            change
-                          }
-                        }
+                      for {
+                        systemCheck <- if (onlyUpdateNodes) {
+                                         oldGroup.succeed
+                                       } else {
+                                         (oldGroup.isSystem, systemCall) match {
+                                           case (true, false) =>
+                                             s"System group '${oldGroup.name}' (${oldGroup.id.serialize}) can not be modified".fail
+                                           case (false, true) =>
+                                             s"You can not modify a non system group (${oldGroup.name}) with that method".fail
+                                           case _             => oldGroup.succeed
+                                         }
+                                       }
+                        name        <- checkNameAlreadyInUse(con, nodeGroup.name, nodeGroup.id)
+                        exists      <- ZIO.when(name && !onlyUpdateNodes) {
+                                         s"Cannot change the group name to ${nodeGroup.name} : there is already a group with the same name".fail
+                                       }
+                        onlyNodes   <- if (!onlyUpdateNodes) {
+                                         ZIO.unit
+                                       } else { // check that nothing but the node list changed
+                                         if (nodeGroup.modify(_.serverList).setTo(oldGroup.serverList) == oldGroup) {
+                                           ZIO.unit
+                                         } else {
+                                           logPure.debug(
+                                             s"Inconsistency when modifying node lists for ng ${nodeGroup.name}: previous content was ${oldGroup}, new is ${nodeGroup} - only the node list should change"
+                                           ) *>
+                                           "The group configuration changed compared to the reference group you want to change the node list for. Aborting to preserve consistency".fail
+                                         }
+                                       }
+                        change      <- saveModifyNodeGroupDiff(existing, con, nodeGroup)
+                      } yield {
+                        change
                       }
                     }
       } yield {
@@ -1143,7 +1089,8 @@ class WoLDAPNodeGroupRepository(
       con:       RwLDAPConnection,
       nodeGroup: NodeGroup
   )(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]] = {
-    val entry = mapper.nodeGroupToLdap(nodeGroup, existing.dn.getParent)
+    given QueryContext = cc.toQC
+    val entry          = mapper.nodeGroupToLdap(nodeGroup, existing.dn.getParent)
     // note: this is not protected by a lock because of the risk of calling it in a read lock
     // in a subclass. All callers must call it in a `writeLock`.
     for {
@@ -1202,7 +1149,7 @@ class WoLDAPNodeGroupRepository(
                     )
         oldGroup <-
           mapper.entry2NodeGroup(existing).toIO.chainError(s"Error when trying to check for the group '${nodeGroupId.serialize}'")
-        newGroup  = oldGroup.copy(serverList = (oldGroup.serverList -- delete) ++ add)
+        newGroup  = oldGroup.modify(_.serverList).setTo((oldGroup.serverList -- delete) ++ add)
         result   <- saveModifyNodeGroupDiff(existing, con, newGroup)
       } yield {
         result
@@ -1215,6 +1162,7 @@ class WoLDAPNodeGroupRepository(
       containerId: NodeGroupCategoryId
   )(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]] = {
     import cc.*
+    given QueryContext = cc.toQC
     groupLibMutex.writeLock(for {
       con         <- ldap
       oldParents  <- if (autoExportOnModify) {
@@ -1274,6 +1222,7 @@ class WoLDAPNodeGroupRepository(
    * @return
    */
   override def delete(id: NodeGroupId)(implicit cc: ChangeContext): IOResult[DeleteNodeGroupDiff] = {
+    given QueryContext = cc.toQC
     groupLibMutex.writeLock(for {
       con          <- ldap
       parents      <- if (autoExportOnModify) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -63,13 +63,13 @@ import zio.json.*
 import zio.syntax.*
 
 class WoLDAPNodeRepository(
-    nodeDit:      NodeDit,
-    acceptedDit:  InventoryDit,
-    mapper:       LDAPEntityMapper,
-    ldap:         LDAPConnectionProvider[RwLDAPConnection],
-    actionLogger: EventLogRepository,
-    nodeLibMutex: ScalaReadWriteLock, // that's a scala-level mutex to have some kind of consistency with LDAP
-
+    nodeDit:              NodeDit,
+    acceptedDit:          InventoryDit,
+    mapper:               LDAPEntityMapper,
+    ldap:                 LDAPConnectionProvider[RwLDAPConnection],
+    actionLogger:         EventLogRepository,
+    nodeLibMutex:         ScalaReadWriteLock,
+    // that's a scala-level mutex to have some kind of consistency with LDAP
     cacheExpectedReports: InvalidateCache[CacheExpectedReportAction],
     cacheConfiguration:   InvalidateCache[CacheComplianceQueueAction]
 ) extends WoNodeRepository with NamedZioLogger {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
@@ -37,8 +37,6 @@
 package com.normation.rudder.repository.ldap
 
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.ldap.sdk.*
 import com.normation.ldap.sdk.BuildFilter.*
 import com.normation.ldap.sdk.LDAPIOResult.*
@@ -54,6 +52,8 @@ import com.normation.rudder.domain.properties.ModifyGlobalParameterDiff
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.repository.*
 import com.normation.rudder.services.user.PersonIdentService
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.unboundid.ldif.LDIFChangeRecord
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -69,7 +69,7 @@ class RoLDAPParameterRepository(
 ) extends RoParameterRepository {
   repo =>
 
-  def getGlobalParameter(parameterName: String): IOResult[Option[GlobalParameter]] = {
+  def getGlobalParameter(parameterName: String)(using qc: QueryContext): IOResult[Option[GlobalParameter]] = {
     paramMutex.readLock(for {
       con   <- ldap
       opt   <- con.get(rudderDit.PARAMETERS.parameterDN(parameterName))
@@ -78,18 +78,20 @@ class RoLDAPParameterRepository(
                  case Some(entry) =>
                    mapper
                      .entry2Parameter(entry)
-                     .map(Some.apply)
                      .toIO
                      .chainError(
                        s"Error when transforming LDAP entry into global parameter for name '${parameterName}'. Entry: ${entry}"
                      )
+                     .map(Some(_))
                }
     } yield {
       param
     })
   }
 
-  private def getGP(search: RoLDAPConnection => LDAPIOResult[Seq[LDAPEntry]]): IOResult[Seq[GlobalParameter]] = {
+  private def getGP(
+      search: RoLDAPConnection => LDAPIOResult[Seq[LDAPEntry]]
+  ): IOResult[Seq[GlobalParameter]] = {
     paramMutex.readLock(for {
       con     <- ldap
       entries <- search(con)
@@ -104,7 +106,7 @@ class RoLDAPParameterRepository(
     })
   }
 
-  def getAllGlobalParameters(): IOResult[Seq[GlobalParameter]] = {
+  def getAllGlobalParameters()(using qc: QueryContext): IOResult[Seq[GlobalParameter]] = {
     getGP(con => con.searchSub(rudderDit.PARAMETERS.dn, IS(OC_PARAMETER)))
   }
 }
@@ -123,15 +125,12 @@ class WoLDAPParameterRepository(
   import roLDAPParameterRepository.*
 
   def saveParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): IOResult[AddGlobalParameterDiff] = {
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): IOResult[AddGlobalParameterDiff] = {
     paramMutex.writeLock(
       for {
         con          <- ldap
-        doesntExists <- roLDAPParameterRepository.getGlobalParameter(parameter.name).flatMap {
+        doesntExists <- roLDAPParameterRepository.getGlobalParameter(parameter.name)(using QueryContext.systemQC).flatMap {
                           case Some(entry) =>
                             Inconsistency(
                               s"Cannot create a global parameter with name ${parameter.name} : there is already a parameter with the same name"
@@ -139,15 +138,17 @@ class WoLDAPParameterRepository(
                           case None        => ZIO.unit
                         }
         paramEntry    = mapper.parameter2Entry(parameter)
-        result       <- con.save(paramEntry).chainError(s"Error when saving parameter entry in repository: ${paramEntry}")
+        result       <-
+          con.save(paramEntry).chainError(s"Error when saving parameter entry in repository: ${paramEntry}")
         diff         <- diffMapper.addChangeRecords2GlobalParameterDiff(paramEntry.dn, result).toIO
         loggedAction <- actionLogger
-                          .saveAddGlobalParameter(modId, principal = actor, addDiff = diff, reason = reason)
+                          .saveAddGlobalParameter(cc.modId, principal = cc.actor, addDiff = diff, reason = cc.message)
                           .chainError("Error when logging modification as an event")
         autoArchive  <- ZIO.when(autoExportOnModify) {
                           for {
-                            commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                            archive  <- gitParameterArchiver.archiveParameter(parameter, Some((modId, commiter, reason)))
+                            commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                            archive  <- gitParameterArchiver
+                                          .archiveParameter(parameter, Some((cc.modId, commiter, cc.message)))
                           } yield {
                             archive
                           }
@@ -159,22 +160,20 @@ class WoLDAPParameterRepository(
   }
 
   def updateParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): IOResult[Option[ModifyGlobalParameterDiff]] = {
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): IOResult[Option[ModifyGlobalParameterDiff]] = {
     paramMutex.writeLock(
       for {
         con          <- ldap
         oldParameter <-
           roLDAPParameterRepository
-            .getGlobalParameter(parameter.name)
+            .getGlobalParameter(parameter.name)(using QueryContext.systemQC)
             .notOptional(s"Cannot update Global Parameter '${parameter.name}': there is no parameter with that name")
         _            <- if (GenericProperty.canBeUpdated(oldParameter.provider, parameter.provider)) ZIO.unit
                         else {
                           val newProvider = parameter.provider.getOrElse(PropertyProvider.defaultPropertyProvider).value
-                          val oldProvider = oldParameter.provider.getOrElse(PropertyProvider.defaultPropertyProvider).value
+                          val oldProvider =
+                            oldParameter.provider.getOrElse(PropertyProvider.defaultPropertyProvider).value
                           Inconsistency(
                             s"Parameter with name '${parameter.name}' can not be updated by provider '${newProvider}' since its current provider is '${oldProvider}'"
                           ).fail
@@ -198,13 +197,19 @@ class WoLDAPParameterRepository(
                           case None       => ZIO.unit
                           case Some(diff) =>
                             actionLogger
-                              .saveModifyGlobalParameter(modId, principal = actor, modifyDiff = diff, reason = reason)
+                              .saveModifyGlobalParameter(
+                                cc.modId,
+                                principal = cc.actor,
+                                modifyDiff = diff,
+                                reason = cc.message
+                              )
                               .chainError("Error when logging modification as an event")
                         }
         autoArchive  <- ZIO.when(autoExportOnModify && optDiff.isDefined) { // only persists if modification are present
                           for {
-                            commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                            archive  <- gitParameterArchiver.archiveParameter(parameter, Some((modId, commiter, reason)))
+                            commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                            archive  <- gitParameterArchiver
+                                          .archiveParameter(parameter, Some((cc.modId, commiter, cc.message)))
                           } yield {
                             archive
                           }
@@ -217,11 +222,8 @@ class WoLDAPParameterRepository(
 
   def delete(
       parameterName: String,
-      provider:      Option[PropertyProvider],
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String]
-  ): IOResult[Option[DeleteGlobalParameterDiff]] = {
+      provider:      Option[PropertyProvider]
+  )(using cc: ChangeContext): IOResult[Option[DeleteGlobalParameterDiff]] = {
     def debugString(provider: Option[PropertyProvider]) = provider match {
       case None    => PropertyProvider.defaultPropertyProvider.value
       case Some(p) => p.value
@@ -229,7 +231,7 @@ class WoLDAPParameterRepository(
 
     paramMutex.writeLock(for {
       con         <- ldap
-      optOldParam <- roLDAPParameterRepository.getGlobalParameter(parameterName)
+      optOldParam <- roLDAPParameterRepository.getGlobalParameter(parameterName)(using QueryContext.systemQC)
       res         <- optOldParam match {
                        case None                => None.succeed
                        case Some(oldParamEntry) =>
@@ -246,12 +248,14 @@ class WoLDAPParameterRepository(
                                              .chainError(s"Error when deleting Global Parameter with name ${parameterName}")
                            diff          = DeleteGlobalParameterDiff(oldParamEntry)
                            loggedAction <-
-                             actionLogger.saveDeleteGlobalParameter(modId, principal = actor, deleteDiff = diff, reason = reason)
+                             actionLogger
+                               .saveDeleteGlobalParameter(cc.modId, principal = cc.actor, deleteDiff = diff, reason = cc.message)
                            autoArchive  <- ZIO.when(autoExportOnModify && deleted.nonEmpty) {
                                              for {
-                                               commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
+                                               commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
                                                archive  <-
-                                                 gitParameterArchiver.deleteParameter(parameterName, Some((modId, commiter, reason)))
+                                                 gitParameterArchiver
+                                                   .deleteParameter(parameterName, Some((cc.modId, commiter, cc.message)))
                                              } yield {
                                                archive
                                              }
@@ -298,7 +302,7 @@ class WoLDAPParameterRepository(
     val ou = rudderDit.ARCHIVES.parameterModel(id)
 
     paramMutex.writeLock(for {
-      existingParams <- getAllGlobalParameters()
+      existingParams <- getAllGlobalParameters()(using QueryContext.systemQC)
       con            <- ldap
       // ok, now that's the dangerous part
       swapParams     <- (for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
@@ -41,8 +41,6 @@ package ldap
 import com.normation.GitVersion
 import com.normation.NamedZioLogger
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.inventory.ldap.core.LDAPConstants.A_NAME
 import com.normation.ldap.sdk.*
 import com.normation.ldap.sdk.BuildFilter.*
@@ -53,6 +51,8 @@ import com.normation.rudder.domain.RudderLDAPConstants.*
 import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.services.user.PersonIdentService
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.unboundid.ldif.LDIFChangeRecord
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -73,7 +73,7 @@ class RoLDAPRuleRepository(
   /**
    * Try to find the rule with the given ID.
    */
-  def getOpt(id: RuleId): IOResult[Option[Rule]] = {
+  def getOpt(id: RuleId)(using qc: QueryContext): IOResult[Option[Rule]] = {
     ruleMutex.readLock(for {
       con     <- ldap
       crEntry <- con.get(rudderDit.RULES.configRuleDN(id))
@@ -82,16 +82,16 @@ class RoLDAPRuleRepository(
                    case Some(r) =>
                      mapper
                        .entry2Rule(r)
-                       .map(Some(_))
                        .toIO
                        .chainError(s"Error when transforming LDAP entry into a rule for id '${id.serialize}'. Entry: ${r}")
+                       .map(Some(_))
                  }
     } yield {
       rule
     })
   }
 
-  def getAll(includeSystem: Boolean = false): IOResult[Seq[Rule]] = {
+  def getAll(includeSystem: Boolean = false)(using qc: QueryContext): IOResult[Seq[Rule]] = {
     val filter = if (includeSystem) IS(OC_RULE) else AND(IS(OC_RULE), EQ(A_IS_SYSTEM, false.toLDAPString))
     ruleMutex.readLock(for {
       con     <- ldap
@@ -105,22 +105,8 @@ class RoLDAPRuleRepository(
     })
   }
 
-  def getIds(includeSystem: Boolean = false): IOResult[Set[RuleId]] = {
-    val filter = if (includeSystem) IS(OC_RULE) else AND(IS(OC_RULE), EQ(A_IS_SYSTEM, false.toLDAPString))
-    ruleMutex.readLock(for {
-      con     <- ldap
-      entries <- con.searchOne(rudderDit.RULES.dn, filter, A_RULE_UUID)
-      ids     <- ZIO.foreach(entries) { ruleEntry =>
-                   for {
-                     id <-
-                       ruleEntry(A_RULE_UUID).notOptional(s"Missing required attribute uuid in rule entry ${ruleEntry.dn.toString}")
-                   } yield {
-                     RuleId(RuleUid(id))
-                   }
-                 }
-    } yield {
-      ids.toSet
-    })
+  def getIds(includeSystem: Boolean = false)(using qc: QueryContext): IOResult[Set[RuleId]] = {
+    getAll(includeSystem).map(_.map(_.id).toSet)
   }
 
 }
@@ -157,11 +143,8 @@ class WoLDAPRuleRepository(
 
   private def internalDeleteRule(
       id:         RuleId,
-      modId:      ModificationId,
-      actor:      EventActor,
-      reason:     Option[String],
       callSystem: Boolean
-  ): IOResult[DeleteRuleDiff] = {
+  )(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
     ruleMutex.writeLock(for {
       _            <- ZIO.when(id.rev != GitVersion.DEFAULT_REV) {
                         Inconsistency(
@@ -182,11 +165,11 @@ class WoLDAPRuleRepository(
                       }
       deleted      <- con.delete(rudderDit.RULES.configRuleDN(id)).chainError("Error when deleting rule with ID %s".format(id))
       diff          = DeleteRuleDiff(oldCr)
-      loggedAction <- actionLogger.saveDeleteRule(modId, principal = actor, deleteDiff = diff, reason = reason)
+      loggedAction <- actionLogger.saveDeleteRule(cc.modId, principal = cc.actor, deleteDiff = diff, reason = cc.message)
       autoArchive  <- ZIO.when(autoExportOnModify && deleted.nonEmpty && !oldCr.isSystem) {
                         for {
-                          commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                          archive  <- gitCrArchiver.deleteRule(id, Some((modId, commiter, reason)))
+                          commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                          archive  <- gitCrArchiver.deleteRule(id, Some((cc.modId, commiter, cc.message)))
                         } yield {
                           archive
                         }
@@ -196,20 +179,15 @@ class WoLDAPRuleRepository(
     })
   }
 
-  override def deleteSystemRule(
-      id:     RuleId,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[DeleteRuleDiff] = {
-    internalDeleteRule(id, modId, actor, reason, callSystem = true)
+  override def deleteSystemRule(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
+    internalDeleteRule(id, callSystem = true)
   }
 
-  override def delete(id: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[DeleteRuleDiff] = {
-    internalDeleteRule(id, modId, actor, reason, callSystem = false)
+  override def delete(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
+    internalDeleteRule(id, callSystem = false)
   }
 
-  override def load(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit] = {
+  override def load(rule: Rule)(using cc: ChangeContext): IOResult[Unit] = {
     ruleMutex.writeLock(
       for {
         _             <- ZIO.when(rule.id.rev == GitVersion.DEFAULT_REV) {
@@ -218,12 +196,16 @@ class WoLDAPRuleRepository(
                            ).fail
                          }
         con           <- ldap
-        ruleExits     <- con.exists(rudderDit.RULES.configRuleDN(rule.id))
-        idDoesntExist <- ZIO.when(ruleExits) {
+        existingEntry <- con.get(rudderDit.RULES.configRuleDN(rule.id))
+        existingRule  <- existingEntry match {
+                           case None    => None.succeed
+                           case Some(e) => mapper.entry2Rule(e).toIO.map(Some(_))
+                         }
+        idDoesntExist <- ZIO.when(existingRule.isDefined) {
                            logPure.info(s"Rule with ID '${rule.id.serialize}' is already loaded: updating it.")
                          }
         crEntry        = mapper.rule2Entry(rule)
-        _             <- con.save(crEntry).chainError(s"Error when saving rule entry in repository: ${crEntry}")
+        _             <- con.save(crEntry).chainError(s"Error when saving rule entry in repository: ${crEntry}").unit
         // we don't persist a diff in git here because it wouldn't make any sens, but perhaps we
         // at least need to store an new event log for that. Since it's a WIP API, not doing it right now.
         // That's also why there is a modId/actor/reason not used.
@@ -231,7 +213,7 @@ class WoLDAPRuleRepository(
     )
   }
 
-  override def unload(ruleId: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit] = {
+  override def unload(ruleId: RuleId)(using cc: ChangeContext): IOResult[Unit] = {
     ruleMutex.writeLock(
       for {
         _   <- ZIO.when(ruleId.rev == GitVersion.DEFAULT_REV) {
@@ -251,7 +233,7 @@ class WoLDAPRuleRepository(
     )
   }
 
-  def create(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[AddRuleDiff] = {
+  def create(rule: Rule)(using cc: ChangeContext): IOResult[AddRuleDiff] = {
     ruleMutex.writeLock(for {
       _          <- ZIO.when(rule.id.rev != GitVersion.DEFAULT_REV) {
                       Inconsistency(
@@ -270,11 +252,11 @@ class WoLDAPRuleRepository(
       crEntry     = mapper.rule2Entry(rule)
       result     <- con.save(crEntry).chainError(s"Error when saving rule entry in repository: ${crEntry}")
       diff       <- diffMapper.addChangeRecords2RuleDiff(crEntry.dn, result).toIO
-      _          <- actionLogger.saveAddRule(modId, principal = actor, addDiff = diff, reason = reason)
+      _          <- actionLogger.saveAddRule(cc.modId, principal = cc.actor, addDiff = diff, reason = cc.message)
       _          <- ZIO.when(autoExportOnModify && !rule.isSystem) {
                       for {
-                        commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                        archive  <- gitCrArchiver.archiveRule(rule, Some((modId, commiter, reason)))
+                        commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                        archive  <- gitCrArchiver.archiveRule(rule, Some((cc.modId, commiter, cc.message)))
                       } yield {
                         archive
                       }
@@ -286,73 +268,69 @@ class WoLDAPRuleRepository(
 
   private def internalUpdate(
       rule:       Rule,
-      modId:      ModificationId,
-      actor:      EventActor,
-      reason:     Option[String],
       systemCall: Boolean
-  ): IOResult[Option[ModifyRuleDiff]] = {
+  )(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]] = {
     ruleMutex.writeLock(
       for {
-        _               <- ZIO.when(rule.id.rev != GitVersion.DEFAULT_REV) {
-                             Inconsistency(
-                               s"Error: you can't update a rule with a specific revision like here for rule with id '${rule.id.uid.serialize}' which has revision '${rule.id.rev.value}'"
-                             ).fail
-                           }
-        con             <- ldap
-        existingEntry   <- con
-                             .get(rudderDit.RULES.configRuleDN(rule.id))
-                             .notOptional(s"Cannot update rule with id ${rule.id.serialize} : there is no rule with that id")
-        oldRule         <-
+        _             <- ZIO.when(rule.id.rev != GitVersion.DEFAULT_REV) {
+                           Inconsistency(
+                             s"Error: you can't update a rule with a specific revision like here for rule with id '${rule.id.uid.serialize}' which has revision '${rule.id.rev.value}'"
+                           ).fail
+                         }
+        con           <- ldap
+        existingEntry <- con
+                           .get(rudderDit.RULES.configRuleDN(rule.id))
+                           .notOptional(s"Cannot update rule with id ${rule.id.serialize} : there is no rule with that id")
+        oldRule       <-
           mapper
             .entry2Rule(existingEntry)
             .toIO
             .chainError(s"Error when transforming LDAP entry into a Rule for id ${rule.id.serialize}. Entry: ${existingEntry}")
-        systemCheck     <- (oldRule.isSystem, systemCall) match {
-                             case (true, false) => s"System rule '${oldRule.name}' (${oldRule.id.serialize}) can not be modified".fail
-                             case (false, true) => "You can't modify a non-system rule with updateSystem method".fail
-                             case _             => ZIO.unit
+        systemCheck   <- (oldRule.isSystem, systemCall) match {
+                           case (true, false) =>
+                             s"System rule '${oldRule.name}' (${oldRule.id.serialize}) can not be modified".fail
+                           case (false, true) =>
+                             "You can't modify a non-system rule with updateSystem method".fail
+                           case _             => ZIO.unit
+                         }
+        exists        <- nodeRuleNameExists(con, rule.name, rule.id)
+        _             <- ZIO.when(exists) {
+                           s"Cannot update rule with name ${rule.name}: this name is already in use.".fail
+                         }
+        crEntry        = mapper.rule2Entry(rule)
+        result        <- con
+                           .save(crEntry, removeMissingAttributes = true)
+                           .chainError(s"Error when saving rule entry in repository: ${crEntry}")
+        optDiff       <- diffMapper
+                           .modChangeRecords2RuleDiff(existingEntry, result)
+                           .toIO
+                           .chainError(s"Error when mapping rule '${rule.id.serialize}' update to an diff: ${result}")
+        loggedAction  <- optDiff match {
+                           case None       => ZIO.unit
+                           case Some(diff) =>
+                             actionLogger
+                               .saveModifyRule(cc.modId, principal = cc.actor, modifyDiff = diff, reason = cc.message)
+                         }
+        autoArchive   <- ZIO.when(autoExportOnModify && optDiff.isDefined && !rule.isSystem) {
+                           for {
+                             commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                             archive  <- gitCrArchiver.archiveRule(rule, Some((cc.modId, commiter, cc.message)))
+                           } yield {
+                             archive
                            }
-        exists          <- nodeRuleNameExists(con, rule.name, rule.id)
-        nameIsAvailable <- ZIO.when(exists) {
-                             s"Cannot update rule with name ${rule.name}: this name is already in use.".fail
-                           }
-        crEntry          = mapper.rule2Entry(rule)
-        result          <-
-          con.save(crEntry, removeMissingAttributes = true).chainError(s"Error when saving rule entry in repository: ${crEntry}")
-        optDiff         <- diffMapper
-                             .modChangeRecords2RuleDiff(existingEntry, result)
-                             .toIO
-                             .chainError(s"Error when mapping rule '${rule.id.serialize}' update to an diff: ${result}")
-        loggedAction    <- optDiff match {
-                             case None       => ZIO.unit
-                             case Some(diff) =>
-                               actionLogger.saveModifyRule(modId, principal = actor, modifyDiff = diff, reason = reason)
-                           }
-        autoArchive     <- ZIO.when(autoExportOnModify && optDiff.isDefined && !rule.isSystem) {
-                             for {
-                               commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                               archive  <- gitCrArchiver.archiveRule(rule, Some((modId, commiter, reason)))
-                             } yield {
-                               archive
-                             }
-                           }
+                         }
       } yield {
         optDiff
       }
     )
   }
 
-  def update(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Option[ModifyRuleDiff]] = {
-    internalUpdate(rule, modId, actor, reason, systemCall = false)
+  def update(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]] = {
+    internalUpdate(rule, systemCall = false)
   }
 
-  def updateSystem(
-      rule:   Rule,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[Option[ModifyRuleDiff]] = {
-    internalUpdate(rule, modId, actor, reason, systemCall = true)
+  def updateSystem(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]] = {
+    internalUpdate(rule, systemCall = true)
   }
 
   /**
@@ -393,7 +371,7 @@ class WoLDAPRuleRepository(
 
     ruleMutex.writeLock(
       for {
-        existingCrs <- getAll(true)
+        existingCrs <- getAll(true)(using QueryContext.systemQC)
         con         <- ldap
         // ok, now that's the dangerous part
         swapCr      <- (for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.ncf.TechniqueCompiler
 import com.normation.rudder.repository.*
 import com.normation.rudder.services.marshalling.*
 import com.normation.rudder.services.user.PersonIdentService
+import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.XmlSafe
 import java.io.File
 import java.io.FileNotFoundException
@@ -728,7 +729,7 @@ trait ActiveTechniqueModificationCallback {
       activeTechnique: ActiveTechnique,
       parents:         List[ActiveTechniqueCategoryId],
       gitCommit:       Option[(ModificationId, PersonIdent, Option[String])]
-  ): IOResult[Seq[DirectiveNotArchived]]
+  )(using qc: QueryContext): IOResult[Seq[DirectiveNotArchived]]
 
   /**
    * What to do on activeTechnique deletion
@@ -763,7 +764,7 @@ class UpdatePiOnActiveTechniqueEvent(
       activeTechnique: ActiveTechnique,
       parents:         List[ActiveTechniqueCategoryId],
       gitCommit:       Option[(ModificationId, PersonIdent, Option[String])]
-  ): IOResult[Seq[DirectiveNotArchived]] = {
+  )(using qc: QueryContext): IOResult[Seq[DirectiveNotArchived]] = {
 
     logPure.debug("Executing archivage of PIs for UPT '%s'".format(activeTechnique))
 
@@ -868,7 +869,9 @@ class GitActiveTechniqueArchiverImpl(
       // strategy for callbaack:
       // if at least one callback is in error, we don't execute the others and the full ActiveTechnique is in error.
       // if none is in error, we are going to next step
-      callbacks <- ZIO.foreach(uptModificationCallback.toList)(_.onArchive(activeTechnique, parents, gitCommit))
+      // archiving is a system-level operation, the callbacks see all tenants
+      callbacks <-
+        ZIO.foreach(uptModificationCallback.toList)(_.onArchive(activeTechnique, parents, gitCommit)(using QueryContext.systemQC))
       _         <- gitCommit match {
                      case Some((modId, commiter, reason)) =>
                        commitAddFileWithModId(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
@@ -58,6 +58,7 @@ import com.normation.rudder.rule.category.RoRuleCategoryRepository
 import com.normation.rudder.services.queries.DynGroupUpdaterService
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.zio.*
 import java.io.File
 import java.time.Instant
@@ -122,6 +123,24 @@ class ItemArchiveManagerImpl(
   ///// implementation /////
   override def loggerName: String = this.getClass.getName
 
+  /*
+   * Archive import/rollback restore a whole library (rules, groups, technique library, parameters) by
+   * swapping it wholesale. There is no sound per-tenant semantic for such a "replace everything" operation,
+   * so it must be restricted to administrators (tenant access grant '*'). For a tenant-restricted user, it
+   * would otherwise allow replacing/removing configuration objects belonging to other tenants.
+   * Note: when the multi-tenant feature is disabled, every user has an 'All' grant, so this is a no-op.
+   */
+  private def checkArchiveRestoreAllowed(implicit cc: ChangeContext): IOResult[Unit] = {
+    ZIO
+      .unless(cc.accessGrant == TenantAccessGrant.All) {
+        Inconsistency(
+          s"User '${cc.actor.name}' is not allowed to import or rollback an archive: this operation replaces the " +
+          s"whole configuration and is restricted to administrators with access to all tenants (grant '*')."
+        ).fail
+      }
+      .unit
+  }
+
   // Clean a directory only if it exists, all exception are caught by the tryo
   private def cleanExistingDirectory(directory: File): IOResult[Unit] = {
     IOResult.attempt {
@@ -162,7 +181,7 @@ class ItemArchiveManagerImpl(
   ) = {
     for {
       // Get Map of all categories grouped by parent categories
-      categories  <- roRuleCategoryeRepository.getRootCategory().map(_.childrenMap)
+      categories  <- roRuleCategoryeRepository.getRootCategory()(using QueryContext.systemQC).map(_.childrenMap)
       cleanedRoot <- cleanExistingDirectory(gitRuleCategoryArchiver.getItemDirectory)
       _           <- ZIO.foreachDiscard(categories) {
                        case (parentCategories, cats) =>
@@ -185,7 +204,7 @@ class ItemArchiveManagerImpl(
     for {
       // Treat categories before treating Rules
       categories  <- exportRuleCategories(commiter, modId, actor, reason)
-      rules       <- roRuleRepository.getAll(false)
+      rules       <- roRuleRepository.getAll(false)(using QueryContext.systemQC)
       cleanedRoot <- IOResult.attempt(FileUtils.cleanDirectory(gitRuleArchiver.getItemDirectory))
       saved       <- ZIO.foreach(rules.filterNot(_.isSystem))(rule => gitRuleArchiver.archiveRule(rule, None))
       commitId    <- gitRuleArchiver.commitRules(modId, commiter, reason)
@@ -201,10 +220,9 @@ class ItemArchiveManagerImpl(
       actor:    EventActor,
       reason:   Option[String]
   ): IOResult[(GitArchiveId, NotArchivedElements)] = {
-    // case class SavedDirective( saved:Seq[String, ])
-
+    // export is a system-level operation, it sees all tenants
     for {
-      catWithUPT  <- uptRepository.getActiveTechniqueByCategory(includeSystem = true)
+      catWithUPT  <- uptRepository.getActiveTechniqueByCategory(includeSystem = true)(using QueryContext.systemQC)
       // remove systems categories, we don't want to export them anymore
       okCatWithUPT = catWithUPT.toMap.collect {
                        // always include root category, even if it's a system one
@@ -323,7 +341,7 @@ class ItemArchiveManagerImpl(
       reason:   Option[String]
   ): IOResult[GitArchiveId] = {
     for {
-      parameters <- roParameterRepository.getAllGlobalParameters()
+      parameters <- roParameterRepository.getAllGlobalParameters()(using QueryContext.systemQC)
       _          <- IOResult.attempt(FileUtils.cleanDirectory(gitParameterArchiver.getItemDirectory))
       _          <- ZIO.foreach(parameters)(param => gitParameterArchiver.archiveParameter(param, None))
       commitId   <- gitParameterArchiver.commitParameters(modId, commiter, reason)
@@ -341,6 +359,7 @@ class ItemArchiveManagerImpl(
     import cc.*
     useSemaphoreOrFail(
       for {
+        _ <- checkArchiveRestoreAllowed
         _ <- GitArchiveLoggerPure.info("Importing full archive with id '%s'".format(archiveId.value))
         _ <- importRulesAndDeploy(archiveId, deploy = false)
         _ <- importTechniqueLibraryAndDeploy(archiveId, deploy = false)
@@ -369,6 +388,7 @@ class ItemArchiveManagerImpl(
     val commitMsg = "User %s requested rule archive restoration to commit %s".format(actor.name, archiveId.value)
     useSemaphoreOrFail(
       for {
+        _ <- checkArchiveRestoreAllowed
         _ <- importRulesAndDeploy(archiveId)
         _ <- eventLogger.saveEventLog(modId, new ImportRulesArchive(actor, archiveId, message))
         _ <- restoreCommitAtHead(commiter, commitMsg, archiveId, PartialArchive.ruleArchive, modId)
@@ -417,6 +437,7 @@ class ItemArchiveManagerImpl(
     val commitMsg = "User %s requested directive archive restoration to commit %s".format(actor.name, archiveId.value)
     useSemaphoreOrFail(
       for {
+        _ <- checkArchiveRestoreAllowed
         _ <- importTechniqueLibraryAndDeploy(archiveId)
         _ <- eventLogger.saveEventLog(modId, new ImportTechniqueLibraryArchive(actor, archiveId, message))
         _ <- restoreCommitAtHead(commiter, commitMsg, archiveId, TechniqueLibraryArchive, modId)
@@ -448,6 +469,7 @@ class ItemArchiveManagerImpl(
     val commitMsg = "User %s requested group archive restoration to commit %s".format(actor.name, archiveId.value)
     useSemaphoreOrFail(
       for {
+        _ <- checkArchiveRestoreAllowed
         _ <- importGroupLibraryAndDeploy(archiveId)
         _ <- eventLogger.saveEventLog(modId, new ImportGroupsArchive(actor, archiveId, message))
         _ <- restoreCommitAtHead(commiter, commitMsg, archiveId, PartialArchive.groupArchive, modId)
@@ -480,6 +502,7 @@ class ItemArchiveManagerImpl(
     val commitMsg = "User %s requested Parameters archive restoration to commit %s".format(actor.name, archiveId.value)
     useSemaphoreOrFail(
       for {
+        _ <- checkArchiveRestoreAllowed
         _ <- importParametersAndDeploy(archiveId)
         _ <- eventLogger.saveEventLog(modId, new ImportParametersArchive(actor, archiveId, message))
         _ <- restoreCommitAtHead(commiter, commitMsg, archiveId, PartialArchive.parameterArchive, modId)
@@ -525,6 +548,7 @@ class ItemArchiveManagerImpl(
     import cc.*
     useSemaphoreOrFail(
       for {
+        _ <- checkArchiveRestoreAllowed
         _ <- GitArchiveLoggerPure.info(s"Importing full archive with id '${archiveId.value}'")
         _ <- importRulesAndDeploy(archiveId, deploy = false)
         _ <- importTechniqueLibraryAndDeploy(archiveId, deploy = false)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
@@ -40,8 +40,6 @@ package com.normation.rudder.rule.category
 import cats.implicits.*
 import com.normation.NamedZioLogger
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.inventory.ldap.core.LDAPConstants.*
 import com.normation.ldap.ldif.LDIFNoopChangeRecord
 import com.normation.ldap.sdk.*
@@ -51,6 +49,8 @@ import com.normation.rudder.domain.RudderLDAPConstants.*
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.repository.ldap.ScalaReadWriteLock
 import com.normation.rudder.services.user.PersonIdentService
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.Utils
 import com.unboundid.ldap.sdk.DN
@@ -81,7 +81,7 @@ class RoLDAPRuleCategoryRepository(
   /**
    * Get category with given Id
    */
-  def get(id: RuleCategoryId): IOResult[RuleCategory] = {
+  def get(id: RuleCategoryId)(using qc: QueryContext): IOResult[RuleCategory] = {
     categoryMutex.readLock(for {
       con      <- ldap
       entry    <- getCategoryEntry(con, id).notOptional(s"Entry with ID '${id.value}' was not found")
@@ -121,7 +121,7 @@ class RoLDAPRuleCategoryRepository(
   /**
    * get Root category
    */
-  override def getRootCategory(): IOResult[RuleCategory] = {
+  override def getRootCategory()(using qc: QueryContext): IOResult[RuleCategory] = {
     val catAttributes = Seq(A_OC, A_RULE_CATEGORY_UUID, A_NAME, A_RULE_TARGET, A_DESCRIPTION, A_IS_ENABLED, A_IS_SYSTEM)
 
     categoryMutex.readLock(for {
@@ -226,7 +226,7 @@ class WoLDAPRuleCategoryRepository(
   /**
    * Return the list of parents for that category, from the root category
    */
-  private def getParents(id: RuleCategoryId): IOResult[List[RuleCategory]] = {
+  private def getParents(id: RuleCategoryId)(using qc: QueryContext): IOResult[List[RuleCategory]] = {
     for {
       root    <- getRootCategory()
       parents <- root.findParents(id).leftMap(s => Inconsistency(s)).toIO
@@ -243,12 +243,10 @@ class WoLDAPRuleCategoryRepository(
    * return the new category.
    */
   override def create(
-      that:   RuleCategory,
-      into:   RuleCategoryId,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[RuleCategory] = {
+      that: RuleCategory,
+      into: RuleCategoryId
+  )(implicit cc: ChangeContext): IOResult[RuleCategory] = {
+    given QueryContext = cc.toQC
     categoryMutex.writeLock(for {
       con                 <- ldap
       parentCategoryEntry <-
@@ -264,8 +262,9 @@ class WoLDAPRuleCategoryRepository(
       autoArchive         <- ZIO.when(autoExportOnModify && !result.isInstanceOf[LDIFNoopChangeRecord] && !that.isSystem) {
                                for {
                                  parents  <- getParents(that.id)
-                                 commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                                 archive  <- gitArchiver.archiveRuleCategory(that, parents.map(_.id), Some((modId, commiter, reason)))
+                                 commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
+                                 archive  <-
+                                   gitArchiver.archiveRuleCategory(that, parents.map(_.id), Some((cc.modId, commiter, cc.message)))
                                } yield {
                                  archive
                                }
@@ -281,11 +280,9 @@ class WoLDAPRuleCategoryRepository(
    */
   override def updateAndMove(
       category:    RuleCategory,
-      containerId: RuleCategoryId,
-      modId:       ModificationId,
-      actor:       EventActor,
-      reason:      Option[String]
-  ): IOResult[RuleCategory] = {
+      containerId: RuleCategoryId
+  )(implicit cc: ChangeContext): IOResult[RuleCategory] = {
+    given QueryContext = cc.toQC
     categoryMutex.writeLock(for {
       con              <- ldap
       oldParents       <- if (autoExportOnModify) {
@@ -314,12 +311,12 @@ class WoLDAPRuleCategoryRepository(
                             case _ if (autoExportOnModify && !updated.isSystem)     =>
                               (for {
                                 parents  <- getParents(updated.id)
-                                commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
+                                commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
                                 moved    <- gitArchiver.moveRuleCategory(
                                               updated,
                                               oldParents.map(_.id),
                                               parents.map(_.id),
-                                              Some((modId, commiter, reason))
+                                              Some((cc.modId, commiter, cc.message))
                                             )
                               } yield {
                                 moved
@@ -342,11 +339,9 @@ class WoLDAPRuleCategoryRepository(
    */
   override def delete(
       that:       RuleCategoryId,
-      modId:      ModificationId,
-      actor:      EventActor,
-      reason:     Option[String],
       checkEmpty: Boolean = true
-  ): IOResult[RuleCategoryId] = {
+  )(implicit cc: ChangeContext): IOResult[RuleCategoryId] = {
+    given QueryContext = cc.toQC
     categoryMutex.writeLock(for {
       con     <- ldap
       deleted <- {
@@ -363,9 +358,10 @@ class WoLDAPRuleCategoryRepository(
               autoArchive <- ZIO
                                .when(autoExportOnModify && ok.size > 0 && !category.isSystem) {
                                  for {
-                                   commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
+                                   commiter <- personIdentService.getPersonIdentOrDefault(cc.actor.name)
                                    archive  <-
-                                     gitArchiver.deleteRuleCategory(that, parents.map(_.id), Some((modId, commiter, reason)))
+                                     gitArchiver
+                                       .deleteRuleCategory(that, parents.map(_.id), Some((cc.modId, commiter, cc.message)))
                                  } yield {
                                    archive
                                  }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategory.scala
@@ -174,6 +174,7 @@ object RuleCategory {
   given HasSecurityTag[RuleCategory] with {
     extension (a: RuleCategory) {
       override def security: Option[SecurityTag] = a.security
+      override def isSystem: Boolean             = a.isSystem
       override def debugId:  String              = a.id.value
       override def updateSecurityContext(security: Option[SecurityTag]): RuleCategory = a.copy(security = security)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategoryRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategoryRepository.scala
@@ -38,41 +38,32 @@
 package com.normation.rudder.rule.category
 
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 
 trait RoRuleCategoryRepository {
 
-  def get(id: RuleCategoryId): IOResult[RuleCategory]
+  def get(id: RuleCategoryId)(using qc: QueryContext): IOResult[RuleCategory]
 
-  def getRootCategory(): IOResult[RuleCategory]
+  def getRootCategory()(using qc: QueryContext): IOResult[RuleCategory]
 
 }
 
 trait WoRuleCategoryRepository {
 
   def create(
-      that:   RuleCategory,
-      into:   RuleCategoryId,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[RuleCategory]
+      that: RuleCategory,
+      into: RuleCategoryId
+  )(implicit cc: ChangeContext): IOResult[RuleCategory]
 
   def updateAndMove(
-      that:   RuleCategory,
-      into:   RuleCategoryId,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): IOResult[RuleCategory]
+      that: RuleCategory,
+      into: RuleCategoryId
+  )(implicit cc: ChangeContext): IOResult[RuleCategory]
 
   def delete(
       category:   RuleCategoryId,
-      modId:      ModificationId,
-      actor:      EventActor,
-      reason:     Option[String],
       checkEmpty: Boolean = true
-  ): IOResult[RuleCategoryId]
+  )(implicit cc: ChangeContext): IOResult[RuleCategoryId]
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -381,7 +381,7 @@ class RefuseGroups(
   override def refuseOne(cnf: CoreNodeFact)(implicit cc: ChangeContext): IOResult[Unit] = {
     // remove server id in all groups
     for {
-      groupIds <- roGroupRepo.findGroupWithAnyMember(Seq(cnf.id))
+      groupIds <- roGroupRepo.findGroupWithAnyMember(Seq(cnf.id))(using cc.toQC)
       _        <- ZIO.foreach(groupIds) { groupId =>
                     for {
                       groupPair <- roGroupRepo.getNodeGroup(groupId)(using cc.toQC)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -170,7 +170,7 @@ class FactRemoveNodeBackend(backend: NodeFactRepository) extends RemoveNodeBacke
   override def findNodeStatuses(nodeId: NodeId): IOResult[Set[InventoryStatus]] = {
     // here, we need to return "RemovedInventory" in case of missing node, so CoreNodeFactRepo #getStatus
     // is not what we want;
-    backend.get(nodeId)(using QueryContext.todoQC, SelectNodeStatus.Any).map {
+    backend.get(nodeId)(using QueryContext.systemQC, SelectNodeStatus.Any).map {
       case None    => Set(RemovedInventory)
       case Some(x) => Set(x.rudderSettings.status)
     }
@@ -467,7 +467,7 @@ class RemoveNodeFromGroups(
   )(implicit cc: ChangeContext): UIO[Unit] = {
     (for {
       _            <- NodeLoggerPure.Delete.debug(s"  - remove node ${nodeId.value} from his groups")
-      nodeGroupIds <- roNodeGroupRepository.findGroupWithAnyMember(Seq(nodeId))
+      nodeGroupIds <- roNodeGroupRepository.findGroupWithAnyMember(Seq(nodeId))(using cc.toQC)
       _            <- ZIO.foreach(nodeGroupIds) { nodeGroupId =>
                         val msg = Some("Automatic update of group due to deletion of node " + nodeId.value)
                         woNodeGroupRepository

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -81,6 +81,7 @@ import com.normation.rudder.domain.reports.NodeModeConfig
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.reports.ComplianceMode
 import com.normation.rudder.schedule.JsonDirectiveSchedule
+import com.normation.rudder.tenants.SecurityTag
 import com.typesafe.config.ConfigValue
 import java.time.Instant
 import scala.collection.immutable.TreeMap
@@ -822,3 +823,11 @@ final case class RuleVal(
     nodeIds:            Set[NodeId],
     parsedPolicyDrafts: Seq[ParsedPolicyDraft]
 )
+
+/*
+ * The per-node information needed to resolve a rule's targets to actual nodes during policy generation:
+ * whether the node is a policy server (used by the special targets), and its tenant security tag (used to
+ * enforce the tenant boundary). Both come from the same `NodeFact`, so they travel together rather than as
+ * two parallel `Map[NodeId, _]`.
+ */
+final case class NodeSecurityInfo(isPolicyServer: Boolean, security: Option[SecurityTag])

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
@@ -40,8 +40,6 @@ package com.normation.rudder.services.policies
 import com.normation.NamedZioLogger
 import com.normation.box.*
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.ldap.sdk.BuildFilter.*
 import com.normation.ldap.sdk.LDAPConnectionProvider
 import com.normation.ldap.sdk.LDAPIOResult.*
@@ -60,6 +58,7 @@ import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.repository.*
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import net.liftweb.common.*
 import zio.*
 import zio.syntax.*
@@ -129,11 +128,8 @@ trait DependencyAndDeletionService {
    * Return the list of items actually modified.
    */
   def cascadeDeleteDirective(
-      id:     DirectiveUid,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): Box[DirectiveDependencies]
+      id: DirectiveUid
+  )(using cc: ChangeContext): Box[DirectiveDependencies]
 
   /**
    * Find all rules and directives that depend on that
@@ -159,11 +155,8 @@ trait DependencyAndDeletionService {
    * Return the list of items actually modified.
    */
   def cascadeDeleteTechnique(
-      id:     ActiveTechniqueId,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): Box[TechniqueDependencies]
+      id: ActiveTechniqueId
+  )(using cc: ChangeContext): Box[TechniqueDependencies]
 
   /**
    * Find all rules that depend on that
@@ -297,24 +290,21 @@ class DependencyAndDeletionServiceImpl(
    * Return the list of items actually deleted.
    */
   override def cascadeDeleteDirective(
-      id:     DirectiveUid,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): Box[DirectiveDependencies] = {
+      id: DirectiveUid
+  )(using cc: ChangeContext): Box[DirectiveDependencies] = {
     for {
       configRules  <- findDependencies.findRulesForDirective(id)
       diff         <- woDirectiveRepository
-                        .delete(id, modId, actor, reason)
+                        .delete(id)
                         .chainError(s"Error when deleting policy instance with ID '${id.value}'.")
       updatedRules <- ZIO.foreach(configRules) { rule =>
                         // check that directive is actually in rule directives, and remove it
                         if (rule.directiveIds.exists(i => id == i.uid)) {
                           val newRule        = rule.copy(directiveIds = rule.directiveIds.filterNot(_.uid == id))
                           val updatedRuleRes = if (rule.isSystem) {
-                            woRuleRepository.updateSystem(newRule, modId, actor, reason)
+                            woRuleRepository.updateSystem(newRule)
                           } else {
-                            woRuleRepository.update(newRule, modId, actor, reason)
+                            woRuleRepository.update(newRule)
                           }
                           updatedRuleRes.chainError(
                             s"Can not remove directive '${id.value}' from rule with ID '${rule.id.serialize}'. %s".format {
@@ -352,6 +342,8 @@ class DependencyAndDeletionServiceImpl(
       boxGroupLib:  Box[FullNodeGroupCategory],
       onlyForState: ModificationStatus = DontCare
   ): Box[TechniqueDependencies] = {
+    // dependency look-up is a system-level query, not tenant-restricted
+    given qc: QueryContext = QueryContext.systemQC
     for {
       directives <- roDirectiveRepository.getDirectives(id)
       // if we are asked only for enable directives, remove disabled ones
@@ -396,18 +388,14 @@ class DependencyAndDeletionServiceImpl(
    * Return the list of items actually deleted.
    */
   def cascadeDeleteTechnique(
-      id:     ActiveTechniqueId,
-      modId:  ModificationId,
-      actor:  EventActor,
-      reason: Option[String]
-  ): Box[TechniqueDependencies] = {
+      id: ActiveTechniqueId
+  )(using cc: ChangeContext): Box[TechniqueDependencies] = {
+    given qc: QueryContext = cc.toQC
     for {
       directives             <- roDirectiveRepository.getDirectives(id)
       piMap                   = directives.map(directive => (directive.id.uid, directive)).toMap
-      deletedPis             <- ZIO.foreach(directives) { directive =>
-                                  cascadeDeleteDirective(directive.id.uid, modId, actor, reason = reason).toIO
-                                }
-      deletedActiveTechnique <- woDirectiveRepository.deleteActiveTechnique(id, modId, actor, reason)
+      deletedPis             <- ZIO.foreach(directives)(directive => cascadeDeleteDirective(directive.id.uid).toIO)
+      deletedActiveTechnique <- woDirectiveRepository.deleteActiveTechnique(id)
     } yield {
       val allCrs     = scala.collection.mutable.Map[RuleId, Rule]()
       val directives = deletedPis.map {
@@ -446,7 +434,7 @@ class DependencyAndDeletionServiceImpl(
           case (id, seq) =>
             for {
               optPair <- roDirectiveRepository
-                           .getActiveTechniqueAndDirective(id)
+                           .getActiveTechniqueAndDirective(id)(using QueryContext.systemQC)
                            .chainError(s"Error when retrieving directive with ID '${id.debugString}'")
               // here, if we don't have a directive for the ID, we assume it's a directive that was
               // deleted but not cleanly removed everywhere.
@@ -497,9 +485,9 @@ class DependencyAndDeletionServiceImpl(
       // Update the Rule and save it
       val updatedRule    = rule.copy(targets = updatedTargets)
       val updatedRuleRes = if (rule.isSystem) {
-        woRuleRepository.updateSystem(updatedRule, cc.modId, cc.actor, cc.message)
+        woRuleRepository.updateSystem(updatedRule)
       } else {
-        woRuleRepository.update(updatedRule, cc.modId, cc.actor, cc.message)
+        woRuleRepository.update(updatedRule)
       }
       updatedRuleRes.chainError(s"Can not remove target '${targetToDelete.target}' from rule with id '${rule.id.serialize}'.")
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
@@ -497,12 +497,14 @@ class DependencyAndDeletionServiceImpl(
         for {
           configRules   <- findDependencies.findRulesForTarget(targetToDelete)
           updatedRules  <- ZIO.foreach(configRules)(updateRule)
-          deletedTarget <- woGroupRepository
-                             .delete(groupId)
-                             .chainError(
-                               "Error when deleting target %s. All dependent rules where updated %s"
-                                 .format(targetToDelete, configRules.map(_.id.serialize).mkString("(", ", ", ")"))
-                             )
+          deletedTarget <-
+            woGroupRepository
+              .delete(groupId)
+              .chainError(
+                s"Error when deleting target '${targetToDelete.target}'. All dependent rules where updated: ${configRules
+                    .map(_.id.serialize)
+                    .mkString("(", ", ", ")")}"
+              )
         } yield {
           TargetDependencies(targetToDelete, configRules.toSet)
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
@@ -38,13 +38,13 @@
 package com.normation.rudder.services.policies
 
 import com.normation.box.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.properties.*
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import net.liftweb.common.*
 
 trait RoParameterService {
@@ -52,12 +52,12 @@ trait RoParameterService {
   /**
    * Returns a Global Parameter by its name
    */
-  def getGlobalParameter(parameterName: String): Box[Option[GlobalParameter]]
+  def getGlobalParameter(parameterName: String)(using qc: QueryContext): Box[Option[GlobalParameter]]
 
   /**
    * Returns all defined Global Parameters
    */
-  def getAllGlobalParameters(): Box[Seq[GlobalParameter]]
+  def getAllGlobalParameters()(using qc: QueryContext): Box[Seq[GlobalParameter]]
 }
 
 trait WoParameterService {
@@ -68,11 +68,8 @@ trait WoParameterService {
    * Will fail if a parameter with the same name exists
    */
   def saveParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): Box[GlobalParameter]
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): Box[GlobalParameter]
 
   /**
    * Updates a parameter
@@ -80,22 +77,16 @@ trait WoParameterService {
    * Will fail if no params with the same name exists
    */
   def updateParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): Box[GlobalParameter]
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): Box[GlobalParameter]
 
   /**
    * Delete a global parameter
    */
   def delete(
       parameterName: String,
-      provider:      Option[PropertyProvider],
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String]
-  ): Box[String]
+      provider:      Option[PropertyProvider]
+  )(using cc: ChangeContext): Box[String]
 }
 
 class RoParameterServiceImpl(
@@ -105,7 +96,7 @@ class RoParameterServiceImpl(
   /**
    * Returns a Global Parameter by its name
    */
-  def getGlobalParameter(parameterName: String): Box[Option[GlobalParameter]] = {
+  def getGlobalParameter(parameterName: String)(using qc: QueryContext): Box[Option[GlobalParameter]] = {
     roParamRepo.getGlobalParameter(parameterName).toBox match {
       case Full(entry) => Full(entry)
       case Empty       => Full(None)
@@ -118,7 +109,7 @@ class RoParameterServiceImpl(
   /**
    * Returns all defined Global Parameters
    */
-  def getAllGlobalParameters(): Box[Seq[GlobalParameter]] = {
+  def getAllGlobalParameters()(using qc: QueryContext): Box[Seq[GlobalParameter]] = {
     roParamRepo.getAllGlobalParameters().toBox match {
       case Full(seq) => Full(seq)
       case Empty     => Full(Seq())
@@ -141,12 +132,9 @@ class WoParameterServiceImpl(
    * Will fail if a parameter with the same name exists
    */
   def saveParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): Box[GlobalParameter] = {
-    woParamRepo.saveParameter(parameter, modId, actor, reason).toBox match {
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): Box[GlobalParameter] = {
+    woParamRepo.saveParameter(parameter).toBox match {
       case e: Failure =>
         logger.error("Error while trying to create param %s : %s".format(parameter.name, e.messageChain))
         e
@@ -155,14 +143,14 @@ class WoParameterServiceImpl(
         Failure("Something unexpected happened when trying to create parameter %s".format(parameter.name))
       case Full(diff) =>
         // Ok, it's been save, try to fetch the new value
-        roParamService.getGlobalParameter(parameter.name) match {
+        roParamService.getGlobalParameter(parameter.name)(using cc.toQC) match {
           case e: EmptyBox => e
           case Full(option) =>
             option match {
               case Some(entry) =>
                 logger.debug("Successfully created parameter %s".format(parameter.name))
                 // launch a deployement
-                asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
+                asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, cc.actor)
                 Full(entry)
               case None        =>
                 logger.error("Could not fetch back newly created global parameter with name %s".format(parameter.name))
@@ -178,12 +166,9 @@ class WoParameterServiceImpl(
    * Will fail if no params with the same name exists
    */
   def updateParameter(
-      parameter: GlobalParameter,
-      modId:     ModificationId,
-      actor:     EventActor,
-      reason:    Option[String]
-  ): Box[GlobalParameter] = {
-    woParamRepo.updateParameter(parameter, modId, actor, reason).toBox match {
+      parameter: GlobalParameter
+  )(using cc: ChangeContext): Box[GlobalParameter] = {
+    woParamRepo.updateParameter(parameter).toBox match {
       case e: Failure =>
         logger.error("Error while trying to update param %s : %s".format(parameter.name, e.messageChain))
         e
@@ -192,14 +177,14 @@ class WoParameterServiceImpl(
         Failure("Something unexpected happened when trying to update parameter %s".format(parameter.name))
       case Full(diff) =>
         // Ok, it's been updated, try to fetch the new value
-        roParamService.getGlobalParameter(parameter.name) match {
+        roParamService.getGlobalParameter(parameter.name)(using cc.toQC) match {
           case e: EmptyBox => e
           case Full(option) =>
             option match {
               case Some(entry) =>
                 logger.debug("Successfully udated parameter %s".format(parameter.name))
                 // launch a deployement
-                asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
+                asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, cc.actor)
                 Full(entry)
               case None        =>
                 logger.error("Could not fetch back updated global parameter with name %s".format(parameter.name))
@@ -211,12 +196,9 @@ class WoParameterServiceImpl(
 
   def delete(
       parameterName: String,
-      provider:      Option[PropertyProvider],
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String]
-  ): Box[String] = {
-    woParamRepo.delete(parameterName, provider, modId, actor, reason).toBox match {
+      provider:      Option[PropertyProvider]
+  )(using cc: ChangeContext): Box[String] = {
+    woParamRepo.delete(parameterName, provider).toBox match {
       case e: Failure =>
         logger.error("Error while trying to delete param %s : %s".format(parameterName, e.messageChain))
         e
@@ -225,7 +207,7 @@ class WoParameterServiceImpl(
         Failure("Something unexpected happened when trying to update parameter %s".format(parameterName))
       case Full(diff) =>
         logger.debug("Successfully deleted parameter %s".format(parameterName))
-        asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
+        asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, cc.actor)
         Full(parameterName)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
@@ -46,15 +46,18 @@ import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.FullNodeGroupCategory
+import com.normation.rudder.tenants.TenantAccessGrant
 import java.time.Instant
 import zio.syntax.*
 
 trait RuleValService {
   def buildRuleVal(
-      rule:             Rule,
-      directiveLib:     FullActiveTechniqueCategory,
-      groupLib:         FullNodeGroupCategory,
-      arePolicyServers: Map[NodeId, Boolean]
+      rule:         Rule,
+      directiveLib: FullActiveTechniqueCategory,
+      groupLib:     FullNodeGroupCategory,
+      // per-node info (is-policy-server + tenant security tag) used to resolve targets and enforce the
+      // tenant boundary at generation time
+      nodes:        Map[NodeId, NodeSecurityInfo]
   ): IOResult[RuleVal]
 
   def lookupNodeParameterization(
@@ -197,30 +200,63 @@ class RuleValServiceImpl(
     }
   }
 
-  def getTargetedNodes(rule: Rule, groupLib: FullNodeGroupCategory, arePolicyServers: Map[NodeId, Boolean]): Set[NodeId] = {
-    val wantedNodeIds = groupLib.getNodeIds(rule.targets, arePolicyServers)
-    val nodeIds       = wantedNodeIds.intersect(arePolicyServers.keySet)
-    if (nodeIds.size != wantedNodeIds.size) {
+  def getTargetedNodes(
+      rule:     Rule,
+      groupLib: FullNodeGroupCategory,
+      nodes:    Map[NodeId, NodeSecurityInfo]
+  ): Set[NodeId] = {
+    // Tenant boundary: the tenants on a rule direct which objects and nodes it actually reaches.
+    val ruleScope = TenantAccessGrant.fromSecurityScope(rule.security)
+
+    // (d) target-level filter: drop simple targets the rule can't see - foreign groups, and admin-only
+    // special targets (AllTarget, etc: security `None`) which must not be usable by a tenant-scoped rule.
+    // Composite targets (union/intersection/exclusion) are not in `allTargets`; they pass through and are
+    // contained by the node-level filter below.
+    val scopedTargets = rule.targets.filter(t => groupLib.allTargets.get(t).forall(info => ruleScope.canSee(info.security)))
+
+    // target resolution only needs the is-policy-server flag; project it from the node info
+    val arePolicyServers = nodes.view.mapValues(_.isPolicyServer).toMap
+    val wantedNodeIds    = groupLib.getNodeIds(scopedTargets, arePolicyServers)
+    val presentNodeIds   = wantedNodeIds.intersect(nodes.keySet)
+    if (presentNodeIds.size != wantedNodeIds.size) {
       // ignored nodes are filtered-out early during generation, so we don't have access to their node info here,
       // they are just missing from allNodeInfos map.
       logger.debug(
         s"Some nodes are in the target of rule '${rule.name}' (${rule.id.serialize}) but are not present " +
-        s"in the system. These nodes are likely in state `ignored`: ${(wantedNodeIds -- nodeIds).map(_.value).mkString(", ")}"
+        s"in the system. These nodes are likely in state `ignored`: ${(wantedNodeIds -- presentNodeIds).map(_.value).mkString(", ")}"
+      )
+    }
+
+    // (node level, load-bearing) whatever the targets resolved to, keep only the nodes the rule's tenants
+    // can see. This contains composite targets and any node wrongly present in a group's serverList.
+    val nodeIds = presentNodeIds.filter(id => ruleScope.canSee(nodes.get(id).flatMap(_.security)))
+    if (nodeIds.size != presentNodeIds.size) {
+      logger.trace(
+        s"Rule '${rule.name}' (${rule.id.serialize}) targeted nodes filtered by tenant: excluded " +
+        s"${(presentNodeIds -- nodeIds).map(_.value).mkString(", ")}"
       )
     }
     nodeIds
   }
 
   override def buildRuleVal(
-      rule:             Rule,
-      directiveLib:     FullActiveTechniqueCategory,
-      groupLib:         FullNodeGroupCategory,
-      arePolicyServers: Map[NodeId, Boolean]
+      rule:         Rule,
+      directiveLib: FullActiveTechniqueCategory,
+      groupLib:     FullNodeGroupCategory,
+      nodes:        Map[NodeId, NodeSecurityInfo]
   ): IOResult[RuleVal] = {
-    val nodeIds = getTargetedNodes(rule, groupLib, arePolicyServers)
+    val ruleScope = TenantAccessGrant.fromSecurityScope(rule.security)
+    val nodeIds   = getTargetedNodes(rule, groupLib, nodes)
+
+    // (e) directive-level filter: a tenant-scoped rule only applies directives it shares a tenant with.
+    // Foreign or admin-only (`None`) directives referenced by a tenant rule are dropped. Untagged/admin
+    // rules (scope `All`) see every directive, so non-tenant setups are unaffected.
+    val scopedDirectiveIds = rule.directiveIds.toList.filter { id =>
+      directiveLib.allDirectives.get(id).forall { case (_, directive) => ruleScope.canSee(directive.security) }
+    }
 
     for {
-      drafts <- rule.directiveIds.toList.accumulate {
+      drafts <- scopedDirectiveIds.accumulate {
                   getParsedPolicyDraft(_, rule.id, BundleOrder(rule.name), rule.name, directiveLib)
                 }
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
@@ -243,7 +243,7 @@ class TechniqueAcceptationUpdater(
             }
           case TechniqueCategoryModType.Updated(cat)         =>
             logPure.debug(s"Category '${cat.id.toString}' updated") *>
-            roActiveTechniqueRepo.getActiveTechniqueCategory(toActiveCatId(cat.id)).flatMap { opt =>
+            roActiveTechniqueRepo.getActiveTechniqueCategory(toActiveCatId(cat.id))(using cc.toQC).flatMap { opt =>
               opt match {
                 case None           =>
                   (cat.id: @unchecked) match {
@@ -275,7 +275,7 @@ class TechniqueAcceptationUpdater(
 
     (for {
       _               <- handleCategoriesUpdate(updatedCategories)
-      techLib         <- roActiveTechniqueRepo.getFullDirectiveLibrary()
+      techLib         <- roActiveTechniqueRepo.getFullDirectiveLibrary()(using cc.toQC)
       activeTechniques = techLib.allActiveTechniques.map { case (_, at) => (at.techniqueName, at) }
       now             <- Clock.instant
       accepted        <- techniqueMods.accumulate {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
@@ -149,7 +149,7 @@ class TechniqueAcceptationUpdater(
             List(),
             List(),
             isSystem = false,
-            security = cc.accessGrant.toSecurityTag
+            security = cc.accessGrant.restrictToWrite.toSecurityTag
           )
 
           rwActiveTechniqueRepo

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
@@ -64,6 +64,7 @@ import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.schedule.DirectiveSchedule
 import com.normation.rudder.services.policies.FetchAllInfo
+import com.normation.rudder.services.policies.NodeSecurityInfo
 import com.normation.rudder.services.policies.RuleApplicationStatusService
 import com.normation.rudder.services.policies.RuleVal
 import com.normation.rudder.services.policies.RuleValService
@@ -204,18 +205,18 @@ class FetchAllInfoServiceImpl(
    * to a context latter.
    */
   def buildRuleVals(
-      activeRuleIds:    Set[RuleId],
-      rules:            List[Rule],
-      directiveLib:     FullActiveTechniqueCategory,
-      allGroups:        FullNodeGroupCategory,
-      arePolicyServers: Map[NodeId, Boolean]
+      activeRuleIds: Set[RuleId],
+      rules:         List[Rule],
+      directiveLib:  FullActiveTechniqueCategory,
+      allGroups:     FullNodeGroupCategory,
+      nodes:         Map[NodeId, NodeSecurityInfo]
   ): IOResult[Seq[RuleVal]] = {
 
     val appliedRules = rules.filter(r => activeRuleIds.contains(r.id))
     for {
-      rawRuleVals <- appliedRules.accumulate { rule =>
-                       ruleValService.buildRuleVal(rule, directiveLib, allGroups, arePolicyServers)
-                     }.chainError("Could not find configuration vals")
+      rawRuleVals <- appliedRules
+                       .accumulate(rule => ruleValService.buildRuleVal(rule, directiveLib, allGroups, nodes))
+                       .chainError("Could not find configuration vals")
     } yield rawRuleVals
   }
 
@@ -294,14 +295,18 @@ class FetchAllInfoServiceImpl(
       ///// - number of rules: any rule without target or with only target with no node can be skipped
 
       ruleValTime0                             <- currentTimeMillis
-      arePolicyServers                          = nodeFacts.view.mapValues(_.rudderSettings.isPolicyServer).toMap
+      // per-node info (is-policy-server + tenant security tag) is the single source of truth derived from
+      // the node facts; `getAppliedRuleIds` only needs the is-policy-server projection.
+      nodeInfos                                 =
+        nodeFacts.view.mapValues(nf => NodeSecurityInfo(nf.rudderSettings.isPolicyServer, nf.rudderSettings.security)).toMap
+      arePolicyServers                          = nodeInfos.view.mapValues(_.isPolicyServer).toMap
       activeRuleIds                             = getAppliedRuleIds(allRules, groupLib, directiveLib, arePolicyServers)
       ruleVals                                 <- buildRuleVals(
                                                     activeRuleIds,
                                                     allRules.toList,
                                                     directiveLib,
                                                     groupLib,
-                                                    arePolicyServers
+                                                    nodeInfos
                                                   ).chainError("Cannot build Rule vals")
       ruleValTime1                             <- currentTimeMillis
       timeRuleVal                               = ruleValTime1 - ruleValTime0

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -125,7 +125,7 @@ class DynGroupUpdaterServiceImpl(
 
   override def updateAll(modId: ModificationId)(implicit cc: ChangeContext): Box[Seq[DynGroupDiff]] = {
     for {
-      allGroups <- roNodeGroupRepository.getAll().toBox
+      allGroups <- roNodeGroupRepository.getAll()(using cc.toQC).toBox
       dynGroups  = allGroups.filter(_.isDynamic)
       result    <- com.normation.utils.Control.traverse(dynGroups) { group =>
                      for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -47,6 +47,7 @@ import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.TenantAccessGrant
 import net.liftweb.common.*
 
 /**
@@ -107,10 +108,16 @@ class DynGroupUpdaterServiceImpl(
         case None        => Full(group)
         case Some(query) =>
           val timePreCompute = System.currentTimeMillis
+          // Tenant boundary: a dynamic group only ever contains nodes its own tenants can see, whatever the
+          // tenant grant of the actor triggering the update. We run the query under the group's tenant scope
+          // (untagged/`None` group => `All`, so non-tenant setups are unaffected).
+          val groupScopedQc  = qc.copy(accessGrant = TenantAccessGrant.fromSecurityScope(group.security))
           for {
             newMembers      <-
               queryProcessor.process(
                 query
+              )(using
+                groupScopedQc
               ) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.serialize})"
             timeGroupCompute = (System.currentTimeMillis - timePreCompute)
             _                = DynamicGroupLoggerPure.Timing.logEffect.trace(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
@@ -62,6 +62,7 @@ import com.normation.rudder.ncf.MethodCall
 import com.normation.rudder.ncf.MethodElem
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.SecurityTag
 import com.unboundid.ldap.sdk.Attribute
 import com.unboundid.ldap.sdk.Filter
 import java.util.regex.Pattern
@@ -415,7 +416,8 @@ object QSLdapBackend {
    */
   def search(query: Query)(implicit
       ldap:      LDAPConnectionProvider[RoLDAPConnection],
-      rudderDit: RudderDit
+      rudderDit: RudderDit,
+      qc:        QueryContext
   ): IOResult[Seq[QuickSearchResult]] = {
     // the filter for attribute and for attributes must be non empty, else return nothing
     val ocFilter           = query.objectClass.map(_.filter).flatten.toSeq
@@ -426,9 +428,12 @@ object QSLdapBackend {
     )
     // the ldap query part. It should be in a box, but the person who implemented ldap backend was
     // not really strict on the semantic
-    // the second group is always needed (displayed name, id+test system)
-    val returnedAttributes =
-      (query.attributes.map(_.ldapName).toSeq ++ Seq(A_OC, A_HOSTNAME, A_NAME, A_UUID, A_PARAMETER_NAME, A_IS_SYSTEM)).distinct
+    // the second group is always needed (displayed name, id+test system). `A_SECURITY_TAG` is needed to
+    // enforce the tenant boundary below.
+    val returnedAttributes = {
+      (query.attributes.map(_.ldapName).toSeq
+      ++ Seq(A_OC, A_HOSTNAME, A_NAME, A_UUID, A_PARAMETER_NAME, A_IS_SYSTEM, A_SECURITY_TAG)).distinct
+    }
 
     if (ocFilter.isEmpty || attrFilter.isEmpty) { // nothing to search for in that backend
       Seq.empty[QuickSearchResult].succeed
@@ -437,10 +442,13 @@ object QSLdapBackend {
         connection <- ldap
         entries    <- connection.search(rudderDit.BASE_DN, Sub, filter, returnedAttributes*)
       } yield {
-        // transformat LDAPEntries to quicksearch results, keeping only the attribute
-        // that matches the query on the result and no system entries but nodes.
-        // Also, only keep nodes that exists.
-        entries.flatMap(_.toResult(query))
+        // tenant boundary: only keep entries the current security context can see. Rules/groups/parameters
+        // carry a security tag; an entry without one is admin-only (`canSee(None)` is true only for `*`).
+        // Then transform LDAPEntries to quicksearch results, keeping only the attribute that matches the
+        // query, and no system entries but nodes.
+        entries
+          .filter(e => qc.accessGrant.canSee(e(A_SECURITY_TAG).flatMap(_.fromJson[SecurityTag].toOption)))
+          .flatMap(_.toResult(query))
       }
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
@@ -206,7 +206,7 @@ object QSDirectiveBackend extends Loggable {
   /**
    * Lookup directives
    */
-  def search(query: Query)(implicit repo: RoDirectiveRepository): IOResult[Seq[QuickSearchResult]] = {
+  def search(query: Query)(using repo: RoDirectiveRepository, qc: QueryContext): IOResult[Seq[QuickSearchResult]] = {
 
     // only search if query is on Directives and attributes contains
     // DirectiveId, DirectiveVarName, DirectiveVarValue, TechniqueName, TechniqueVersion

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -310,13 +310,14 @@ class CommitAndDeployChangeRequestServiceImpl(
    * Returns the modificationId, plus a boolean indicating if we need to trigger a deployment
    */
   private def saveConfigurationChangeRequest(cr: ConfigurationChangeRequest)(implicit cc: ChangeContext): Box[Boolean] = {
-    import cc.modId
+    given qc: QueryContext = cc.toQC
 
     def doDirectiveChange(directiveChanges: DirectiveChanges): Box[TriggerDeploymentDiff] = {
       def save(tn: TechniqueName, d: Directive, change: DirectiveChangeItem): Box[Option[DirectiveSaveDiff]] = {
         for {
           activeTechnique <- roDirectiveRepo.getActiveTechnique(tn).notOptional(s"Missing active technique with name ${tn}")
-          saved           <- woDirectiveRepo.saveDirective(activeTechnique.id, d, modId, change.actor, change.reason)
+          saved           <-
+            woDirectiveRepo.saveDirective(activeTechnique.id, d)(using cc.copy(actor = change.actor, message = change.reason))
         } yield {
           saved
         }
@@ -327,7 +328,7 @@ class CommitAndDeployChangeRequestServiceImpl(
         diff   <- change.diff match {
                     case DeleteDirectiveDiff(tn, d)       =>
                       dependencyService
-                        .cascadeDeleteDirective(d.id.uid, modId, change.actor, change.reason)
+                        .cascadeDeleteDirective(d.id.uid)(using cc.copy(actor = change.actor, message = change.reason))
                         .map(_ => DeleteDirectiveDiff(tn, d))
                     case ModifyToDirectiveDiff(tn, d, rs) =>
                       // if the save returns None, then we return the original modification object
@@ -374,12 +375,14 @@ class CommitAndDeployChangeRequestServiceImpl(
         change <- change.changes.change.toBox
         diff   <- (change.diff match {
                     case DeleteRuleDiff(r)   =>
-                      woRuleRepository.delete(r.id, modId, change.actor, change.reason)
+                      woRuleRepository.delete(r.id)(using cc.copy(actor = change.actor, message = change.reason))
                     case AddRuleDiff(r)      =>
-                      woRuleRepository.create(r, modId, change.actor, change.reason)
+                      woRuleRepository.create(r)(using cc.copy(actor = change.actor, message = change.reason))
                     case ModifyToRuleDiff(r) =>
                       // if the update returns None, then we return the original modification object
-                      woRuleRepository.update(r, modId, change.actor, change.reason).map(_.getOrElse(ModifyToRuleDiff(r)))
+                      woRuleRepository
+                        .update(r)(using cc.copy(actor = change.actor, message = change.reason))
+                        .map(_.getOrElse(ModifyToRuleDiff(r)))
                   }).toBox
       } yield {
         diff
@@ -392,17 +395,19 @@ class CommitAndDeployChangeRequestServiceImpl(
         diff   <- (change.diff match {
                     case DeleteGlobalParameterDiff(param)   =>
                       woParameterRepository
-                        .delete(param.name, Some(PropertyProvider.defaultPropertyProvider), modId, change.actor, change.reason)
+                        .delete(param.name, Some(PropertyProvider.defaultPropertyProvider))(using
+                          cc.copy(actor = change.actor, message = change.reason)
+                        )
                         .map {
                           case None       => new TriggerDeploymentDiff { override def needDeployment: Boolean = false }
                           case Some(diff) => diff
                         }
                     case AddGlobalParameterDiff(param)      =>
-                      woParameterRepository.saveParameter(param, modId, change.actor, change.reason)
+                      woParameterRepository.saveParameter(param)(using cc.copy(actor = change.actor, message = change.reason))
                     case ModifyToGlobalParameterDiff(param) =>
                       // if the update returns None, then we return the original modification object
                       woParameterRepository
-                        .updateParameter(param, modId, change.actor, change.reason)
+                        .updateParameter(param)(using cc.copy(actor = change.actor, message = change.reason))
                         .map(_.getOrElse(ModifyToGlobalParameterDiff(param)))
                   }).toBox
       } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
@@ -75,7 +75,7 @@ sealed trait TenantAccessGrant {
 object TenantAccessGrant {
 
   // a grant that can see all nodes whatever their security tags
-  case object All                                      extends TenantAccessGrant {
+  case object All                                          extends TenantAccessGrant {
     override val value = "all"
     override def serialize:     String              = "*"
     // Be careful here: having the right to see any tenants does mean that the security
@@ -83,18 +83,21 @@ object TenantAccessGrant {
     override def toSecurityTag: Option[SecurityTag] = Option.empty
   }
   // a grant that can't see any node. Very good for performance.
-  case object None                                     extends TenantAccessGrant {
+  case object None                                         extends TenantAccessGrant {
     override val value     = "none"
     override def serialize = "-"
     override def toSecurityTag: Option[SecurityTag] = Some(SecurityTag.empty)
   }
-  // a grant associated with a list of tenants. If the node share at least one of the
-  // tenants, if it can be seen. Be careful, it's really just non-empty interesting (so that adding
-  // more tag here leads to more nodes, not less).
-  final case class ByTenants(tenants: Chunk[TenantId]) extends TenantAccessGrant {
-    override val value: String = s"tags:[${tenants.map(_.value).mkString(", ")}]"
-    override def serialize = tenants.map(_.value).mkString(",")
-    override def toSecurityTag: Option[SecurityTag] = Some(SecurityTag.ByTenants(tenants))
+  // a grant associated with a list of tenant accesses (tenant id + read/write permission). If the
+  // node shares at least one of the tenants (with a compatible permission), it can be seen/changed.
+  // Be careful, it's really just non-empty interesting (so that adding more tag here leads to more
+  // nodes, not less).
+  final case class ByTenants(tenants: Chunk[TenantAccess]) extends TenantAccessGrant {
+    override val value:     String = s"tags:[${tenants.map(_.serialize).mkString(", ")}]"
+    override def serialize: String = tenants.map(_.serialize).mkString(",")
+
+    // the security tag of an object is just its set of tenant ids, whatever the user's permission on them
+    override def toSecurityTag: Option[SecurityTag] = Some(SecurityTag.ByTenants(tenants.map(_.id)))
   }
 
   /*
@@ -116,18 +119,22 @@ object TenantAccessGrant {
             case (x: Left[RudderError, TenantAccessGrant], _) => x
             case (Right(t1), t2)                              =>
               t2.strip() match {
-                case "*"                       => Right(t1.plus(TenantAccessGrant.All))
-                case "-"                       => Right(TenantAccessGrant.None)
-                case TenantId.checkTenantId(v) => Right(t1.plus(TenantAccessGrant.ByTenants(Chunk(TenantId(v)))))
-                case x                         =>
-                  if (ignoreMalformed) Right(t1.plus(TenantAccessGrant.ByTenants(Chunk.empty)))
-                  else {
-                    Left(
-                      Inconsistency(
-                        s"Value '${x}' is not a valid tenant identifier. It must contains only alpha-num  ascii chars or " +
-                        s"'-' and '_' (not in the first) place; or exactly '*' (all tenants) or '-' (none tenants)"
-                      )
-                    )
+                case "*" => Right(t1.plus(TenantAccessGrant.All))
+                case "-" => Right(TenantAccessGrant.None)
+                case x   =>
+                  TenantAccess.parse(x) match {
+                    case Some(ta)   => Right(t1.plus(TenantAccessGrant.ByTenants(Chunk(ta))))
+                    case scala.None =>
+                      if (ignoreMalformed) Right(t1.plus(TenantAccessGrant.ByTenants(Chunk.empty)))
+                      else {
+                        Left(
+                          Inconsistency(
+                            s"Value '${x}' is not a valid tenant access. It must be a tenant identifier (alpha-num ascii " +
+                            s"chars or '-'/'_', not in first place) optionally followed by ':r' or ':rw'; or exactly '*' " +
+                            s"(all tenants) or '-' (none tenants)"
+                          )
+                        )
+                      }
                   }
               }
           })
@@ -158,13 +165,14 @@ object TenantAccessGrant {
     }
 
     // can that security tag be seen in that context, given the set of known tenants?
+    // (read semantics: a tenant access grants visibility as soon as it allows read - `r` or `rw`)
     def canSee(tag: SecurityTag): Boolean = {
       tag match {
         case SecurityTag.ByTenants(tenants) =>
           nsc match {
             case All           => true
             case None          => false
-            case ByTenants(ts) => ts.exists(s => tenants.exists(_ == s))
+            case ByTenants(ts) => ts.exists(a => a.grant.canRead && tenants.exists(_ == a.id))
           }
         case SecurityTag.Open               => true
       }
@@ -186,6 +194,42 @@ object TenantAccessGrant {
       if (canSee(n)) zio else Inconsistency(s"Object '${n.debugId}' can't be accessed in current security context'").fail
     }
 
+    /*
+     * The same grant restricted to the tenants on which the user has write (`rw`) permission.
+     * Used for `ChangeContext`-protected (write) operations: a read-only (`r`) tenant access is dropped,
+     * so the user behaves "as if it didn't have the grant" for that tenant when writing.
+     */
+    def restrictToWrite: TenantAccessGrant = nsc match {
+      case All           => All
+      case None          => None
+      case ByTenants(ts) =>
+        val writable = ts.filter(_.grant.canWrite)
+        if (writable.isEmpty) None else ByTenants(writable)
+    }
+
+    // write semantics of `canSee`: only tenants with `rw` permission are considered.
+    def canModify[A: HasSecurityTag](n: A): Boolean = {
+      nsc.restrictToWrite.canSee(n)
+    }
+
+    // execute given action if the object can be modified in that context (write permission), or fail.
+    def canModifyOrFail[A: HasSecurityTag, B](n: A)(zio: IOResult[B]): IOResult[B] = {
+      if (nsc.canModify(n)) zio
+      else Inconsistency(s"Object '${n.debugId}' can't be modified in current security context").fail
+    }
+
+    // Filter a security tag for display: admin sees everything; a ByTenants user sees only the
+    // tenants of the object that are also in their own grant (intersection).
+    def visibleSecurityTag(tag: Option[SecurityTag]): Option[SecurityTag] = (nsc, tag) match {
+      case (All, t)                                         => t
+      case (None, _)                                        => scala.None
+      case (ByTenants(_), scala.None)                       => scala.None
+      case (ByTenants(_), Some(SecurityTag.Open))           => Some(SecurityTag.Open)
+      case (ByTenants(us), Some(SecurityTag.ByTenants(os))) =>
+        val userIds = us.map(_.id).toSet
+        Some(SecurityTag.ByTenants(os.filter(t => userIds.contains(t))))
+    }
+
     // NodeSecurityContext is a lattice
     def plus(nsc2: TenantAccessGrant): TenantAccessGrant = {
       (nsc, nsc2) match {
@@ -193,7 +237,16 @@ object TenantAccessGrant {
         case (_, None)                      => None
         case (All, _)                       => All
         case (_, All)                       => All
-        case (ByTenants(c1), ByTenants(c2)) => ByTenants((c1 ++ c2).distinctBy(_.value))
+        case (ByTenants(c1), ByTenants(c2)) =>
+          // merge accesses by tenant id, keeping the highest permission for a given tenant and
+          // preserving the first-seen order (so serialization is deterministic)
+          val merged = (c1 ++ c2).foldLeft(Chunk.empty[TenantAccess]) { (acc, ta) =>
+            acc.indexWhere(_.id == ta.id) match {
+              case -1 => acc :+ ta
+              case i  => acc.updated(i, TenantAccess(ta.id, TenantPermission.union(acc(i).grant, ta.grant)))
+            }
+          }
+          ByTenants(merged)
       }
     }
   }
@@ -228,6 +281,9 @@ object QueryContext {
 
   // for system queries (when rudder needs to look-up things)
   implicit val systemQC: QueryContext = QueryContext(eventlog.RudderEventActor, TenantAccessGrant.All)
+
+  // for no right queries
+  implicit val noneQC: QueryContext = QueryContext(EventActor("none"), TenantAccessGrant.None)
 
   // For places where a query context may be required (UI snippets), provide a way to recover from unknown
   extension (opt: Option[QueryContext]) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
@@ -145,6 +145,24 @@ object TenantAccessGrant {
     }
   }
 
+  /*
+   * Build the (read) access grant that an object carrying the given security tag "scopes to" for
+   * policy-generation filtering. The tenants on a rule (or a group) direct which objects and nodes
+   * are actually used at generation time:
+   *   - `None` (admin-only object) and `Open` (library object) mean "no tenant restriction" => `All`,
+   *     so admin/system objects keep applying to everything and non-tenant setups are unaffected,
+   *   - a `ByTenants` list scopes to exactly those tenants (read permission is enough for filtering);
+   *     an empty list scopes to nothing (`None`).
+   * Combined with `canSee`, this keeps only the nodes/objects that share a tenant with the scoping object.
+   */
+  def fromSecurityScope(tag: Option[SecurityTag]): TenantAccessGrant = tag match {
+    case scala.None                      => TenantAccessGrant.All
+    case Some(SecurityTag.Open)          => TenantAccessGrant.All
+    case Some(SecurityTag.ByTenants(ts)) =>
+      if (ts.isEmpty) TenantAccessGrant.None
+      else TenantAccessGrant.ByTenants(ts.map(id => TenantAccess(id, TenantPermission.Read)))
+  }
+
   // json codec for `TenantAccessGrant`
   given encoderTenantAccessGrant: JsonEncoder[TenantAccessGrant] =
     JsonEncoder.string.contramap(_.serialize)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityTag.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityTag.scala
@@ -51,6 +51,11 @@ trait HasSecurityTag[A] {
   extension (a: A) {
     def security: Option[SecurityTag]
 
+    // Whether the object is a system (shared/global) object. System objects can only be managed by an
+    // administrator (all-tenants grant), so the tenant check logic needs to know it. There is no default:
+    // each instance states explicitly whether its type has a system notion (and how it is computed).
+    def isSystem: Boolean
+
     // update the security context of the object, returning is updated
     def updateSecurityContext(security: Option[SecurityTag]): A
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityTag.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityTag.scala
@@ -54,8 +54,10 @@ trait HasSecurityTag[A] {
     // update the security context of the object, returning is updated
     def updateSecurityContext(security: Option[SecurityTag]): A
 
-    // simplify common usage with cc
-    def updateFromChangeContext(implicit cc: ChangeContext): A = updateSecurityContext(cc.accessGrant.toSecurityTag)
+    // simplify common usage with cc: tag the object with the tenants the user can write on
+    def updateFromChangeContext(implicit cc: ChangeContext): A = updateSecurityContext(
+      cc.accessGrant.restrictToWrite.toSecurityTag
+    )
 
     // this is needed for giving useful log/debug message to users
     def debugId: String
@@ -109,6 +111,11 @@ object SecurityTag {
     },
     codecOpen.decoder.widen <> codecByTenants.decoder.widen
   )
+
+  // JsonCodec[A] does not implicitly provide JsonEncoder[A] in ZIO JSON, so we expose it
+  // explicitly so that DeriveJsonEncoder.gen for case classes containing SecurityTag fields
+  // uses our custom non-discriminated encoding instead of auto-deriving a sum-type encoder.
+  implicit val encoderSecurityTag: JsonEncoder[SecurityTag] = codecSecurityTag.encoder
 
   // XML serialization / deserialisation for events
   import scala.xml.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityTag.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityTag.scala
@@ -91,8 +91,8 @@ object SecurityTag {
 
   def empty: SecurityTag = SecurityTag.ByTenants(Chunk.empty)
 
-  implicit val codecByTenants: JsonCodec[ByTenants] = DeriveJsonCodec.gen
-  implicit val codecOpen:      JsonCodec[Open.type] = new JsonCodec[Open.type](
+  given codecByTenants: JsonCodec[ByTenants] = DeriveJsonCodec.gen
+  given codecOpen:      JsonCodec[Open.type] = new JsonCodec[Open.type](
     JsonEncoder.string.contramap(_ => "open"),
     JsonDecoder.string.mapOrFail {
       case "open" => Right(Open)
@@ -100,7 +100,7 @@ object SecurityTag {
     }
   )
 
-  implicit val codecSecurityTag: JsonCodec[SecurityTag] = new JsonCodec[SecurityTag](
+  given codecSecurityTag: JsonCodec[SecurityTag] = new JsonCodec[SecurityTag](
     new JsonEncoder[SecurityTag] {
       override def unsafeEncode(a: SecurityTag, indent: Option[Int], out: Write): Unit = {
         a match {
@@ -112,10 +112,12 @@ object SecurityTag {
     codecOpen.decoder.widen <> codecByTenants.decoder.widen
   )
 
-  // JsonCodec[A] does not implicitly provide JsonEncoder[A] in ZIO JSON, so we expose it
-  // explicitly so that DeriveJsonEncoder.gen for case classes containing SecurityTag fields
-  // uses our custom non-discriminated encoding instead of auto-deriving a sum-type encoder.
-  implicit val encoderSecurityTag: JsonEncoder[SecurityTag] = codecSecurityTag.encoder
+  // JsonCodec[A] does not implicitly provide JsonEncoder[A]/JsonDecoder[A] in ZIO JSON, so we expose
+  // them explicitly so that derivation for case classes containing a SecurityTag field uses our custom
+  // non-discriminated encoding/decoding instead of auto-deriving a sum-type codec (which would expect a
+  // discriminator and reject the `{"tenants":[...]}` / `"open"` shapes used by the API).
+  given JsonEncoder[SecurityTag] = codecSecurityTag.encoder
+  given JsonDecoder[SecurityTag] = codecSecurityTag.decoder
 
   // XML serialization / deserialisation for events
   import scala.xml.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -333,32 +333,33 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
               action(updated.updateSecurityContext(e.security))
             // update when feature enabled: check consistency
             case TenantStatus.Enabled(tenants) =>
-              (if (writeGrant.canSee(e)) {
-                 if (writeGrant.canSee(updated)) {
-
-                   (e.security, updated.security) match {
-                     // no tenants in updated: existing security info is cleared (admin only, already checked)
-                     case (_, None)                            => updated.succeed
-                     // if b is open, it's ok
-                     case (_, Some(SecurityTag.Open))          => updated.succeed
-                     // if both have identical tags, it's ok
-                     case (Some(a), Some(b)) if (a == b)       => updated.succeed
-                     // case where the tags are different: update only if the tenant exists.
-                     // Only admin can reach here (checked above).
-                     case (_, Some(SecurityTag.ByTenants(ts))) =>
-                       if (ts.forall(t => tenants.contains(t))) {
-                         updated.succeed
-                       } else {
-                         Inconsistency(
-                           s"Object '${updated.debugId}' security tag's tenant can not be updated to '${ts.map(_.value).mkString(",")}' because it does not exist"
-                         ).fail
-                       }
-                   }
-                 } else {
-                   error(updated)
+              (if (!writeGrant.canSee(e)) {
+                 // the user can't even write the existing object
+                 error(e)
+               } else if (writeGrant == TenantAccessGrant.All) {
+                 // only admin (all-tenants write grant) is allowed to change the tenant list of an object.
+                 (e.security, updated.security) match {
+                   // no tenants in updated: existing security info is cleared (admin only)
+                   case (_, None)                            => updated.succeed
+                   // if b is open, it's ok
+                   case (_, Some(SecurityTag.Open))          => updated.succeed
+                   // if both have identical tags, it's ok
+                   case (Some(a), Some(b)) if (a == b)       => updated.succeed
+                   // case where the tags are different: update only if the tenant exists.
+                   case (_, Some(SecurityTag.ByTenants(ts))) =>
+                     if (ts.forall(t => tenants.contains(t))) {
+                       updated.succeed
+                     } else {
+                       Inconsistency(
+                         s"Object '${updated.debugId}' security tag's tenant can not be updated to '${ts.map(_.value).mkString(",")}' because it does not exist"
+                       ).fail
+                     }
                  }
                } else {
-                 error(e)
+                 // non-admin user: the tenant list can NOT be changed. Whatever security tag the request
+                 // carries is ignored and the existing tag is kept (this also makes a read-modify-write
+                 // round-trip safe, since the user only ever reads the tenants it owns).
+                 updated.updateSecurityContext(e.security).succeed
                }).flatMap(up => action(up))
           }
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -168,12 +168,37 @@ trait TenantCheckLogic {
   ): IOResult[B]
 
   /*
-   * Check if the node can be deleted given ChangeContext
+   * Check if the node can be deleted given ChangeContext. A delete is a write, so this enforces the same
+   * rules as `checkModify`: tenant write-visibility and, for system objects, admin-only.
    */
   def checkDelete[A: HasSecurityTag](
       existing: A,
       cc:       ChangeContext
   ): Either[RudderError, A]
+
+  /*
+   * The single write-authorization entry point for repositories. Check that the actor may change
+   * (create/update/move/delete) the given object:
+   *   - it must share a writable tenant with the object (tenant write-visibility), and
+   *   - if the object is a system object, the actor must be an administrator (all-tenants grant).
+   * Repositories must use this instead of reaching into `accessGrant.canModify*` directly, so that all
+   * the tenant/authorization logic lives here.
+   */
+  def checkModify[A: HasSecurityTag](a: A, cc: ChangeContext): IOResult[Unit]
+
+  /*
+   * Check that the actor may add or keep children under the given container (a parent category, a parent
+   * active technique, a move destination): it must share a writable tenant with the container. Unlike
+   * `checkModify`, this is NOT system-gated: tenant objects legitimately live under the shared/system root
+   * categories, so being able to create into a system container is a matter of tenant write-visibility only.
+   */
+  def checkWriteInto[A: HasSecurityTag](container: A, cc: ChangeContext): IOResult[Unit]
+
+  /*
+   * Check that the actor may perform an admin-only operation. Used for system operations that have no
+   * `HasSecurityTag` object to check (e.g. policy server targets). Fails unless the grant is all-tenants.
+   */
+  def checkAdmin(cc: ChangeContext): IOResult[Unit]
 
 }
 
@@ -301,9 +326,11 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
     // a read-only ('r') tenant access is dropped, as if the user didn't have the grant for that tenant.
     val writeGrant = cc.accessGrant.restrictToWrite
 
-    // whatever the status of "existing", if the plugin is disabled and there is a write grant
-    // different from '*' for user, then return an error
-    if (tenantStatus == TenantStatus.Disabled && writeGrant != TenantAccessGrant.All) {
+    // system objects (whether the existing one being changed, or the submitted one) can only be managed by
+    // an administrator (all-tenants grant), whatever the tenant scoping.
+    if ((existing.exists(_.isSystem) || updated.isSystem) && cc.accessGrant != TenantAccessGrant.All) {
+      systemAdminError(updated.debugId).fail
+    } else if (tenantStatus == TenantStatus.Disabled && writeGrant != TenantAccessGrant.All) {
       error(updated)
     } else if (writeGrant.isNone) {
       // the user has no tenant it can write on (e.g. read-only tenant access or no grant): it can't modify anything
@@ -376,12 +403,43 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
       existing: A,
       cc:       ChangeContext
   ): Either[RudderError, A] = {
-    // delete is a write operation: only tenants with write permission are considered
-    if (cc.accessGrant.canModify(existing)) {
+    // a system object can only be deleted by an administrator (all-tenants grant)
+    if (existing.isSystem && cc.accessGrant != TenantAccessGrant.All) {
+      Left(systemAdminError(existing.debugId))
+    } else if (cc.accessGrant.canModify(existing)) {
+      // delete is a write operation: only tenants with write permission are considered
       Right(existing)
     } else {
       // only id to avoid giving too much info in error in that case
       Left(Inconsistency(s"Object '${existing.debugId}' can't be deleted by ${cc.actor.name}"))
     }
   }
+
+  override def checkModify[A: HasSecurityTag](a: A, cc: ChangeContext): IOResult[Unit] = {
+    // a system object can only be changed by an administrator (all-tenants grant)
+    if (a.isSystem && cc.accessGrant != TenantAccessGrant.All) {
+      systemAdminError(a.debugId).fail
+    } else if (!cc.accessGrant.canModify(a)) {
+      Inconsistency(s"Object '${a.debugId}' can't be modified in the current security context").fail
+    } else ZIO.unit
+  }
+
+  override def checkWriteInto[A: HasSecurityTag](container: A, cc: ChangeContext): IOResult[Unit] = {
+    // tenant write-visibility only, NOT system-gated (children can be created under system root categories)
+    if (!cc.accessGrant.canModify(container)) {
+      Inconsistency(s"Objects can't be created or moved under '${container.debugId}' in the current security context").fail
+    } else ZIO.unit
+  }
+
+  override def checkAdmin(cc: ChangeContext): IOResult[Unit] = {
+    ZIO
+      .unless(cc.accessGrant == TenantAccessGrant.All)(
+        Inconsistency("This operation on a system object is only allowed to an administrator").fail
+      )
+      .unit
+  }
+
+  // error raised when a non-administrator (a tenant-restricted actor) tries to manage a system object
+  private def systemAdminError(debugId: String): RudderError =
+    Inconsistency(s"Only an administrator can create, modify or delete the system object '${debugId}'")
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -73,7 +73,7 @@ trait TenantService {
       case TenantAccessGrant.ByTenants(tenants) =>
         getStatus.map {
           case TenantStatus.Enabled(existingTenants) =>
-            TenantAccessGrant.ByTenants(tenants.filter(t => existingTenants.contains(t)))
+            TenantAccessGrant.ByTenants(tenants.filter(t => existingTenants.contains(t.id)))
           case TenantStatus.Disabled                 =>
             TenantAccessGrant.None
         }
@@ -92,22 +92,54 @@ trait TenantCheckLogic {
    */
   def flatMap[A: HasSecurityTag](opt: Option[A])(using qc: QueryContext): Option[A]
 
+  def flatMap[A: HasSecurityTag, B: HasSecurityTag](opt: Option[(A, B)])(using qc: QueryContext): Option[(A, B)] = {
+    for {
+      (a, b) <- opt
+      _      <- check(a)
+      _      <- check(b)
+    } yield (a, b)
+  }
+
+  def flatMap[A: HasSecurityTag, B: HasSecurityTag, C: HasSecurityTag](
+      opt: Option[(A, B, C)]
+  )(using qc: QueryContext): Option[(A, B, C)] = {
+    for {
+      (a, b, c) <- opt
+      _         <- check(a)
+      _         <- check(b)
+      _         <- check(c)
+    } yield (a, b, c)
+  }
+
   /*
    * Check if the node can be seen in the given query context. Return none if it can't.
    */
-  def filter[A: HasSecurityTag](a: A)(using qc: QueryContext): Option[A] = flatMap(Some(a))
+  def check[A: HasSecurityTag](a: A)(using qc: QueryContext): Option[A] = flatMap(Some(a))
+
+  /*
+   * Collect elements that can be seen
+   */
+  def collect[A: HasSecurityTag, B, CC[A] <: Iterable[A]](it: CC[A])(
+      f: A => B
+  )(using qc: QueryContext, bf: BuildFrom[CC[A], B, CC[B]]): CC[B]
+
+  def filter[A: HasSecurityTag, CC[A] <: Iterable[A]](
+      it: CC[A]
+  )(using qc: QueryContext, bf: BuildFrom[CC[A], A, CC[A]]): CC[A] = {
+    collect(it)(identity)
+  }
 
   def filterStream[A: HasSecurityTag](s: IOStream[A])(using qc: QueryContext): IOStream[A]
 
   /*
    * Filter a map of objects `A` based on tenants
    */
-  def filterMapView[ID, A: HasSecurityTag](nodes: Ref[Map[ID, A]])(using qc: QueryContext): UIO[MapView[ID, A]]
+  def filterMapView[ID, A: HasSecurityTag](objs: Ref[Map[ID, A]])(using qc: QueryContext): UIO[MapView[ID, A]]
 
   /*
    * Get the node with ID if it exists on ref map and qc/tenants allows to get it
    */
-  def getMapView[ID, A: HasSecurityTag](nodes: Ref[Map[ID, A]], id: ID)(using
+  def getMapView[ID, A: HasSecurityTag](objs: Ref[Map[ID, A]], id: ID)(using
       qc: QueryContext
   ): IOResult[Option[A]]
 
@@ -161,6 +193,7 @@ object InMemoryTenantService {
  * We still put its modification behind an eval.
  */
 class InMemoryTenantService(private var _tenantsEnabled: Boolean, val tenantIds: Ref[Set[TenantId]]) extends TenantService {
+  private def showTenantIds(ids: Set[TenantId]) = ids.toList.map(_.value).sorted.mkString(s",", "','", "'")
 
   def setTenantEnabled(isEnabled: Boolean): UIO[Unit] = {
     ApplicationLoggerPure.Plugin.info(s"Multi-tenants feature enabled: ${isEnabled}") *>
@@ -172,20 +205,41 @@ class InMemoryTenantService(private var _tenantsEnabled: Boolean, val tenantIds:
   }
 
   override def getStatus: UIO[TenantStatus] = {
-    if (tenantsEnabled) tenantIds.get.map(TenantStatus.Enabled(_))
-    else TenantStatus.Disabled.succeed
+    if (tenantsEnabled) {
+      tenantIds.get.flatMap(ids => {
+        TenantsLogger.debug(
+          s"Multi-tenant feature is enabled on tenants: '${showTenantIds(ids)}'"
+        ) *>
+        TenantStatus.Enabled(ids).succeed
+      })
+    } else {
+      TenantsLogger.debug("Multi-tenant feature is disabled") *>
+      TenantStatus.Disabled.succeed
+    }
   }
 
   override def updateTenants(ids: Set[TenantId]): IOResult[Unit] = {
-    if (tenantsEnabled) tenantIds.set(ids)
-    else Inconsistency(s"Error: tenants are not enabled").fail
+    if (tenantsEnabled) {
+      tenantIds
+        .getAndSet(ids)
+        .flatMap(oldIds =>
+          TenantsLogger.info(s"Available tenant list updated from: ${showTenantIds(oldIds)} to: ${showTenantIds(ids)}")
+        )
+    } else Inconsistency(s"Error: tenants are not enabled").fail
   }
 }
 
 class DefaultTenantCheckLogic extends TenantCheckLogic {
   override def flatMap[A: HasSecurityTag](opt: Option[A])(implicit qc: QueryContext): Option[A] = {
     opt match {
-      case Some(n) => if (qc.accessGrant.canSee(n)) Some(n) else None
+      case Some(n) =>
+        if (qc.accessGrant.canSee(n)) {
+          TenantsLogger.logEffect.trace(s"User '${qc.actor.name}' can see ${n.debugId}")
+          Some(n)
+        } else {
+          TenantsLogger.logEffect.trace(s"User '${qc.actor.name}' can not see ${n.debugId}")
+          None
+        }
       case None    => None
     }
   }
@@ -199,6 +253,17 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
       for {
         ns <- nodes.get
       } yield ns.view.filter { case (_, n) => qc.accessGrant.canSee(n) }
+    }
+  }
+
+  override def collect[A: HasSecurityTag, B, CC[A] <: Iterable[A]](
+      it: CC[A]
+  )(f: A => B)(using qc: QueryContext, bf: BuildFrom[CC[A], B, CC[B]]): CC[B] = {
+    if (qc.accessGrant.isNone) bf.fromSpecific(it)(Nil)
+    else {
+      bf.fromSpecific(it)(it.collect {
+        case x if qc.accessGrant.canSee(x.security) => f(x)
+      })
     }
   }
 
@@ -232,9 +297,16 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
       Inconsistency(s"Object '${x.debugId}' [${tag}] can't be modified by '${cc.actor.name}' (perm:${cc.accessGrant.value})").fail
     }
 
-    // whatever the status of "existing", if the plugin is disabled and there is a grant
+    // a write operation only considers the tenants on which the user has write ('rw') permission:
+    // a read-only ('r') tenant access is dropped, as if the user didn't have the grant for that tenant.
+    val writeGrant = cc.accessGrant.restrictToWrite
+
+    // whatever the status of "existing", if the plugin is disabled and there is a write grant
     // different from '*' for user, then return an error
-    if (tenantStatus == TenantStatus.Disabled && cc.accessGrant != TenantAccessGrant.All) {
+    if (tenantStatus == TenantStatus.Disabled && writeGrant != TenantAccessGrant.All) {
+      error(updated)
+    } else if (writeGrant.isNone) {
+      // the user has no tenant it can write on (e.g. read-only tenant access or no grant): it can't modify anything
       error(updated)
     } else {
       existing match {
@@ -244,16 +316,16 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
             // creation when feature disabled: set securityTag to "none".
             case TenantStatus.Disabled         =>
               action(updated.updateSecurityContext(None))
-            // in the case of creation, we force the user tenant to its tenant
+            // in the case of creation, we force the user tenant to its (writable) tenant
             case TenantStatus.Enabled(tenants) =>
-              if (cc.accessGrant.canSee(updated)) {
+              if (writeGrant.canSee(updated)) {
                 action(updated)
               } else {
                 action(updated.updateFromChangeContext(using cc))
               }
           }
 
-        // when we update an existing item, we must also check that the user can see the previous item
+        // when we update an existing item, we must also check that the user can write the previous item
         case Some(e) =>
           tenantStatus match {
             // update when feature is disabled: keep existing security tag if any
@@ -261,19 +333,18 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
               action(updated.updateSecurityContext(e.security))
             // update when feature enabled: check consistency
             case TenantStatus.Enabled(tenants) =>
-              (if (cc.accessGrant.canSee(e)) {
-                 if (cc.accessGrant.canSee(updated)) {
+              (if (writeGrant.canSee(e)) {
+                 if (writeGrant.canSee(updated)) {
 
                    (e.security, updated.security) match {
-                     // no tenants in updated: existing security info is cleared
+                     // no tenants in updated: existing security info is cleared (admin only, already checked)
                      case (_, None)                            => updated.succeed
                      // if b is open, it's ok
                      case (_, Some(SecurityTag.Open))          => updated.succeed
                      // if both have identical tags, it's ok
                      case (Some(a), Some(b)) if (a == b)       => updated.succeed
                      // case where the tags are different: update only if the tenant exists.
-                     // We know that the user has the right to change the security tag because
-                     // his access grant is ok on both existing and updated items.
+                     // Only admin can reach here (checked above).
                      case (_, Some(SecurityTag.ByTenants(ts))) =>
                        if (ts.forall(t => tenants.contains(t))) {
                          updated.succeed
@@ -304,7 +375,8 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
       existing: A,
       cc:       ChangeContext
   ): Either[RudderError, A] = {
-    if (cc.accessGrant.canSee(existing)) {
+    // delete is a write operation: only tenants with write permission are considered
+    if (cc.accessGrant.canModify(existing)) {
       Right(existing)
     } else {
       // only id to avoid giving too much info in error in that case

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -42,6 +42,7 @@ import com.normation.errors.IOResult
 import com.normation.errors.IOStream
 import com.normation.errors.RudderError
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
+import com.softwaremill.quicklens.*
 import scala.collection.MapView
 import zio.*
 import zio.stream.ZStream
@@ -345,10 +346,22 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
               action(updated.updateSecurityContext(None))
             // in the case of creation, we force the user tenant to its (writable) tenant
             case TenantStatus.Enabled(tenants) =>
-              if (writeGrant.canSee(updated)) {
-                action(updated)
-              } else {
-                action(updated.updateFromChangeContext(using cc))
+              cc.accessGrant match {
+                case TenantAccessGrant.All           =>
+                  // for admin, use admin logic: admin can chose tenant
+                  action(updated)
+                case TenantAccessGrant.None          =>
+                  // already manage above
+                  error(updated)
+                case TenantAccessGrant.ByTenants(ts) =>
+                  // restrict to the actual list of writeGrant intersect existing tenants
+                  val intersect = ts.filter(t => tenants.contains(t.id))
+                  if (intersect.isEmpty) {
+                    error(updated)
+                  } else {
+                    val restrictedCC = cc.modify(_.accessGrant).setTo(TenantAccessGrant.ByTenants(intersect))
+                    action(updated.updateFromChangeContext(using restrictedCC))
+                  }
               }
           }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/Tenants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/Tenants.scala
@@ -37,8 +37,18 @@
 
 package com.normation.rudder.tenants
 
+import com.normation.NamedZioLogger
+import enumeratum.*
 import scala.util.matching.Regex
 import zio.json.*
+
+object TenantsLogger extends NamedZioLogger {
+  override def loggerName: String = "tenants"
+
+  object Engine extends NamedZioLogger {
+    override def loggerName: String = "tenants.engine"
+  }
+}
 
 /*
  * A node can belong to one (or technically more, but we will limit that for now) `tenant`.
@@ -46,7 +56,7 @@ import zio.json.*
  * Tenants should be \ascii\num_-
  */
 final case class TenantId(value: String) extends AnyVal {
-  def debugString = value
+  def debugString: String = value
 }
 
 object TenantId {
@@ -56,10 +66,99 @@ object TenantId {
     JsonDecoder.string.map(TenantId(_))
   )
 
-  // Tenant d can only be non empty alpha-num and hyphen. Check externally to avoid perf cost
+  // Tenant d can only be non-empty alpha-num and hyphen. Check externally to avoid perf cost
   // at instantiation;
   val checkTenantId: Regex = """^(\p{Alnum}[\p{Alnum}-_]*)$""".r
 
+  // parse a tenant id, returning None if it is not a valid identifier
+  def parse(s: String): Option[TenantId] = s match {
+    case checkTenantId(v) => Some(TenantId(v))
+    case _                => None
+  }
+}
+
+/*
+ * The kind of access a user/API token has on a given tenant:
+ * - `Read`     : can only access the tenant objects through read (`QueryContext`) operations
+ * - `ReadWrite`: can access the tenant objects through both read and write (`ChangeContext`) operations
+ * - `None`     : has no access at all (mostly used as the neutral/absorbing element of the lattice)
+ *
+ * Serialized form (in the `tenantId:permission` access string): `r` for Read, `rw` for ReadWrite.
+ * For backward compatibility, an absent permission means `ReadWrite`.
+ */
+sealed trait TenantPermission(override val entryName: String) extends EnumEntry {
+  def canRead:  Boolean
+  def canWrite: Boolean
+}
+
+object TenantPermission extends Enum[TenantPermission] {
+  // order is important, from least powerful to most powerful
+  case object None      extends TenantPermission("none") {
+    override val canRead  = false
+    override val canWrite = false
+  }
+  case object Read      extends TenantPermission("r")    {
+    override val canRead  = true
+    override val canWrite = false
+  }
+  case object ReadWrite extends TenantPermission("rw")   {
+    override val canRead  = true
+    override val canWrite = true
+  }
+
+  override val values: IndexedSeq[TenantPermission] = findValues
+
+  // keep the highest permission of the two (used to merge accesses on the same tenant)
+  def union(a: TenantPermission, b: TenantPermission): TenantPermission = if (indexOf(a) < indexOf(b)) b else a
+
+  // parse the permission token (the part after the ':'); absence (None) means ReadWrite for backward compat
+  def parseToken(token: Option[String]): Option[TenantPermission] = token match {
+    case scala.None => Some(ReadWrite)
+    case Some(t)    => TenantPermission.withNameInsensitiveOption(t)
+  }
+}
+
+/*
+ * A `TenantAccess` is the access a user/API token has on a single tenant: a tenant id plus the
+ * permission (read or read-write) on it.
+ *
+ * It is NOT json-serialized as a structure, but as a simple string with the pattern `tenantId:permission`
+ * where the permission part is optional:
+ * - `zoneA`    -> ReadWrite on `zoneA` (backward compatible with the previous `TenantId`-only serialization)
+ * - `zoneA:r`  -> Read on `zoneA`
+ * - `zoneA:rw` -> ReadWrite on `zoneA`
+ */
+final case class TenantAccess(id: TenantId, grant: TenantPermission)
+
+object TenantAccess {
+  // convenience: a tenant access defaults to ReadWrite (backward compatibility with 9.1)
+  def apply(id: TenantId): TenantAccess = TenantAccess(id, TenantPermission.ReadWrite)
+
+  /*
+   * Parse a `tenantId:permission` string. The permission suffix is optional (absent means ReadWrite).
+   * Returns None if the tenant id or the permission token is not valid.
+   */
+  def parse(s: String): Option[TenantAccess] = {
+    val (rawId, optToken) = s.split(":", 2) match {
+      case Array(id)       => (id, scala.None)
+      case Array(id, perm) => (id, Some(perm))
+      case _               => (s, scala.None)
+    }
+    for {
+      id    <- TenantId.parse(rawId)
+      grant <- TenantPermission.parseToken(optToken)
+    } yield TenantAccess(id, grant)
+  }
+
+  extension (t: TenantAccess) {
+    // do not output "rw" for that case, since it's the default if not provided
+    def serialize: String = if (t.grant == TenantPermission.ReadWrite) t.id.value else s"${t.id.value}:${t.grant.entryName}"
+  }
+
+  given codecTenantAccess: JsonCodec[TenantAccess] = JsonCodec.string.transformOrFail(
+    s => parse(s).toRight(s"Can not parse '${s}' as a valid tenant access permission"),
+    t => t.serialize
+  )
 }
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/rule-category-data.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/rule-category-data.ldif
@@ -1,0 +1,10 @@
+# The root rule category. In production it is created at runtime; the in-memory test LDAP needs it
+# explicitly so that rule creation (which now checks the parent category) can resolve it.
+# Its security tag is forced to "open" by the LDAP mapper, like the group and active technique roots.
+dn: ruleCategoryId=rootRuleCategory,ou=Rudder,cn=rudder-configuration
+objectClass: ruleCategory
+objectClass: top
+ruleCategoryId: rootRuleCategory
+cn: Rules
+description: This is the main category of Rules
+isSystem: TRUE

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-1-rudder.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-1-rudder.ldif
@@ -316,6 +316,24 @@ attributeTypes: ( 1.3.6.1.4.1.35061.2.1.355
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseExactMatch
   SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.356
+  NAME 'visibility'
+  DESC 'visibility of a property or parameter'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.357
+  NAME 'inheritMode'
+  DESC 'inherit mode of a property or parameter'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.358
+  NAME 'revision'
+  DESC 'revision of a versioned object'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 #######################################################
 ################  Object Classes ######################
 #######################################################
@@ -445,7 +463,7 @@ objectClasses: ( 1.3.6.1.4.1.35061.2.2.120
   SUP top
   STRUCTURAL
   MUST ( parameterName )
-  MAY ( parameterValue $ description $ propertyProvider $ securityTag) )
+  MAY ( parameterValue $ description $ propertyProvider $ securityTag $ visibility $ inheritMode $ revision) )
 #
 # Application properties
 #

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/technique-library-data.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/technique-library-data.ldif
@@ -111,6 +111,7 @@ cn: User Techniques
 techniqueCategoryId: ncf_techniques
 description:: CiAgICBUZWNobmlxdWVzIGNyZWF0ZWQgdXNpbmcgdGhlIFRlY2huaXF1ZSBlZGl0b3IuCiAg
 isSystem: FALSE
+securityTag: {"tenants": ["zoneA"]}
 
 dn: activeTechniqueId=user_defined_tech1,techniqueCategoryId=ncf_techniques,techniqueCategoryId=Active Techniques,ou=Rudder,cn=rudder-configuration
 objectClass: activeTechnique
@@ -146,6 +147,15 @@ isEnabled: TRUE
 isSystem: FALSE
 tag: rootRuleCategory
 serial: 0
+securityTag: {"tenants": ["zoneA"]}
+
+# a global parameter tagged with tenant `zoneA`, used to test tenant filtering on parameters
+dn: parameterName=param-zoneA,ou=Parameters,ou=Rudder,cn=rudder-configuration
+objectClass: parameter
+objectClass: top
+parameterName: param-zoneA
+description: A global parameter restricted to tenant zoneA
+parameterValue: "zoneA value"
 securityTag: {"tenants": ["zoneA"]}
 
 ##

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
@@ -40,8 +40,6 @@ package com.normation.cfclerk.services
 import better.files.File
 import com.normation.cfclerk.domain.*
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.policies.AcceptationDateTime
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.domain.policies.ActiveTechniqueCategory
@@ -60,6 +58,7 @@ import com.normation.rudder.repository.WoDirectiveRepository
 import com.normation.rudder.services.policies.TechniqueAcceptationUpdater
 import com.normation.rudder.services.policies.TestNodeConfiguration
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.time.Instant
@@ -142,10 +141,15 @@ class TechniqueRepositoryTest extends Specification with Loggable with AfterAll 
         policyTypes:   PolicyTypes
     )(implicit cc: ChangeContext): IOResult[ActiveTechnique] = {
       updatedTechniques = techniqueName.value :: updatedTechniques
-      ActiveTechnique(ActiveTechniqueId("empty"), techniqueName, AcceptationDateTime.empty, security = None).succeed
+      ActiveTechnique(
+        ActiveTechniqueId("empty"),
+        techniqueName,
+        AcceptationDateTime.empty,
+        security = cc.accessGrant.toSecurityTag
+      ).succeed
     }
     // ALL the following methods are useless for our test
-    override def getFullDirectiveLibrary(): IOResult[FullActiveTechniqueCategory] = {
+    override def getFullDirectiveLibrary()(using qc: QueryContext): IOResult[FullActiveTechniqueCategory] = {
       FullActiveTechniqueCategory(
         ActiveTechniqueCategoryId("Active Techniques"),
         name = "",
@@ -156,54 +160,62 @@ class TechniqueRepositoryTest extends Specification with Loggable with AfterAll 
         None
       ).succeed
     }
-    override def getDirective(directiveId: DirectiveUid): IOResult[Option[Directive]] = ???
-    override def getDirectiveWithContext(directiveId: DirectiveUid): IOResult[Option[(Technique, ActiveTechnique, Directive)]] =
-      ???
-    override def getActiveTechniqueAndDirective(id:      DirectiveId): IOResult[Option[(ActiveTechnique, Directive)]] = ???
-    override def getDirectives(activeTechniqueId:        ActiveTechniqueId, includeSystem: Boolean): IOResult[Seq[Directive]] = ???
+    override def getDirective(directiveId:           DirectiveUid)(using qc: QueryContext): IOResult[Option[Directive]] = ???
+    override def getDirectiveWithContext(
+        directiveId: DirectiveUid
+    )(using qc: QueryContext): IOResult[Option[(Technique, ActiveTechnique, Directive)]] = ???
+    override def getActiveTechniqueAndDirective(
+        id: DirectiveId
+    )(using qc: QueryContext): IOResult[Option[(ActiveTechnique, Directive)]] = ???
+    override def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean)(using
+        qc: QueryContext
+    ): IOResult[Seq[Directive]] = ???
     override def getActiveTechniqueByCategory(
         includeSystem: Boolean
-    ): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = ???
-    override def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId): IOResult[Option[ActiveTechnique]] = ???
-    override def getActiveTechnique(techniqueName:       TechniqueName): IOResult[Option[ActiveTechnique]] = ???
-    override def activeTechniqueBreadCrump(id:           ActiveTechniqueId): IOResult[List[ActiveTechniqueCategory]] = ???
-    override def getActiveTechniqueLibrary: IOResult[ActiveTechniqueCategory] = ???
-    override def getAllActiveTechniqueCategories(includeSystem: Boolean):                   IOResult[Seq[ActiveTechniqueCategory]]    = ???
-    override def getActiveTechniqueCategory(id:                 ActiveTechniqueCategoryId): IOResult[Option[ActiveTechniqueCategory]] = ???
-    override def getParentActiveTechniqueCategory(id:           ActiveTechniqueCategoryId): IOResult[ActiveTechniqueCategory]         = ???
-    override def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[List[ActiveTechniqueCategory]] =
+    )(using qc: QueryContext): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = ???
+    override def getActiveTechniqueByActiveTechnique(
+        id: ActiveTechniqueId
+    )(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = ???
+    override def getActiveTechnique(techniqueName: TechniqueName)(using qc: QueryContext): IOResult[Option[ActiveTechnique]] =
       ???
-    override def getParentsForActiveTechnique(id: ActiveTechniqueId):         IOResult[ActiveTechniqueCategory] = ???
-    override def containsDirective(id:            ActiveTechniqueCategoryId): UIO[Boolean]                      = ???
+    override def activeTechniqueBreadCrump(
+        id: ActiveTechniqueId
+    )(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = ???
+    override def getActiveTechniqueLibrary(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = ???
+    override def getAllActiveTechniqueCategories(includeSystem: Boolean)(using
+        qc: QueryContext
+    ): IOResult[Seq[ActiveTechniqueCategory]] = ???
+    override def getActiveTechniqueCategory(
+        id: ActiveTechniqueCategoryId
+    )(using qc: QueryContext): IOResult[Option[ActiveTechniqueCategory]] = ???
+    override def getParentActiveTechniqueCategory(
+        id: ActiveTechniqueCategoryId
+    )(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = ???
+    override def getParentsForActiveTechniqueCategory(
+        id: ActiveTechniqueCategoryId
+    )(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = ???
+    override def getParentsForActiveTechnique(id: ActiveTechniqueId)(using
+        qc: QueryContext
+    ): IOResult[ActiveTechniqueCategory] =
+      ???
+    override def containsDirective(id:               ActiveTechniqueCategoryId): UIO[Boolean] = ???
     override def saveActiveTechniqueCategory(
         category: ActiveTechniqueCategory
     )(implicit cc: ChangeContext): IOResult[ActiveTechniqueCategory] = ???
     override def saveDirective(
         inActiveTechniqueId: ActiveTechniqueId,
-        directive:           Directive,
-        modId:               ModificationId,
-        actor:               EventActor,
-        reason:              Option[String]
-    ): IOResult[Option[DirectiveSaveDiff]] = ???
+        directive:           Directive
+    )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = ???
     override def saveSystemDirective(
         inActiveTechniqueId: ActiveTechniqueId,
-        directive:           Directive,
-        modId:               ModificationId,
-        actor:               EventActor,
-        reason:              Option[String]
-    ): IOResult[Option[DirectiveSaveDiff]] = ???
+        directive:           Directive
+    )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = ???
     override def delete(
-        id:     DirectiveUid,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[DeleteDirectiveDiff]] = ???
+        id: DirectiveUid
+    )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = ???
     override def deleteSystemDirective(
-        id:     DirectiveUid,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[DeleteDirectiveDiff]] = ???
+        id: DirectiveUid
+    )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = ???
     override def move(
         id:            ActiveTechniqueId,
         newCategoryId: ActiveTechniqueCategoryId
@@ -217,11 +229,8 @@ class TechniqueRepositoryTest extends Specification with Loggable with AfterAll 
         datetimes: Map[TechniqueVersion, Instant]
     )(implicit cc: ChangeContext): IOResult[ActiveTechniqueId] = ???
     override def deleteActiveTechnique(
-        id:     ActiveTechniqueId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[ActiveTechniqueId] = ???
+        id: ActiveTechniqueId
+    )(using cc: ChangeContext): IOResult[ActiveTechniqueId] = ???
   }
 
   val ldapCallBack = new TechniqueAcceptationUpdater("update", 0, ldapRepo, ldapRepo, fsRepos)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -214,6 +214,11 @@ object revisionRepo {
   }
 }
 
+class MockTenants() {
+  val tenantRepo = InMemoryTenantService.make(List(TenantId("zoneA"), TenantId("zoneB"))).runNow
+  val checkTenant: TenantCheckLogic = new DefaultTenantCheckLogic()
+}
+
 class MockGitConfigRepo(prefixTestResources: String = "", configRepoDirName: String = "configuration-repository") {
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -546,7 +551,7 @@ object TV {
     TechniqueVersion.parse(s).getOrElse(throw new IllegalArgumentException(s"Cannot parse '${s}' as a technique version'"))
 }
 
-class MockDirectives(mockTechniques: MockTechniques) {
+class MockDirectives(mockTechniques: MockTechniques, mockTenants: MockTenants) {
 
   object directives {
 
@@ -914,7 +919,7 @@ class MockDirectives(mockTechniques: MockTechniques) {
         subCategories = Nil,
         activeTechniques = Nil,
         isSystem = true,
-        security = None
+        security = Some(SecurityTag.Open)
       )
     )
     .runNow
@@ -934,7 +939,7 @@ class MockDirectives(mockTechniques: MockTechniques) {
         .mkString("", "\n", "")}""".stripMargin
   }
 
-  object directiveRepo extends RoDirectiveRepository with WoDirectiveRepository with DirectiveRevisionRepository {
+  object directiveRepoImpl extends RoDirectiveRepository with WoDirectiveRepository with DirectiveRevisionRepository {
 
     override def getDirectiveRevision(
         uid: DirectiveUid,
@@ -958,31 +963,38 @@ class MockDirectives(mockTechniques: MockTechniques) {
       }
     }
 
-    override def getFullDirectiveLibrary(): IOResult[FullActiveTechniqueCategory] = rootActiveTechniqueCategory.get
+    override def getFullDirectiveLibrary()(using qc: QueryContext): IOResult[FullActiveTechniqueCategory] =
+      rootActiveTechniqueCategory.get
 
-    override def getDirective(uid: DirectiveUid): IOResult[Option[Directive]] = {
+    override def getDirective(uid: DirectiveUid)(using qc: QueryContext): IOResult[Option[Directive]] = {
       getDirectiveRevision(uid, GitVersion.DEFAULT_REV).map(_.map(_._2))
     }
 
-    override def getDirectiveWithContext(directiveId: DirectiveUid): IOResult[Option[(Technique, ActiveTechnique, Directive)]] = {
+    override def getDirectiveWithContext(
+        directiveId: DirectiveUid
+    )(using qc: QueryContext): IOResult[Option[(Technique, ActiveTechnique, Directive)]] = {
       rootActiveTechniqueCategory.get.map(_.allDirectives.get(DirectiveId(directiveId)).map {
         case (fat, d) =>
           (fat.techniques(d.techniqueVersion), fat.toActiveTechnique(), d)
       })
     }
 
-    override def getActiveTechniqueAndDirective(id: DirectiveId): IOResult[Option[(ActiveTechnique, Directive)]] = {
+    override def getActiveTechniqueAndDirective(
+        id: DirectiveId
+    )(using qc: QueryContext): IOResult[Option[(ActiveTechnique, Directive)]] = {
       getDirectiveWithContext(id.uid).map(_.map { case (t, at, d) => (at, d) })
     }
 
-    override def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean): IOResult[Seq[Directive]] = {
+    override def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean)(using
+        qc: QueryContext
+    ): IOResult[Seq[Directive]] = {
       val predicate = (d: Directive) => if (includeSystem) true else !d.isSystem
       rootActiveTechniqueCategory.get.map(_.allDirectives.collect { case (_, (_, d)) if (predicate(d)) => d }.toSeq)
     }
 
     override def getActiveTechniqueByCategory(
         includeSystem: Boolean
-    ): IOResult[ISortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = {
+    )(using qc: QueryContext): IOResult[ISortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = {
       implicit val ordering = ActiveTechniqueCategoryOrdering
       rootActiveTechniqueCategory.get.map(c => {
         ISortedMap.empty[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques] ++ c.fullIndex.map {
@@ -995,17 +1007,23 @@ class MockDirectives(mockTechniques: MockTechniques) {
       })
     }
 
-    override def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId): IOResult[Option[ActiveTechnique]] = {
+    override def getActiveTechniqueByActiveTechnique(
+        id: ActiveTechniqueId
+    )(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = {
       rootActiveTechniqueCategory.get.map(_.allActiveTechniques.get(id).map(_.toActiveTechnique()))
     }
 
-    override def getActiveTechnique(techniqueName: TechniqueName): IOResult[Option[ActiveTechnique]] = {
+    override def getActiveTechnique(
+        techniqueName: TechniqueName
+    )(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = {
       rootActiveTechniqueCategory.get.map(
         _.allActiveTechniques.valuesIterator.find(_.techniqueName == techniqueName).map(_.toActiveTechnique())
       )
     }
 
-    override def activeTechniqueBreadCrump(id: ActiveTechniqueId): IOResult[List[ActiveTechniqueCategory]] = {
+    override def activeTechniqueBreadCrump(
+        id: ActiveTechniqueId
+    )(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = {
       import cats.implicits.*
 
       rootActiveTechniqueCategory.get.map(root => {
@@ -1023,11 +1041,13 @@ class MockDirectives(mockTechniques: MockTechniques) {
       })
     }
 
-    override def getActiveTechniqueLibrary: IOResult[ActiveTechniqueCategory] = {
+    override def getActiveTechniqueLibrary(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
       rootActiveTechniqueCategory.get.map(_.toActiveTechniqueCategory())
     }
 
-    override def getAllActiveTechniqueCategories(includeSystem: Boolean): IOResult[Seq[ActiveTechniqueCategory]] = {
+    override def getAllActiveTechniqueCategories(includeSystem: Boolean)(using
+        qc: QueryContext
+    ): IOResult[Seq[ActiveTechniqueCategory]] = {
       val predicate = (fat: FullActiveTechniqueCategory) => if (includeSystem) true else !fat.isSystem
       rootActiveTechniqueCategory.get.map {
         _.allCategories.values.collect {
@@ -1037,11 +1057,15 @@ class MockDirectives(mockTechniques: MockTechniques) {
       }
     }
 
-    override def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[Option[ActiveTechniqueCategory]] = {
+    override def getActiveTechniqueCategory(
+        id: ActiveTechniqueCategoryId
+    )(using qc: QueryContext): IOResult[Option[ActiveTechniqueCategory]] = {
       rootActiveTechniqueCategory.get.map(_.allCategories.get(id).map(_.toActiveTechniqueCategory()))
     }
 
-    override def getParentActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[ActiveTechniqueCategory] = {
+    override def getParentActiveTechniqueCategory(
+        id: ActiveTechniqueCategoryId
+    )(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
       rootActiveTechniqueCategory.get.flatMap(root => {
         root.fullIndex.find(_._1.lastOption == Some(id)) match {
           case None            =>
@@ -1058,10 +1082,12 @@ class MockDirectives(mockTechniques: MockTechniques) {
 
     // scalafmt makes scalameta ScalametaParser to fail for now
     // format: off
-    override def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[List[ActiveTechniqueCategory]] = ???
+    override def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = ???
     // format: on
 
-    override def getParentsForActiveTechnique(id: ActiveTechniqueId): IOResult[ActiveTechniqueCategory] = ???
+    override def getParentsForActiveTechnique(id: ActiveTechniqueId)(using
+        qc: QueryContext
+    ): IOResult[ActiveTechniqueCategory] = ???
 
     override def containsDirective(id: ActiveTechniqueCategoryId): UIO[Boolean] = ???
 
@@ -1115,22 +1141,16 @@ class MockDirectives(mockTechniques: MockTechniques) {
     }
     override def saveDirective(
         inActiveTechniqueId: ActiveTechniqueId,
-        directive:           Directive,
-        modId:               ModificationId,
-        actor:               EventActor,
-        reason:              Option[String]
-    ): IOResult[Option[DirectiveSaveDiff]] = {
+        directive:           Directive
+    )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = {
       if (directive.isSystem) Inconsistency(s"Can not modify system directive '${directive.id}' here").fail
       else saveGen(inActiveTechniqueId, directive)
     }
 
     override def saveSystemDirective(
         inActiveTechniqueId: ActiveTechniqueId,
-        directive:           Directive,
-        modId:               ModificationId,
-        actor:               EventActor,
-        reason:              Option[String]
-    ): IOResult[Option[DirectiveSaveDiff]] = {
+        directive:           Directive
+    )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = {
       if (!directive.isSystem) Inconsistency(s"Can not modify non system directive '${directive.id}' here").fail
       else saveGen(inActiveTechniqueId, directive)
     }
@@ -1142,20 +1162,14 @@ class MockDirectives(mockTechniques: MockTechniques) {
         .map(_.map(p => DeleteDirectiveDiff(p._1.techniqueName, p._2)))
     }
     override def delete(
-        id:     DirectiveUid,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[DeleteDirectiveDiff]] = {
+        id: DirectiveUid
+    )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = {
       deleteGen(id)
     }
 
     override def deleteSystemDirective(
-        id:     DirectiveUid,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[DeleteDirectiveDiff]] = {
+        id: DirectiveUid
+    )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = {
       deleteGen(id)
     }
 
@@ -1198,11 +1212,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
     )(implicit cc: ChangeContext): IOResult[ActiveTechniqueId] = ???
 
     override def deleteActiveTechnique(
-        id:     ActiveTechniqueId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[ActiveTechniqueId] = ???
+        id: ActiveTechniqueId
+    )(using cc: ChangeContext): IOResult[ActiveTechniqueId] = ???
 
     override def addActiveTechniqueCategory(
         that: ActiveTechniqueCategory,
@@ -1239,22 +1250,35 @@ class MockDirectives(mockTechniques: MockTechniques) {
 
   }
 
+  // the tenant-filtering repository used by services/tests, backed by the in-memory `directiveRepoImpl`
+  object directiveRepo
+      extends WoTenantDirectiveRepo(
+        mockTenants.checkTenant,
+        mockTenants.tenantRepo,
+        directiveRepoImpl,
+        new RoTenantDirectiveRepo(mockTenants.checkTenant, directiveRepoImpl)
+      ) with DirectiveRevisionRepository {
+    export directiveRepoImpl.getDirectiveRevision
+    export directiveRepoImpl.getRevisions
+  }
+
+  // seeding is done directly on the underlying repo, as an admin, to avoid any tenant filtering
   val initDirectivesTree =
-    new InitDirectivesTree(mockTechniques.techniqueRepo, directiveRepo, directiveRepo, new StringUuidGeneratorImpl())
+    new InitDirectivesTree(mockTechniques.techniqueRepo, directiveRepoImpl, directiveRepoImpl, new StringUuidGeneratorImpl())
 
   initDirectivesTree.copyReferenceLib(includeSystem = true)
 
   {
-    val modId = ModificationId(s"init directives in lib")
+    given cc: ChangeContext = ChangeContext.newForRudder(Some("init directives in lib"))
     ZIO
       .foreachDiscard(directives.all) {
         case (t, list) =>
           val at = ActiveTechniqueId(t.id.name.value)
           ZIO.foreachDiscard(list) { d =>
             if (d.isSystem) {
-              directiveRepo.saveSystemDirective(at, d, modId, TestActor.get, None)
+              directiveRepoImpl.saveSystemDirective(at, d)
             } else {
-              directiveRepo.saveDirective(at, d, modId, TestActor.get, None)
+              directiveRepoImpl.saveDirective(at, d)
             }
           }
       }
@@ -1262,7 +1286,7 @@ class MockDirectives(mockTechniques: MockTechniques) {
   }
 }
 
-class MockRules() {
+class MockRules(mockTenants: MockTenants) {
   val t1: Long = System.currentTimeMillis()
 
   val rootRuleCategory: RuleCategory = RuleCategory(
@@ -1271,10 +1295,10 @@ class MockRules() {
     "This is the main category of Rules",
     RuleCategory(RuleCategoryId("category1"), "Category 1", "description of category 1", Nil, security = None) :: Nil,
     isSystem = true,
-    security = None
+    security = Some(SecurityTag.Open) // root cat must be open
   )
 
-  object ruleCategoryRepo extends RoRuleCategoryRepository with WoRuleCategoryRepository {
+  object ruleCategoryRepoImpl extends RoRuleCategoryRepository with WoRuleCategoryRepository {
 
     import com.softwaremill.quicklens.*
 
@@ -1314,18 +1338,15 @@ class MockRules() {
 
     val categories: Ref.Synchronized[RuleCategory] = Ref.Synchronized.make(rootRuleCategory).runNow
 
-    override def get(id: RuleCategoryId): IOResult[RuleCategory] = {
+    override def get(id: RuleCategoryId)(using qc: QueryContext): IOResult[RuleCategory] = {
       categories.get.flatMap(c => recGet(c, id).map(_._2).notOptional(s"category with id '${id.value}' not found"))
     }
-    override def getRootCategory():       IOResult[RuleCategory] = categories.get
+    override def getRootCategory()(using qc: QueryContext): IOResult[RuleCategory] = categories.get
 
     override def create(
-        that:   RuleCategory,
-        into:   RuleCategoryId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[RuleCategory] = {
+        that: RuleCategory,
+        into: RuleCategoryId
+    )(implicit cc: ChangeContext): IOResult[RuleCategory] = {
       categories
         .updateZIO(cats => {
           recGet(cats, into) match {
@@ -1342,12 +1363,9 @@ class MockRules() {
     }
 
     override def updateAndMove(
-        that:   RuleCategory,
-        into:   RuleCategoryId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[RuleCategory] = {
+        that: RuleCategory,
+        into: RuleCategoryId
+    )(implicit cc: ChangeContext): IOResult[RuleCategory] = {
       categories
         .updateZIO(cats => {
           recGet(cats, that.id) match {
@@ -1370,14 +1388,20 @@ class MockRules() {
 
     override def delete(
         category:   RuleCategoryId,
-        modId:      ModificationId,
-        actor:      EventActor,
-        reason:     Option[String],
         checkEmpty: Boolean
-    ): IOResult[RuleCategoryId] = {
+    )(implicit cc: ChangeContext): IOResult[RuleCategoryId] = {
       categories.updateZIO(cats => inDelete(cats, category).succeed).map(_ => category)
     }
   }
+
+  // the tenant-filtering repository used by services/tests, backed by the in-memory `ruleCategoryRepoImpl`
+  object ruleCategoryRepo
+      extends WoTenantRuleCategoryRepo(
+        mockTenants.checkTenant,
+        mockTenants.tenantRepo,
+        ruleCategoryRepoImpl,
+        new RoTenantRuleCategoryRepo(mockTenants.checkTenant, ruleCategoryRepoImpl)
+      )
 
   object rules {
 
@@ -1560,25 +1584,25 @@ class MockRules() {
     )
   }
 
-  object ruleRepo extends RoRuleRepository with WoRuleRepository {
+  object ruleRepoImpl extends RoRuleRepository with WoRuleRepository {
 
     val rulesMap: Ref.Synchronized[Map[RuleId, Rule]] = Ref.Synchronized.make(rules.all.map(r => (r.id, r)).toMap).runNow
 
     val predicate: Boolean => (Rule => Boolean) = (includeSystem: Boolean) =>
       (r: Rule) => if (includeSystem) true else r.isSystem == false
 
-    override def getOpt(ruleId: RuleId): IOResult[Option[Rule]] =
+    override def getOpt(ruleId: RuleId)(using qc: QueryContext): IOResult[Option[Rule]] =
       rulesMap.get.map(_.get(ruleId))
 
-    override def getAll(includeSystem: Boolean): IOResult[Seq[Rule]] = {
+    override def getAll(includeSystem: Boolean)(using qc: QueryContext): IOResult[Seq[Rule]] = {
       rulesMap.get.map(_.valuesIterator.filter(predicate(includeSystem)).toSeq)
     }
 
-    override def getIds(includeSystem: Boolean): IOResult[Set[RuleId]] = {
+    override def getIds(includeSystem: Boolean)(using qc: QueryContext): IOResult[Set[RuleId]] = {
       rulesMap.get.map(_.valuesIterator.collect { case r if (predicate(includeSystem)(r)) => r.id }.toSet)
     }
 
-    override def create(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[AddRuleDiff] = {
+    override def create(rule: Rule)(using cc: ChangeContext): IOResult[AddRuleDiff] = {
       rulesMap
         .updateZIO(rules => {
           rules.get(rule.id) match {
@@ -1616,12 +1640,7 @@ class MockRules() {
       }
     }
 
-    override def update(
-        rule:   Rule,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[ModifyRuleDiff]] = {
+    override def update(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]] = {
       rulesMap
         .modifyZIO(rules => {
           rules.get(rule.id) match {
@@ -1636,12 +1655,7 @@ class MockRules() {
         .map(buildRuleDiff(_, rule))
     }
 
-    override def updateSystem(
-        rule:   Rule,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[ModifyRuleDiff]] = {
+    override def updateSystem(rule: Rule)(using cc: ChangeContext): IOResult[Option[ModifyRuleDiff]] = {
       rulesMap
         .modifyZIO(rules => {
           rules.get(rule.id) match {
@@ -1656,12 +1670,7 @@ class MockRules() {
         .map(buildRuleDiff(_, rule))
     }
 
-    override def delete(
-        id:     RuleId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[DeleteRuleDiff] = {
+    override def delete(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
       rulesMap
         .modifyZIO(rules => {
           rules.get(id) match {
@@ -1677,12 +1686,7 @@ class MockRules() {
         .map(DeleteRuleDiff(_))
     }
 
-    override def deleteSystemRule(
-        id:     RuleId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[DeleteRuleDiff] = {
+    override def deleteSystemRule(id: RuleId)(using cc: ChangeContext): IOResult[DeleteRuleDiff] = {
       rulesMap
         .modifyZIO(rules => {
           rules.get(id) match {
@@ -1709,9 +1713,20 @@ class MockRules() {
 
     override def deleteSavedRuleArchiveId(saveId: RuleArchiveId): IOResult[Unit] = ZIO.unit
 
-    override def load(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit] = ???
+    override def load(rule: Rule)(using cc: ChangeContext): IOResult[Unit] = ???
 
-    override def unload(ruleId: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit] = ???
+    override def unload(ruleId: RuleId)(using cc: ChangeContext): IOResult[Unit] = ???
+  }
+
+  // the tenant-filtering repository used by services/tests, backed by the in-memory `ruleRepoImpl`
+  object ruleRepo
+      extends WoTenantRuleRepo(
+        mockTenants.checkTenant,
+        mockTenants.tenantRepo,
+        ruleRepoImpl,
+        new RoTenantRuleRepo(mockTenants.checkTenant, ruleRepoImpl)
+      ) {
+    export ruleRepoImpl.rulesMap
   }
 }
 
@@ -1734,7 +1749,7 @@ class MockConfigRepo(
   )
 }
 
-class MockGlobalParam() {
+class MockGlobalParam(mockTenants: MockTenants) {
 
   val mode: InheritMode = {
     import com.normation.rudder.domain.properties.InheritMode.*
@@ -1824,8 +1839,7 @@ class MockGlobalParam() {
   val all: Map[String, GlobalParameter] =
     List(stringParam, hiddenParam, jsonParam, modeParam, systemParam, rudderConfig).map(p => (p.name, p)).toMap
 
-  val paramsRepo: paramsRepo = new paramsRepo
-  class paramsRepo extends RoParameterRepository with WoParameterRepository {
+  class paramsRepoImpl extends RoParameterRepository with WoParameterRepository {
 
     // needed because we don't have real dyngroup update in mock, so propertiesService is
     // not called when it should.
@@ -1841,20 +1855,17 @@ class MockGlobalParam() {
     val paramsMap: Ref.Synchronized[Map[String, GlobalParameter]] =
       Ref.Synchronized.make[Map[String, GlobalParameter]](all).runNow
 
-    override def getGlobalParameter(parameterName: String): IOResult[Option[GlobalParameter]] = {
+    override def getGlobalParameter(parameterName: String)(using qc: QueryContext): IOResult[Option[GlobalParameter]] = {
       paramsMap.get.map(_.get(parameterName))
     }
 
-    override def getAllGlobalParameters(): IOResult[Seq[GlobalParameter]] = {
+    override def getAllGlobalParameters()(using qc: QueryContext): IOResult[Seq[GlobalParameter]] = {
       paramsMap.get.map(_.valuesIterator.toSeq)
     }
 
     override def saveParameter(
-        parameter: GlobalParameter,
-        modId:     ModificationId,
-        actor:     EventActor,
-        reason:    Option[String]
-    ): IOResult[AddGlobalParameterDiff] = {
+        parameter: GlobalParameter
+    )(using cc: ChangeContext): IOResult[AddGlobalParameterDiff] = {
       paramsMap
         .updateZIO(params => {
           params.get(parameter.name) match {
@@ -1869,11 +1880,8 @@ class MockGlobalParam() {
     }
 
     override def updateParameter(
-        parameter: GlobalParameter,
-        modId:     ModificationId,
-        actor:     EventActor,
-        reason:    Option[String]
-    ): IOResult[Option[ModifyGlobalParameterDiff]] = {
+        parameter: GlobalParameter
+    )(using cc: ChangeContext): IOResult[Option[ModifyGlobalParameterDiff]] = {
       paramsMap
         .modifyZIO(params => {
           params.get(parameter.name) match {
@@ -1894,11 +1902,8 @@ class MockGlobalParam() {
 
     override def delete(
         parameterName: String,
-        provider:      Option[PropertyProvider],
-        modId:         ModificationId,
-        actor:         EventActor,
-        reason:        Option[String]
-    ): IOResult[Option[DeleteGlobalParameterDiff]] = {
+        provider:      Option[PropertyProvider]
+    )(using cc: ChangeContext): IOResult[Option[DeleteGlobalParameterDiff]] = {
       paramsMap
         .modifyZIO(params => {
           params.get(parameterName) match {
@@ -1920,6 +1925,20 @@ class MockGlobalParam() {
       ZIO.unit
     }
 
+  }
+
+  private val paramsRepoImplInstance = new paramsRepoImpl
+
+  // the tenant-filtering repository used by services/tests, backed by the in-memory `paramsRepoImplInstance`
+  object paramsRepo
+      extends WoTenantParameterRepo(
+        mockTenants.checkTenant,
+        mockTenants.tenantRepo,
+        paramsRepoImplInstance,
+        new RoTenantParameterRepo(mockTenants.checkTenant, paramsRepoImplInstance)
+      ) {
+    export paramsRepoImplInstance.callbacks
+    export paramsRepoImplInstance.paramsMap
   }
 }
 
@@ -2421,7 +2440,7 @@ Uu/CwaqyaPf39pzyXLNdZszknsXk+ih1+Kn/X7cTTUjNsvlMRqlh/wW2Ss0FK3R3
   }
 }
 
-class MockNodes() {
+class MockNodes(mockTenant: MockTenants) {
   val t2: Long = System.currentTimeMillis()
 
   object nodeFactStorage extends NodeFactStorage {
@@ -2499,7 +2518,7 @@ class MockNodes() {
   }
 
   object softwareDao extends ReadOnlySoftwareDAO {
-    implicit val qc: QueryContext = QueryContext.todoQC
+    implicit val qc: QueryContext = QueryContext.systemQC
 
     val softRef: Ref.Synchronized[Map[SoftwareUuid, Software]] =
       Ref.Synchronized.make(MockNodes.softwares.map(s => (s.id, s)).toMap).runNow
@@ -2544,11 +2563,10 @@ class MockNodes() {
 
   val getNodesBySoftwareName = new SoftDaoGetNodesBySoftwareName(softwareDao)
 
-  val tenantRepo: TenantService = InMemoryTenantService.make(Nil).runNow
-  val tenantService = new DefaultTenantCheckLogic()
-
   val nodeFactRepo: CoreNodeFactRepository = {
-    CoreNodeFactRepository.make(nodeFactStorage, getNodesBySoftwareName, tenantRepo, tenantService, Chunk(), Chunk()).runNow
+    CoreNodeFactRepository
+      .make(nodeFactStorage, getNodesBySoftwareName, mockTenant.tenantRepo, mockTenant.checkTenant, Chunk(), Chunk())
+      .runNow
   }
 
   val propRepo: PropertiesRepository = {
@@ -2647,7 +2665,7 @@ class MockNodes() {
   }
 
   object newNodeManager extends NewNodeManager {
-    implicit val qc: QueryContext = QueryContext.todoQC
+    implicit val qc: QueryContext = QueryContext.systemQC
 
     val list = new FactListNewNodes(nodeFactRepo)
 
@@ -2698,9 +2716,9 @@ class MockNodes() {
   val scoreManager: ScoreServiceManager = new ScoreServiceManager(scoreService)
 }
 
-class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
+class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam, mockTenants: MockTenants) {
 
-  object groupsRepo extends RoNodeGroupRepository with WoNodeGroupRepository {
+  object groupsRepoImpl extends RoNodeGroupRepository with WoNodeGroupRepository {
     implicit val qc:       QueryContext                   = QueryContext.testQC
     implicit val ordering: NodeGroupCategoryOrdering.type = com.normation.rudder.repository.NodeGroupCategoryOrdering
 
@@ -2713,12 +2731,12 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
           subCategories = Nil,
           targetInfos = Nil,
           isSystem = true,
-          security = None
+          security = Some(SecurityTag.Open) // root must be open
         )
       )
       .runNow
 
-    override def categoryExists(id: NodeGroupCategoryId): IOResult[Boolean] = {
+    override def categoryExists(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean] = {
       categories.get.map(_.allCategories.keySet.contains(id))
     }
 
@@ -2734,22 +2752,23 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
         })
       })
     }
-    override def getNodeGroupCategory(id: NodeGroupId): IOResult[NodeGroupCategory] = {
+    override def getNodeGroupCategory(id: NodeGroupId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
       for {
         root <- categories.get
         cid  <- root.categoryByGroupId.get(id).notOptional(s"Category for group '${id.serialize}' not found")
         cat  <- root.allCategories.get(cid).map(_.toNodeGroupCategory).notOptional(s"Category '${cid.value}' not found")
       } yield cat
     }
-    override def getAll():                              IOResult[Seq[NodeGroup]]    = categories.get.map(_.allGroups.values.map(_.nodeGroup).toSeq)
-    override def getAllByIds(ids: Seq[NodeGroupId]):    IOResult[Seq[NodeGroup]]    = {
+    override def getAll()(using qc: QueryContext):                              IOResult[Seq[NodeGroup]]    =
+      categories.get.map(_.allGroups.values.map(_.nodeGroup).toSeq)
+    override def getAllByIds(ids: Seq[NodeGroupId])(using qc: QueryContext):    IOResult[Seq[NodeGroup]]    = {
       categories.get.map(_.allGroups.values.map(_.nodeGroup).filter(g => ids.contains(g.id)).toSeq)
     }
 
-    override def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] =
+    override def getAllNodeIds()(using qc: QueryContext): IOResult[Map[NodeGroupId, Set[NodeId]]] =
       categories.get.map(_.allGroups.values.map(_.nodeGroup).map(g => (g.id, g.serverList)).toMap)
 
-    override def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]] =
+    override def getAllNodeIdsChunk()(using qc: QueryContext): IOResult[Map[NodeGroupId, Chunk[NodeId]]] =
       categories.get.map(_.allGroups.values.map(_.nodeGroup).map(g => (g.id, Chunk.fromIterable(g.serverList))).toMap)
 
     override def getGroupsByCategory(
@@ -2776,13 +2795,15 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
       c
     }
 
-    override def getCategoryHierarchy: IOResult[ISortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = {
+    override def getCategoryHierarchy(using
+        qc: QueryContext
+    ): IOResult[ISortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = {
       getGroupsByCategory(true).map(
         _.map { case (k, v) => (k, v.category) }
       )
     }
 
-    override def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = {
+    override def findGroupWithAnyMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]] = {
       categories.get.map { root =>
         root.allGroups.collect {
           case (_, c) if (c.nodeGroup.serverList.exists(s => nodeIds.contains(s))) => c.nodeGroup.id
@@ -2790,7 +2811,7 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
       }
     }
 
-    override def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = {
+    override def findGroupWithAllMember(nodeIds: Seq[NodeId])(using qc: QueryContext): IOResult[Seq[NodeGroupId]] = {
       categories.get.map { root =>
         root.allGroups.collect {
           case (_, c) if (nodeIds.forall(s => c.nodeGroup.serverList.contains(s))) => c.nodeGroup.id
@@ -2798,10 +2819,11 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
       }
     }
 
-    override def getRootCategoryPure(): IOResult[NodeGroupCategory] = categories.get.map(_.toNodeGroupCategory)
-    override def getRootCategory():     NodeGroupCategory           = getRootCategoryPure().runNow
+    override def getRootCategoryPure()(using qc: QueryContext): IOResult[NodeGroupCategory] =
+      categories.get.map(_.toNodeGroupCategory)
+    override def getRootCategory()(using qc: QueryContext): NodeGroupCategory = getRootCategoryPure().runNow
 
-    override def getAllGroupCategories(includeSystem: Boolean): IOResult[Seq[NodeGroupCategory]] = {
+    override def getAllGroupCategories(includeSystem: Boolean)(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] = {
       categories.get
         .map(_.allCategories.values.collect {
           case c if (!c.isSystem || c.isSystem && includeSystem) => c.toNodeGroupCategory
@@ -2809,11 +2831,11 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
         .map(_.toSeq)
     }
 
-    override def getGroupCategory(id: NodeGroupCategoryId): IOResult[NodeGroupCategory] = {
+    override def getGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
       categories.get.flatMap(_.allCategories.get(id).notOptional(s"Category '${id.value}' not found").map(_.toNodeGroupCategory))
     }
 
-    override def getParentGroupCategory(id: NodeGroupCategoryId): IOResult[NodeGroupCategory] = {
+    override def getParentGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
       categories.get.flatMap { root =>
         root.parentCategories.get(id).notOptional(s"Parent of category '${id.value}' not found").map(_.toNodeGroupCategory)
       }
@@ -2827,11 +2849,15 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
       }
     }
 
-    override def getParents_NodeGroupCategory(id: NodeGroupCategoryId): IOResult[List[NodeGroupCategory]] = {
+    override def getParents_NodeGroupCategory(id: NodeGroupCategoryId)(using
+        qc: QueryContext
+    ): IOResult[List[NodeGroupCategory]] = {
       categories.get.map(recGetParent(_, id).map(_.toNodeGroupCategory))
     }
 
-    override def getAllNonSystemCategories(): IOResult[Seq[NodeGroupCategory]] = getAllGroupCategories(false)
+    override def getAllNonSystemCategories()(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] = getAllGroupCategories(
+      false
+    )
 
     // returns (parents, group) if found
     def recGetCat(
@@ -3068,6 +3094,17 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
     }
   }
 
+  // the tenant-filtering repository used by services/tests, backed by the in-memory `groupsRepoImpl`
+  object groupsRepo
+      extends WoTenantNodeGroupRepo(
+        mockTenants.checkTenant,
+        mockTenants.tenantRepo,
+        groupsRepoImpl,
+        new RoTenantNodeGroupRepo(mockTenants.checkTenant, groupsRepoImpl)
+      ) {
+    export groupsRepoImpl.categories
+  }
+
   // data
   val g0props: List[GroupProperty] = List(
     GroupProperty(
@@ -3180,7 +3217,7 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
       description = "",
       isEnabled = true,
       isSystem = false,
-      security = None
+      security = gt._2.security
     )
   }
 
@@ -3196,7 +3233,7 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
         subCategories = Nil,
         targetInfos = List(groupsTargetInfos.head), // that g0 id:0000f5d3-8c61-4d20-88a7-bb947705ba8
         isSystem = false,
-        security = None
+        security = Some(SecurityTag.Open)           // root must be open
       ),
       FullNodeGroupCategory(
         NodeGroupCategoryId("system-category1"),
@@ -3288,7 +3325,7 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam) {
       )
     ) ++ groupsTargetInfos.drop(1),
     isSystem = true,
-    security = None
+    security = Some(SecurityTag.Open)
   )
 
   // init with full lib

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1724,7 +1724,8 @@ class MockRules(mockTenants: MockTenants) {
         mockTenants.checkTenant,
         mockTenants.tenantRepo,
         ruleRepoImpl,
-        new RoTenantRuleRepo(mockTenants.checkTenant, ruleRepoImpl)
+        new RoTenantRuleRepo(mockTenants.checkTenant, ruleRepoImpl),
+        ruleCategoryRepoImpl
       ) {
     export ruleRepoImpl.rulesMap
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -15,6 +15,7 @@ import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.reports.ReportingConfiguration
 import com.normation.rudder.repository.FullNodeGroupCategory
+import com.normation.rudder.tenants.SecurityTag
 import java.time.Instant
 import net.liftweb.common.*
 import org.junit.runner.RunWith
@@ -156,7 +157,7 @@ class RuleTargetTest extends Specification with Loggable with JsonSpecMatcher {
         "",
         isEnabled = true,
         isSystem = false,
-        security = None
+        security = gt._2.security
       )
     }))
     .toList
@@ -197,7 +198,7 @@ class RuleTargetTest extends Specification with Loggable with JsonSpecMatcher {
     Nil,
     fullRuleTargetInfos,
     isSystem = false,
-    security = None
+    security = Some(SecurityTag.Open) // root category must be open
   )
 
   val allTargets: Set[RuleTarget] = (groupTargets.map(_._1) ++ (allComposite.map(_._1)) ++ allTargetExclusions.map(_._1))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/PropertiesRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/PropertiesRepositoryTest.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.domain.properties
 
 import com.normation.rudder.MockNodes
+import com.normation.rudder.MockTenants
 import com.normation.rudder.properties.InMemoryPropertiesRepository
 import com.normation.rudder.tenants.QueryContext
 import com.normation.zio.UnsafeRun
@@ -50,7 +51,8 @@ import zio.Chunk
 class PropertiesRepositoryTest extends Specification {
   sequential
 
-  private val mockNodes    = new MockNodes()
+  private val mockTenants  = new MockTenants()
+  private val mockNodes    = new MockNodes(mockTenants)
   private val nodeFactRepo = mockNodes.nodeFactRepo
   private val repo         = InMemoryPropertiesRepository.make(nodeFactRepo).runNow
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
@@ -269,7 +269,8 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
       None
     )
   }
-  implicit val qc:                QueryContext  = QueryContext.todoQC
+
+  implicit val qc: QueryContext = QueryContext.systemQC
 
   "basic change in node fact" should {
     "saving core node fact must not kill software" in {
@@ -425,14 +426,16 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
     val ccA = ChangeContext
       .newForRudder()
       .modify(_.accessGrant)
-      .setTo(TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA"))))
+      .setTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")))))
 
     val qcNone = QueryContext.testQC.modify(_.accessGrant).setTo(TenantAccessGrant.None)
-    val qcA    = QueryContext.testQC.modify(_.accessGrant).setTo(TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA"))))
-    val qcB    = QueryContext.testQC.modify(_.accessGrant).setTo(TenantAccessGrant.ByTenants(Chunk(TenantId("zoneB"))))
+    val qcA    =
+      QueryContext.testQC.modify(_.accessGrant).setTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")))))
+    val qcB    =
+      QueryContext.testQC.modify(_.accessGrant).setTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneB")))))
     val qcAB   = QueryContext.testQC
       .modify(_.accessGrant)
-      .setTo(TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA"), TenantId("zoneB"))))
+      .setTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")), TenantAccess(TenantId("zoneB")))))
     val nodeId = NodeId("node0")
 
     "allow to filter all nodes with no access" in {
@@ -537,7 +540,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
         initTs  <- tenantRepository.tenantIds.getAndSet(Set())
         qc       = QueryContext.testQC
                      .modify(_.accessGrant)
-                     .setTo(TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA"), TenantId("zoneB"))))
+                     .setTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")), TenantAccess(TenantId("zoneB")))))
         refined <- tenantRepository.refineTenantAccessGrant(qc.accessGrant)
         nodes   <- factRepo.getAll()(using qc.copy(accessGrant = refined), SelectNodeStatus.Accepted)
         // restore tenants
@@ -704,7 +707,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
     "the count of active nodes changes if we disable one" >> {
       factStorage.clearCallStack
       val (n1, n2) = (for {
-        n1   <- factRepo.getNumberOfManagedNodes()
+        n1   <- factRepo.getNumberOfManagedNodes()(using QueryContext.testQC)
         node <- factRepo
                   .get(node7id)(using QueryContext.testQC, SelectNodeStatus.Accepted)
                   .notOptional("node7 must be here")
@@ -714,7 +717,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
                     .setTo(NodeState.Ignored)
 
         _  <- factRepo.save(updated)(using testChangeContext)
-        n2 <- factRepo.getNumberOfManagedNodes()
+        n2 <- factRepo.getNumberOfManagedNodes()(using QueryContext.testQC)
 
       } yield (n1, n2)).runNow
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -89,6 +89,7 @@ import com.normation.rudder.services.workflows.RuleChangeRequest
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.services.workflows.WorkflowService
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.normation.zio.*
 import java.io.File as JFile
 import java.io.InputStream
@@ -183,37 +184,53 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
   // Not used in test for now
   def readDirectives: RoDirectiveRepository = new RoDirectiveRepository {
 
-    def getFullDirectiveLibrary(): IOResult[FullActiveTechniqueCategory] = ???
+    def getFullDirectiveLibrary()(using qc: QueryContext): IOResult[FullActiveTechniqueCategory] = ???
 
-    def getDirective(directiveId: DirectiveUid): IOResult[Option[Directive]] = ???
+    def getDirective(directiveId: DirectiveUid)(using qc: QueryContext): IOResult[Option[Directive]] = ???
 
-    def getDirectiveWithContext(directiveId: DirectiveUid): IOResult[Option[(domain.Technique, ActiveTechnique, Directive)]] = ???
+    def getDirectiveWithContext(
+        directiveId: DirectiveUid
+    )(using qc: QueryContext): IOResult[Option[(domain.Technique, ActiveTechnique, Directive)]] = ???
 
-    def getActiveTechniqueAndDirective(id: DirectiveId): IOResult[Option[(ActiveTechnique, Directive)]] = ???
+    def getActiveTechniqueAndDirective(
+        id: DirectiveId
+    )(using qc: QueryContext): IOResult[Option[(ActiveTechnique, Directive)]] = ???
 
-    def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean): IOResult[Seq[Directive]] = ???
+    def getDirectives(activeTechniqueId: ActiveTechniqueId, includeSystem: Boolean)(using
+        qc: QueryContext
+    ): IOResult[Seq[Directive]] = ???
 
     def getActiveTechniqueByCategory(
         includeSystem: Boolean
-    ): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = ???
+    )(using qc: QueryContext): IOResult[SortedMap[List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques]] = ???
 
-    def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId): IOResult[Option[ActiveTechnique]] = ???
+    def getActiveTechniqueByActiveTechnique(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[Option[ActiveTechnique]] =
+      ???
 
-    def getActiveTechnique(techniqueName: TechniqueName): IOResult[Option[ActiveTechnique]] = ???
+    def getActiveTechnique(techniqueName: TechniqueName)(using qc: QueryContext): IOResult[Option[ActiveTechnique]] = ???
 
-    def activeTechniqueBreadCrump(id: ActiveTechniqueId): IOResult[List[ActiveTechniqueCategory]] = ???
+    def activeTechniqueBreadCrump(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = ???
 
-    def getActiveTechniqueLibrary: IOResult[ActiveTechniqueCategory] = ???
+    def getActiveTechniqueLibrary(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = ???
 
-    def getAllActiveTechniqueCategories(includeSystem: Boolean): IOResult[Seq[ActiveTechniqueCategory]] = ???
+    def getAllActiveTechniqueCategories(includeSystem: Boolean)(using
+        qc: QueryContext
+    ): IOResult[Seq[ActiveTechniqueCategory]] = ???
 
-    def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[Option[ActiveTechniqueCategory]] = ???
+    def getActiveTechniqueCategory(
+        id: ActiveTechniqueCategoryId
+    )(using qc: QueryContext): IOResult[Option[ActiveTechniqueCategory]] = ???
 
-    def getParentActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[ActiveTechniqueCategory] = ???
+    def getParentActiveTechniqueCategory(id: ActiveTechniqueCategoryId)(using
+        qc: QueryContext
+    ): IOResult[ActiveTechniqueCategory] =
+      ???
 
-    def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[List[ActiveTechniqueCategory]] = ???
+    def getParentsForActiveTechniqueCategory(
+        id: ActiveTechniqueCategoryId
+    )(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = ???
 
-    def getParentsForActiveTechnique(id: ActiveTechniqueId): IOResult[ActiveTechniqueCategory] = ???
+    def getParentsForActiveTechnique(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = ???
 
     def containsDirective(id: ActiveTechniqueCategoryId): UIO[Boolean] = ???
   }
@@ -221,24 +238,15 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
   def writeDirectives: WoDirectiveRepository = new WoDirectiveRepository {
     def saveDirective(
         inActiveTechniqueId: ActiveTechniqueId,
-        directive:           Directive,
-        modId:               ModificationId,
-        actor:               EventActor,
-        reason:              Option[String]
-    ): IOResult[Option[DirectiveSaveDiff]] = ???
+        directive:           Directive
+    )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = ???
     def saveSystemDirective(
         inActiveTechniqueId: ActiveTechniqueId,
-        directive:           Directive,
-        modId:               ModificationId,
-        actor:               EventActor,
-        reason:              Option[String]
-    ): IOResult[Option[DirectiveSaveDiff]] = ???
+        directive:           Directive
+    )(using cc: ChangeContext): IOResult[Option[DirectiveSaveDiff]] = ???
     def delete(
-        id:     DirectiveUid,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[DeleteDirectiveDiff]] = ???
+        id: DirectiveUid
+    )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = ???
     def addTechniqueInUserLibrary(
         categoryId:    ActiveTechniqueCategoryId,
         techniqueName: TechniqueName,
@@ -258,11 +266,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         datetimes: Map[TechniqueVersion, Instant]
     )(implicit cc: ChangeContext): IOResult[ActiveTechniqueId] = ???
     def deleteActiveTechnique(
-        id:     ActiveTechniqueId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[ActiveTechniqueId] = ???
+        id: ActiveTechniqueId
+    )(using cc: ChangeContext): IOResult[ActiveTechniqueId] = ???
     def addActiveTechniqueCategory(
         that: ActiveTechniqueCategory,
         into: ActiveTechniqueCategoryId
@@ -280,11 +285,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         optionNewName: Option[ActiveTechniqueCategoryId]
     )(implicit cc: ChangeContext): IOResult[ActiveTechniqueCategoryId] = ???
     override def deleteSystemDirective(
-        id:     DirectiveUid,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[DeleteDirectiveDiff]] = ???
+        id: DirectiveUid
+    )(using cc: ChangeContext): IOResult[Option[DeleteDirectiveDiff]] = ???
   }
 
   def workflowLevelService: WorkflowLevelService = new WorkflowLevelService {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/BasicLdapPersistenceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/BasicLdapPersistenceTest.scala
@@ -93,7 +93,7 @@ class BasicLdapPersistenceTest extends Specification with SetupLdapRepositories 
   "reading a group category with a tenant should correctly deserialize it" >> {
 
     val catId    = NodeGroupCategoryId("category1")
-    val res      = roGroupRepo.getGroupCategory(catId).runNow
+    val res      = roGroupRepo.getGroupCategory(catId)(using QueryContext.todoQC).runNow
     val expected = {
       NodeGroupCategory(
         catId,
@@ -112,7 +112,7 @@ class BasicLdapPersistenceTest extends Specification with SetupLdapRepositories 
   "reading an active technique with a tenant should correctly deserialize it" >> {
 
     val tech     = TechniqueName("user_defined_tech1")
-    val res      = roDirectiveRepo.getActiveTechnique(tech).runNow
+    val res      = roDirectiveRepo.getActiveTechnique(tech)(using QueryContext.systemQC).runNow
     val expected = ActiveTechnique(
       ActiveTechniqueId(tech.value),
       tech,
@@ -129,7 +129,7 @@ class BasicLdapPersistenceTest extends Specification with SetupLdapRepositories 
 
     val did = DirectiveUid("ce8aec6f-d371-4047-96d1-6b69ccdef9ae")
 
-    val res      = roDirectiveRepo.getDirective(did).runNow
+    val res      = roDirectiveRepo.getDirective(did)(using QueryContext.systemQC).runNow
     val expected = Directive(
       DirectiveId(did),
       TechniqueVersion.V1_0,
@@ -152,7 +152,7 @@ class BasicLdapPersistenceTest extends Specification with SetupLdapRepositories 
     val did    = DirectiveId(DirectiveUid("ce8aec6f-d371-4047-96d1-6b69ccdef9ae"))
     val ruleId = RuleId((RuleUid("34323555-6b6b-4d07-b3bd-043df1239797")))
 
-    val res      = roRuleRepo.get(ruleId).runNow
+    val res      = roRuleRepo.get(ruleId)(using QueryContext.systemQC).runNow
     val expected = Rule(
       ruleId,
       "User rule",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
@@ -241,6 +241,48 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
       )).runNow._1.security must beEqualTo(zoneA.accessGrant.toSecurityTag)
     }
   }
+  // A system object is admin-only to change, uniformly, *in addition to* tenant scoping: even a tenant
+  // user who can see and (tenant-wise) write a system object must be refused, because system objects are
+  // shared/global and a change can affect other tenants.
+  "[Groups] The system-object admin-only guard" should {
+    val sysGroupId = NodeGroupId(NodeGroupUid("system-zoneA-group"))
+    def sysGroup(desc: String): NodeGroup = {
+      NodeGroup(
+        sysGroupId,
+        "system-zoneA-group",
+        desc,
+        Nil,
+        None,
+        isDynamic = false,
+        serverList = Set(),
+        _isEnabled = true,
+        isSystem = true,
+        security = Some(SecurityTag.ByTenants(Chunk(TenantId("zoneA"))))
+      )
+    }
+
+    "let an admin (grant '*') create a system group tagged with a tenant" in {
+      given cc: ChangeContext = ChangeContext.newForRudder()
+      (tenantRepo.setTenantEnabled(true) *> woGroupRepo.create(sysGroup("v1"), rootCat)).either.runNow must beRight
+    }
+    "confirm the zoneA user can actually see that system group (so the block below is the system guard, not tenant scoping)" in {
+      given qc: QueryContext = zoneA
+      roGroupRepo.getNodeGroupOpt(sysGroupId).runNow.map(_._1.id) must beSome(sysGroupId)
+    }
+    "refuse a tenant user (who can see it) from updating that system group" in {
+      given cc: ChangeContext = zoneA.newCC()
+      woGroupRepo.updateSystemGroup(sysGroup("v2-by-zoneA")).either.runNow must beLeft
+    }
+    "refuse a tenant user from deleting that system group" in {
+      given cc: ChangeContext = zoneA.newCC()
+      woGroupRepo.delete(sysGroupId).either.runNow must beLeft
+    }
+    "still let an admin update that system group" in {
+      given cc: ChangeContext = ChangeContext.newForRudder()
+      woGroupRepo.updateSystemGroup(sysGroup("v3-by-admin")).either.runNow must beRight
+    }
+  }
+
   "[Groups] Updating a group" should {
     "doesn't change the tag if the plugin is disabled" in {
       given cc: ChangeContext = ChangeContext.newForRudder()

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
@@ -270,8 +270,26 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
       )
     }
 
-    "allow tenant update if the plugin is enabled and user has correct rights" in {
+    // only admin can update the tenant list: a non-admin user's tenant change is ignored and the
+    // existing tenants are kept (this runs while groupWithTenantId is still in zoneA).
+    "ignore a non-admin user's attempt to change the tenant list (keep existing tenants)" in {
       given cc: ChangeContext = zoneABC.newCC()
+      given qc: QueryContext  = cc.toQC
+
+      // groupWithTenantId is in zoneA
+      val res = for {
+        _ <- tenantRepo.setTenantEnabled(true)
+        g <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)
+        h  = g.copy(security = zoneB.accessGrant.toSecurityTag)
+        _ <- woGroupRepo.update(h)
+        i <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)
+      } yield i.security
+
+      res.runNow must beEqualTo(zoneA.accessGrant.toSecurityTag)
+    }
+
+    "allow an admin (grant '*') to update the tenant list" in {
+      given cc: ChangeContext = ChangeContext.newForRudder()
       given qc: QueryContext  = cc.toQC
 
       // groupWithTenantId is in zoneA
@@ -286,11 +304,11 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
       res.runNow must beEqualTo(zoneB.accessGrant.toSecurityTag)
     }
   }
-  "get an error if the destination tenant ID does not exist" in {
-    given cc: ChangeContext = zoneABC.newCC()
+  // only admin can change the tenant list, so the "tenant does not exist" check is for an admin
+  "get an error if an admin updates to a destination tenant ID that does not exist" in {
+    given cc: ChangeContext = ChangeContext.newForRudder()
     given qc: QueryContext  = cc.toQC
 
-    // groupWithTenantId is in zoneA
     val res = for {
       _ <- tenantRepo.setTenantEnabled(true)
       g <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
@@ -37,16 +37,28 @@
 
 package com.normation.rudder.repository.ldap
 
+import com.normation.GitVersion
 import com.normation.eventlog.EventActor
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.ActiveTechniqueCategory
+import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
+import com.normation.rudder.domain.policies.DirectiveUid
+import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.domain.properties.Visibility
+import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
+import com.normation.rudder.tenants.TenantAccess
 import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.rudder.tenants.TenantId
+import com.normation.rudder.tenants.TenantPermission
 import com.normation.zio.*
 import org.junit.runner.*
 import org.specs2.mutable.*
@@ -64,12 +76,19 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
     .asInstanceOf[ch.qos.logback.classic.Logger]
     .setLevel(ch.qos.logback.classic.Level.DEBUG)
 
-  val zoneA   = QueryContext(EventActor("zoneA user"), TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA"))))
-  val zoneB   = QueryContext(EventActor("zoneB user"), TenantAccessGrant.ByTenants(Chunk(TenantId("zoneB"))))
-  val zoneC   = QueryContext(EventActor("zoneC user"), TenantAccessGrant.ByTenants(Chunk(TenantId("zoneC"))))
+  val zoneA   = QueryContext(EventActor("zoneA user"), TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")))))
+  val zoneB   = QueryContext(EventActor("zoneB user"), TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneB")))))
+  val zoneC   = QueryContext(EventActor("zoneC user"), TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneC")))))
+  // a user with read-only access on zoneA: it can read zoneA objects but not write them
+  val zoneAro = QueryContext(
+    EventActor("zoneA read-only user"),
+    TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA"), TenantPermission.Read)))
+  )
   val zoneABC = QueryContext(
     EventActor("zoneA+B+C user"),
-    TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA"), TenantId("zoneB"), TenantId("zoneC")))
+    TenantAccessGrant.ByTenants(
+      Chunk(TenantAccess(TenantId("zoneA")), TenantAccess(TenantId("zoneB")), TenantAccess(TenantId("zoneC")))
+    )
   )
 
   val groupWithTenantId = NodeGroupId(NodeGroupUid("test-group-node1"))
@@ -96,10 +115,99 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
     val targetWithTenantsA  = Set("group:test-group-node1")
 
     "have an admin with tenant=* able to see everything" in {
-      implicit val qc = QueryContext.systemQC
+      given qc: QueryContext = QueryContext.systemQC
       roGroupRepo.getFullGroupLibrary().runNow.allTargets.values.map(_.debugId) must containTheSameElementsAs(
         targetWithNoTenants.toList ++ targetWithTenantsA
       )
+    }
+  }
+
+  // read-time filtering on the other read APIs (filtering depends only on the access grant,
+  // not on the plugin status, so these are independent of the tenant feature being enabled)
+  "[Groups] Reading groups" should {
+    "have admin (tenant=*) see the zoneA group in getAll" in {
+      given qc: QueryContext = QueryContext.systemQC
+      roGroupRepo.getAll().runNow.map(_.id).contains(groupWithTenantId) must beTrue
+    }
+    "have a zoneA user see the zoneA group in getAll" in {
+      given qc: QueryContext = zoneA
+      roGroupRepo.getAll().runNow.map(_.id).contains(groupWithTenantId) must beTrue
+    }
+    "have a zoneB user NOT see the zoneA group in getAll" in {
+      given qc: QueryContext = zoneB
+      roGroupRepo.getAll().runNow.map(_.id).contains(groupWithTenantId) must beFalse
+    }
+    "have a zoneA user see the zoneA group as a single read (getNodeGroupOpt)" in {
+      given qc: QueryContext = zoneA
+      roGroupRepo.getNodeGroupOpt(groupWithTenantId).runNow.map(_._1.id) must beSome(groupWithTenantId)
+    }
+    "have a zoneB user NOT see the zoneA group as a single read (getNodeGroupOpt)" in {
+      given qc: QueryContext = zoneB
+      roGroupRepo.getNodeGroupOpt(groupWithTenantId).runNow must beNone
+    }
+    "have a zoneA user see the zoneA group in getAllNodeIds" in {
+      given qc: QueryContext = zoneA
+      roGroupRepo.getAllNodeIds().runNow.keySet.contains(groupWithTenantId) must beTrue
+    }
+    "have a zoneB user NOT see the zoneA group in getAllNodeIds" in {
+      given qc: QueryContext = zoneB
+      roGroupRepo.getAllNodeIds().runNow.keySet.contains(groupWithTenantId) must beFalse
+    }
+    "have a zoneB user NOT see the zoneA group in findGroupWithAnyMember" in {
+      given qc: QueryContext = zoneB
+      // the zoneA group's members, if any, must not leak to a zoneB user
+      val membersOfZoneA =
+        roGroupRepo.getNodeGroupOpt(groupWithTenantId)(using QueryContext.systemQC).runNow.map(_._1.serverList).getOrElse(Set())
+      roGroupRepo.findGroupWithAnyMember(membersOfZoneA.toSeq).runNow.contains(groupWithTenantId) must beFalse
+    }
+  }
+
+  // write operations on a group must be refused for a user that can't see it, whatever the plugin status
+  "[Groups] Writing a group a user can't see" should {
+    "refuse to delete it" in {
+      given cc: ChangeContext = zoneB.newCC()
+      woGroupRepo.delete(groupWithTenantId).either.runNow must beLeft
+    }
+    "refuse to move it" in {
+      given cc: ChangeContext = zoneB.newCC()
+      woGroupRepo.move(groupWithTenantId, rootCat).either.runNow must beLeft
+    }
+    "refuse to update its node list" in {
+      given cc: ChangeContext = zoneB.newCC()
+      woGroupRepo.updateDiffNodes(groupWithTenantId, Nil, Nil).either.runNow must beLeft
+    }
+    "still be visible to admin afterwards (it was not modified)" in {
+      given qc: QueryContext = QueryContext.systemQC
+      roGroupRepo.getNodeGroupOpt(groupWithTenantId).runNow.map(_._1.id) must beSome(groupWithTenantId)
+    }
+  }
+
+  // a `r` (read-only) tenant access grants read but not write on that tenant's objects
+  "[Groups] A read-only (r) tenant access" should {
+    "allow to read the tenant's group (getNodeGroupOpt)" in {
+      given qc: QueryContext = zoneAro
+      roGroupRepo.getNodeGroupOpt(groupWithTenantId).runNow.map(_._1.id) must beSome(groupWithTenantId)
+    }
+    "allow to read the tenant's group (getAll)" in {
+      given qc: QueryContext = zoneAro
+      roGroupRepo.getAll().runNow.map(_.id).contains(groupWithTenantId) must beTrue
+    }
+    "refuse to delete the tenant's group" in {
+      given cc: ChangeContext = zoneAro.newCC()
+      woGroupRepo.delete(groupWithTenantId).either.runNow must beLeft
+    }
+    "refuse to move the tenant's group" in {
+      given cc: ChangeContext = zoneAro.newCC()
+      woGroupRepo.move(groupWithTenantId, rootCat).either.runNow must beLeft
+    }
+    "refuse to update the tenant's group node list" in {
+      given cc: ChangeContext = zoneAro.newCC()
+      woGroupRepo.updateDiffNodes(groupWithTenantId, Nil, Nil).either.runNow must beLeft
+    }
+    "refuse to create a group (no writable tenant)" in {
+      given cc: ChangeContext = zoneAro.newCC()
+      val group = newGroup("group-created-by-readonly", None)
+      woGroupRepo.create(group, rootCat).either.runNow must beLeft
     }
   }
 
@@ -108,20 +216,24 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
 
   "[Groups] Creating a group" should {
     "put no security tag if it's a Grant '*', even if plugin disabled" in {
-      implicit val cc = ChangeContext.newForRudder()
-      val group       = newGroup("grantAll-feature-disabled", None)
-      (woGroupRepo.create(group, rootCat) *> roGroupRepo.getNodeGroup(group.id)(using cc.toQC)).runNow._1.security must beNone
+      given cc: ChangeContext = ChangeContext.newForRudder()
+      given qc: QueryContext  = cc.toQC
+
+      val group = newGroup("grantAll-feature-disabled", None)
+      (woGroupRepo.create(group, rootCat) *> roGroupRepo.getNodeGroup(group.id)).runNow._1.security must beNone
     }
     "lead to an error if the user has a tenant and the plugin is disabled" in {
-      implicit val cc = zoneA.newCC()
-      val group       = newGroup("grantZoneA-feature-disabled", None)
-      (woGroupRepo.create(group, rootCat) *> roGroupRepo.getNodeGroup(group.id)(using cc.toQC)).either.runNow.left
+      given cc: ChangeContext = zoneA.newCC()
+      given qc: QueryContext  = cc.toQC
+
+      val group = newGroup("grantZoneA-feature-disabled", None)
+      (woGroupRepo.create(group, rootCat) *> roGroupRepo.getNodeGroup(group.id)).either.runNow.left
         .map(_.msg) must beLeft(
         beEqualTo("Object 'grantZoneA-feature-disabled' [*] can't be modified by 'zoneA user' (perm:tags:[zoneA])")
       )
     }
     "automatically get the correct tenant when the plugin is enabled" in {
-      implicit val cc = zoneA.newCC()
+      given cc: ChangeContext = zoneA.newCC()
 
       val group = newGroup("grantZoneA-feature-enabled", None)
       (tenantRepo.setTenantEnabled(true) *> woGroupRepo.create(group, rootCat) *> roGroupRepo.getNodeGroup(group.id)(using
@@ -131,22 +243,23 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
   }
   "[Groups] Updating a group" should {
     "doesn't change the tag if the plugin is disabled" in {
-      implicit val cc = ChangeContext.newForRudder()
+      given cc: ChangeContext = ChangeContext.newForRudder()
+      given qc: QueryContext  = cc.toQC
 
       val res = for {
         _ <- tenantRepo.setTenantEnabled(false)
-        g <- roGroupRepo.getNodeGroup(groupWithTenantId)(using cc.toQC).map(_._1)
+        g <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)
         h  = g.copy(security = None)
         _ <- woGroupRepo.update(h)
-        i <- roGroupRepo.getNodeGroup(groupWithTenantId)(using cc.toQC).map(_._1)
+        i <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)
       } yield i.security
 
       res.runNow must beEqualTo(zoneA.accessGrant.toSecurityTag)
     }
 
     "lead to an error if the user has a tenant and the plugin is disabled" in {
-      implicit val cc = zoneA.newCC()
-      val group       = newGroup(groupWithTenantId.uid.value, None)
+      given cc: ChangeContext = zoneA.newCC()
+      val group = newGroup(groupWithTenantId.uid.value, None)
       woGroupRepo
         .update(group)
         .either
@@ -157,28 +270,30 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
       )
     }
 
-    "allow tenant update if the plugin is enabled and user as correct rights" in {
-      implicit val cc = zoneABC.newCC()
+    "allow tenant update if the plugin is enabled and user has correct rights" in {
+      given cc: ChangeContext = zoneABC.newCC()
+      given qc: QueryContext  = cc.toQC
 
       // groupWithTenantId is in zoneA
       val res = for {
         _ <- tenantRepo.setTenantEnabled(true)
-        g <- roGroupRepo.getNodeGroup(groupWithTenantId)(using cc.toQC).map(_._1)
+        g <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)
         h  = g.copy(security = zoneB.accessGrant.toSecurityTag)
         _ <- woGroupRepo.update(h)
-        i <- roGroupRepo.getNodeGroup(groupWithTenantId)(using cc.toQC).map(_._1)
+        i <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)
       } yield i.security
 
       res.runNow must beEqualTo(zoneB.accessGrant.toSecurityTag)
     }
   }
   "get an error if the destination tenant ID does not exist" in {
-    implicit val cc = zoneABC.newCC()
+    given cc: ChangeContext = zoneABC.newCC()
+    given qc: QueryContext  = cc.toQC
 
     // groupWithTenantId is in zoneA
     val res = for {
       _ <- tenantRepo.setTenantEnabled(true)
-      g <- roGroupRepo.getNodeGroup(groupWithTenantId)(using cc.toQC).map(_._1)
+      g <- roGroupRepo.getNodeGroup(groupWithTenantId).map(_._1)
       h  = g.copy(security = zoneC.accessGrant.toSecurityTag)
       _ <- woGroupRepo.update(h)
     } yield ()
@@ -186,5 +301,193 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
     res.either.runNow.left.map(_.msg) must beLeft(
       beEqualTo("Object 'test-group-node1' security tag's tenant can not be updated to 'zoneC' because it does not exist")
     )
+  }
+
+  // in the test technique library, the active technique `user_defined_tech1` and its directive
+  // `ce8aec6f-...` (and the parent category `ncf_techniques`) are tagged with tenant `zoneA`.
+  val directiveWithTenantA = DirectiveUid("ce8aec6f-d371-4047-96d1-6b69ccdef9ae")
+  val atRootCat            = ActiveTechniqueCategoryId("Active Techniques")
+
+  "[Directives] Reading the full directive library" should {
+    "let an admin (tenant=*) see the zoneA active technique and directive" in {
+      given qc: QueryContext = QueryContext.systemQC
+      val lib = roDirectiveRepo.getFullDirectiveLibrary().runNow
+      (lib.allActiveTechniques.keySet.map(_.value).contains("user_defined_tech1") must beTrue) and
+      (lib.allDirectives.keySet.map(_.uid.value).contains(directiveWithTenantA.value) must beTrue)
+    }
+    "let a zoneA user see the zoneA active technique and directive" in {
+      given qc: QueryContext = zoneA
+      val lib = roDirectiveRepo.getFullDirectiveLibrary().runNow
+      (lib.allActiveTechniques.keySet.map(_.value).contains("user_defined_tech1") must beTrue) and
+      (lib.allDirectives.keySet.map(_.uid.value).contains(directiveWithTenantA.value) must beTrue)
+    }
+    "hide the zoneA active technique and directive from a zoneB user" in {
+      given qc: QueryContext = zoneB
+      val lib = roDirectiveRepo.getFullDirectiveLibrary().runNow
+      (lib.allActiveTechniques.keySet.map(_.value).contains("user_defined_tech1") must beFalse) and
+      (lib.allDirectives.keySet.map(_.uid.value).contains(directiveWithTenantA.value) must beFalse)
+    }
+  }
+
+  "[Directives] Reading a single directive" should {
+    "be visible to a zoneA user" in {
+      given qc: QueryContext = zoneA
+      roDirectiveRepo.getDirective(directiveWithTenantA).runNow.map(_.id.uid.value) must beSome(directiveWithTenantA.value)
+    }
+    "be hidden from a zoneB user" in {
+      given qc: QueryContext = zoneB
+      roDirectiveRepo.getDirective(directiveWithTenantA).runNow must beNone
+    }
+  }
+
+  "[Directives] Deleting a directive" should {
+    "be refused for a user who can not see it" in {
+      given cc: ChangeContext = zoneB.newCC()
+      woDirectiveRepo.delete(directiveWithTenantA).either.runNow.left.map(_.msg) must beLeft(
+        beEqualTo(s"Object '${directiveWithTenantA.value}' can't be deleted by zoneB user")
+      )
+    }
+  }
+
+  def newActiveTechniqueCategory(id: String, tenant: Option[SecurityTag]): ActiveTechniqueCategory =
+    ActiveTechniqueCategory(ActiveTechniqueCategoryId(id), id, id, Nil, Nil, isSystem = false, security = tenant)
+
+  "[ActiveTechniqueCategories] Creating a category" should {
+    "lead to an error if the user has a tenant and the plugin is disabled" in {
+      given cc: ChangeContext = zoneA.newCC()
+      val cat = newActiveTechniqueCategory("cat-zoneA-feature-disabled", None)
+      (tenantRepo.setTenantEnabled(false) *> woDirectiveRepo.addActiveTechniqueCategory(cat, atRootCat)).either.runNow.left
+        .map(_.msg) must beLeft(
+        beEqualTo("Object 'cat-zoneA-feature-disabled' [*] can't be modified by 'zoneA user' (perm:tags:[zoneA])")
+      )
+    }
+    "automatically get the correct tenant when the plugin is enabled" in {
+      given cc: ChangeContext = zoneA.newCC()
+      val cat = newActiveTechniqueCategory("cat-zoneA-feature-enabled", None)
+      (tenantRepo.setTenantEnabled(true) *>
+      woDirectiveRepo.addActiveTechniqueCategory(cat, atRootCat) *>
+      roDirectiveRepo.getActiveTechniqueCategory(cat.id)(using QueryContext.systemQC)).runNow
+        .flatMap(_.security) must beEqualTo(zoneA.accessGrant.toSecurityTag)
+    }
+  }
+
+  // in the test data, the rule `34323555-...` is tagged with tenant `zoneA`.
+  val ruleWithTenantA = RuleId(RuleUid("34323555-6b6b-4d07-b3bd-043df1239797"))
+
+  "[Rules] Reading all rules" should {
+    "let an admin (tenant=*) see the zoneA rule" in {
+      given qc: QueryContext = QueryContext.systemQC
+      roRuleRepo.getAll().runNow.map(_.id.serialize).contains(ruleWithTenantA.serialize) must beTrue
+    }
+    "let a zoneA user see the zoneA rule" in {
+      given qc: QueryContext = zoneA
+      roRuleRepo.getAll().runNow.map(_.id.serialize).contains(ruleWithTenantA.serialize) must beTrue
+    }
+    "hide the zoneA rule from a zoneB user" in {
+      given qc: QueryContext = zoneB
+      roRuleRepo.getAll().runNow.map(_.id.serialize).contains(ruleWithTenantA.serialize) must beFalse
+    }
+  }
+
+  "[Rules] Reading a single rule" should {
+    "be visible to a zoneA user" in {
+      given qc: QueryContext = zoneA
+      roRuleRepo.getOpt(ruleWithTenantA).runNow.map(_.id.serialize) must beSome(ruleWithTenantA.serialize)
+    }
+    "be hidden from a zoneB user" in {
+      given qc: QueryContext = zoneB
+      roRuleRepo.getOpt(ruleWithTenantA).runNow must beNone
+    }
+  }
+
+  "[Rules] Deleting a rule" should {
+    "be refused for a user who can not see it" in {
+      given cc: ChangeContext = zoneB.newCC()
+      woRuleRepo.delete(ruleWithTenantA).either.runNow.left.map(_.msg) must beLeft(
+        beEqualTo(s"Object '${ruleWithTenantA.serialize}' can't be deleted by zoneB user")
+      )
+    }
+  }
+
+  def newRule(id: String, tenant: Option[SecurityTag]): Rule =
+    Rule(RuleId(RuleUid(id)), id, RuleCategoryId("rootRuleCategory"), security = tenant)
+
+  "[Rules] Creating a rule" should {
+    "lead to an error if the user has a tenant and the plugin is disabled" in {
+      given cc: ChangeContext = zoneA.newCC()
+      val rule = newRule("rule-zoneA-feature-disabled", None)
+      (tenantRepo.setTenantEnabled(false) *> woRuleRepo.create(rule)).either.runNow.left.map(_.msg) must beLeft(
+        beEqualTo("Object 'rule-zoneA-feature-disabled' [*] can't be modified by 'zoneA user' (perm:tags:[zoneA])")
+      )
+    }
+    "automatically get the correct tenant when the plugin is enabled" in {
+      given cc: ChangeContext = zoneA.newCC()
+      val rule = newRule("rule-zoneA-feature-enabled", None)
+      (tenantRepo.setTenantEnabled(true) *> woRuleRepo.create(rule) *>
+      roRuleRepo.getOpt(rule.id)(using QueryContext.systemQC)).runNow
+        .flatMap(_.security) must beEqualTo(zoneA.accessGrant.toSecurityTag)
+    }
+  }
+
+  // in the test data, the global parameter `param-zoneA` is tagged with tenant `zoneA`.
+  val parameterWithTenantA = "param-zoneA"
+
+  "[Parameters] Reading all parameters" should {
+    "let an admin (tenant=*) see the zoneA parameter" in {
+      given qc: QueryContext = QueryContext.systemQC
+      roGlobalPropertyRepo.getAllGlobalParameters().runNow.map(_.name).contains(parameterWithTenantA) must beTrue
+    }
+    "let a zoneA user see the zoneA parameter" in {
+      given qc: QueryContext = zoneA
+      roGlobalPropertyRepo.getAllGlobalParameters().runNow.map(_.name).contains(parameterWithTenantA) must beTrue
+    }
+    "hide the zoneA parameter from a zoneB user" in {
+      given qc: QueryContext = zoneB
+      roGlobalPropertyRepo.getAllGlobalParameters().runNow.map(_.name).contains(parameterWithTenantA) must beFalse
+    }
+  }
+
+  "[Parameters] Reading a single parameter" should {
+    "be visible to a zoneA user" in {
+      given qc: QueryContext = zoneA
+      roGlobalPropertyRepo.getGlobalParameter(parameterWithTenantA).runNow.map(_.name) must beSome(parameterWithTenantA)
+    }
+    "be hidden from a zoneB user" in {
+      given qc: QueryContext = zoneB
+      roGlobalPropertyRepo.getGlobalParameter(parameterWithTenantA).runNow must beNone
+    }
+  }
+
+  "[Parameters] Deleting a parameter" should {
+    "be refused for a user who can not see it" in {
+      given cc: ChangeContext = zoneB.newCC()
+      woGlobalPropertyRepo.delete(parameterWithTenantA, None).either.runNow.left.map(_.msg) must beLeft(
+        beEqualTo(s"Object '$parameterWithTenantA' can't be deleted by zoneB user")
+      )
+    }
+  }
+
+  def newParameter(name: String, tenant: Option[SecurityTag]): GlobalParameter = {
+    GlobalParameter
+      .parse(name, GitVersion.DEFAULT_REV, "\"" + name + "\"", None, "", None, Visibility.default, tenant)
+      .getOrElse(throw new RuntimeException(s"Error in test: can not build parameter '$name'"))
+  }
+
+  "[Parameters] Creating a parameter" should {
+    "lead to an error if the user has a tenant and the plugin is disabled" in {
+      given cc: ChangeContext = zoneA.newCC()
+      val param = newParameter("param-zoneA-feature-disabled", None)
+      (tenantRepo.setTenantEnabled(false) *> woGlobalPropertyRepo.saveParameter(param)).either.runNow.left
+        .map(_.msg) must beLeft(
+        beEqualTo("Object 'param-zoneA-feature-disabled' [*] can't be modified by 'zoneA user' (perm:tags:[zoneA])")
+      )
+    }
+    "automatically get the correct tenant when the plugin is enabled" in {
+      given cc: ChangeContext = zoneA.newCC()
+      val param = newParameter("param-zoneA-feature-enabled", None)
+      (tenantRepo.setTenantEnabled(true) *> woGlobalPropertyRepo.saveParameter(param) *>
+      roGlobalPropertyRepo.getGlobalParameter(param.name)(using QueryContext.systemQC)).runNow
+        .flatMap(_.security) must beEqualTo(zoneA.accessGrant.toSecurityTag)
+    }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/SetupLdapRepositories.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/SetupLdapRepositories.scala
@@ -200,72 +200,97 @@ trait SetupLdapRepositories {
 
   lazy val personIdent = new TrivialPersonIdentService
 
-  lazy val roGroupRepo = {
-    new RoLDAPNodeGroupRepository(
-      rudderDit,
-      roLdap,
-      ldapMapper,
-      nodeFactRepo,
-      new ZioTReentrantLock("group-lock")
-    )
-  }
-
-  lazy val woGroupRepo = new WoLDAPNodeGroupRepository(
-    roGroupRepo,
-    rwLdap,
-    ldapDiffMapper,
-    eventLogRepo,
-    gitArchiver,
-    personIdent,
-    tenantService,
-    tenantRepo,
-    false
+  lazy val ldapRoGroupRepo = new RoLDAPNodeGroupRepository(
+    rudderDit,
+    roLdap,
+    ldapMapper,
+    nodeFactRepo,
+    new ZioTReentrantLock("group-lock")
   )
+
+  lazy val roGroupRepo: RoNodeGroupRepository = new RoTenantNodeGroupRepo(tenantService, ldapRoGroupRepo)
+
+  lazy val woGroupRepo: WoNodeGroupRepository = {
+    val ldapWo = new WoLDAPNodeGroupRepository(
+      ldapRoGroupRepo,
+      rwLdap,
+      ldapDiffMapper,
+      eventLogRepo,
+      gitArchiver,
+      personIdent,
+      false
+    )
+    new WoTenantNodeGroupRepo(tenantService, tenantRepo, ldapWo, ldapRoGroupRepo)
+  }
 
   val mockGitRepo = new MockGitConfigRepo("")
   val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
 
-  lazy val lockDirective   = new ZioTReentrantLock("directive-lock")
-  lazy val roDirectiveRepo = new RoLDAPDirectiveRepository(
+  lazy val lockDirective       = new ZioTReentrantLock("directive-lock")
+  lazy val ldapRoDirectiveRepo = new RoLDAPDirectiveRepository(
     rudderDit,
     roLdap,
     ldapMapper,
     mockTechniques.techniqueRepo,
     new ZioTReentrantLock("directive-lock")
   )
+  lazy val roDirectiveRepo: RoDirectiveRepository =
+    new RoTenantDirectiveRepo(tenantService, ldapRoDirectiveRepo)
 
-  lazy val woDirectiveRepo = new WoLDAPDirectiveRepository(
-    roDirectiveRepo,
-    rwLdap,
-    ldapDiffMapper,
-    eventLogRepo,
-    gitArchiver,
-    gitArchiver,
-    gitArchiver,
-    personIdent,
-    false
-  )
+  lazy val woDirectiveRepo: WoDirectiveRepository = {
+    val ldapWo = new WoLDAPDirectiveRepository(
+      ldapRoDirectiveRepo,
+      rwLdap,
+      ldapDiffMapper,
+      eventLogRepo,
+      gitArchiver,
+      gitArchiver,
+      gitArchiver,
+      personIdent,
+      false
+    )
+    new WoTenantDirectiveRepo(tenantService, tenantRepo, ldapWo, ldapRoDirectiveRepo)
+  }
 
-  lazy val lockRule   = new ZioTReentrantLock("rule-lock")
-  lazy val roRuleRepo = new RoLDAPRuleRepository(rudderDit, roLdap, ldapMapper, lockRule)
+  lazy val lockRule       = new ZioTReentrantLock("rule-lock")
+  lazy val ldapRoRuleRepo = new RoLDAPRuleRepository(rudderDit, roLdap, ldapMapper, lockRule)
+  lazy val roRuleRepo: RoRuleRepository = new RoTenantRuleRepo(tenantService, ldapRoRuleRepo)
+  lazy val woRuleRepo: WoRuleRepository = {
+    val ldapWo = new WoLDAPRuleRepository(
+      ldapRoRuleRepo,
+      rwLdap,
+      ldapDiffMapper,
+      roGroupRepo,
+      eventLogRepo,
+      gitArchiver,
+      personIdent,
+      false
+    )
+    new WoTenantRuleRepo(tenantService, tenantRepo, ldapWo, ldapRoRuleRepo)
+  }
 
-  lazy val lockProperty         = new ZioTReentrantLock("property-lock")
-  lazy val roGlobalPropertyRepo = new RoLDAPParameterRepository(
+  lazy val lockProperty       = new ZioTReentrantLock("property-lock")
+  lazy val ldapRoPropertyRepo = new RoLDAPParameterRepository(
     rudderDit,
     roLdap,
     ldapMapper,
     lockProperty
   )
+  lazy val roGlobalPropertyRepo: RoParameterRepository =
+    new RoTenantParameterRepo(tenantService, ldapRoPropertyRepo)
 
-  lazy val woGlobalPropertyRepo = new WoLDAPParameterRepository(
-    roGlobalPropertyRepo,
-    rwLdap,
-    ldapDiffMapper,
-    eventLogRepo,
-    gitArchiver,
-    personIdent,
-    false
-  )
+  lazy val woGlobalPropertyRepo: WoParameterRepository = {
+    val ldapWo = new WoLDAPParameterRepository(
+      ldapRoPropertyRepo,
+      rwLdap,
+      ldapDiffMapper,
+      eventLogRepo,
+      gitArchiver,
+      personIdent,
+      false
+    )
+    new WoTenantParameterRepo(tenantService, tenantRepo, ldapWo, ldapRoPropertyRepo)
+  }
 
   // event log
   lazy val eventLogRepo = new EventLogRepository {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/SetupLdapRepositories.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/SetupLdapRepositories.scala
@@ -100,7 +100,7 @@ import zio.syntax.*
 trait SetupLdapRepositories {
 
   lazy val bootstrapLDIFs: List[String] = {
-    ("ldap/bootstrap.ldif" :: "ldap-data/technique-library-data.ldif" :: "ldap-data/inventory-sample-data.ldif" :: Nil) map {
+    ("ldap/bootstrap.ldif" :: "ldap-data/technique-library-data.ldif" :: "ldap-data/inventory-sample-data.ldif" :: "ldap-data/rule-category-data.ldif" :: Nil) map {
       name =>
         // toURI is needed for https://issues.rudder.io/issues/19186
         this.getClass.getClassLoader.getResource(name).toURI.getPath
@@ -252,8 +252,16 @@ trait SetupLdapRepositories {
     new WoTenantDirectiveRepo(tenantService, tenantRepo, ldapWo, ldapRoDirectiveRepo)
   }
 
-  lazy val lockRule       = new ZioTReentrantLock("rule-lock")
-  lazy val ldapRoRuleRepo = new RoLDAPRuleRepository(rudderDit, roLdap, ldapMapper, lockRule)
+  lazy val lockRule               = new ZioTReentrantLock("rule-lock")
+  lazy val ldapRoRuleRepo         = new RoLDAPRuleRepository(rudderDit, roLdap, ldapMapper, lockRule)
+  lazy val ldapRoRuleCategoryRepo = {
+    new com.normation.rudder.rule.category.RoLDAPRuleCategoryRepository(
+      rudderDit,
+      roLdap,
+      ldapMapper,
+      new ZioTReentrantLock("rule-cat-lock")
+    )
+  }
   lazy val roRuleRepo: RoRuleRepository = new RoTenantRuleRepo(tenantService, ldapRoRuleRepo)
   lazy val woRuleRepo: WoRuleRepository = {
     val ldapWo = new WoLDAPRuleRepository(
@@ -266,7 +274,7 @@ trait SetupLdapRepositories {
       personIdent,
       false
     )
-    new WoTenantRuleRepo(tenantService, tenantRepo, ldapWo, ldapRoRuleRepo)
+    new WoTenantRuleRepo(tenantService, tenantRepo, ldapWo, ldapRoRuleRepo, ldapRoRuleCategoryRepo)
   }
 
   lazy val lockProperty       = new ZioTReentrantLock("property-lock")

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/score/ScoreServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/score/ScoreServiceTest.scala
@@ -3,6 +3,7 @@ package com.normation.rudder.score
 import com.normation.errors.PureResult
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.MockNodes
+import com.normation.rudder.MockTenants
 import com.normation.rudder.score.ScoreValue.A
 import com.normation.rudder.score.ScoreValue.B
 import com.normation.rudder.score.ScoreValue.D
@@ -18,10 +19,11 @@ import zio.syntax.*
 
 class ScoreServiceTest extends Specification {
 
-  val mock    = new MockNodes()
-  import MockNodes.*
+  val mockTenants = new MockTenants()
+  val mock        = new MockNodes(mockTenants)
+  import com.normation.rudder.MockNodes.*
   import mock.*
-  val scoreId = "testScore"
+  val scoreId     = "testScore"
   case class TestScoreEvent(nodeId: NodeId) extends ScoreEvent
 
   object TestScoreEventHandler extends ScoreEventHandler {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -80,6 +80,7 @@ import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.rudder.services.servers.PolicyServers
 import com.normation.rudder.services.servers.PolicyServersUpdateCommand
 import com.normation.rudder.services.servers.RelaySynchronizationMethod.Classic
+import com.normation.rudder.tenants.SecurityTag
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
@@ -874,7 +875,7 @@ class TestNodeConfiguration(
     subCategories = List(),
     targetInfos = List(),
     isSystem = true,
-    security = None
+    security = Some(SecurityTag.Open) // root must be open
   )
 
   val groupLib: FullNodeGroupCategory = emptyGroupLib.copy(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTenantTest.scala
@@ -1,0 +1,187 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.rudder.services.policies
+
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.FullGroupTarget
+import com.normation.rudder.domain.policies.FullRuleTargetInfo
+import com.normation.rudder.domain.policies.GroupTarget
+import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.repository.FullNodeGroupCategory
+import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.services.nodes.PropertyEngineServiceImpl
+import com.normation.rudder.tenants.SecurityTag
+import com.normation.rudder.tenants.TenantId
+import org.junit.runner.*
+import org.specs2.mutable.*
+import org.specs2.runner.*
+import zio.Chunk
+
+/**
+ * Test that the tenant boundary is enforced when a rule is resolved to its targeted nodes at
+ * policy generation: a rule only ever reaches nodes (and simple targets) sharing one of its tenants.
+ */
+@RunWith(classOf[JUnitRunner])
+class RuleValServiceTenantTest extends Specification {
+
+  val ruleValService =
+    new RuleValServiceImpl(new InterpolatedValueCompilerImpl(new PropertyEngineServiceImpl(List.empty)))
+
+  // three nodes, one per tenant situation
+  val nA:     NodeId = NodeId("nA")     // tenant zoneA
+  val nB:     NodeId = NodeId("nB")     // tenant zoneB
+  val nAdmin: NodeId = NodeId("nAdmin") // no tenant (admin-only)
+
+  def tenants(ids: String*): Option[SecurityTag] = Some(SecurityTag.ByTenants(Chunk.fromIterable(ids.map(TenantId(_)))))
+
+  // all three nodes with their per-node info (none is a policy server) and tenant tag
+  val nodeInfos: Map[NodeId, NodeSecurityInfo] = Map(
+    nA     -> NodeSecurityInfo(isPolicyServer = false, tenants("zoneA")),
+    nB     -> NodeSecurityInfo(isPolicyServer = false, tenants("zoneB")),
+    nAdmin -> NodeSecurityInfo(isPolicyServer = false, None)
+  )
+
+  def mkGroup(id: String, security: Option[SecurityTag], nodes: Set[NodeId]): NodeGroup = {
+    NodeGroup(
+      NodeGroupId(NodeGroupUid(id)),
+      name = id,
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = nodes,
+      _isEnabled = true,
+      security = security
+    )
+  }
+
+  def mkGroupLib(groups: List[NodeGroup]): FullNodeGroupCategory = {
+    FullNodeGroupCategory(
+      NodeGroupCategoryId("root"),
+      name = "",
+      description = "",
+      subCategories = Nil,
+      targetInfos = groups.map(g => {
+        FullRuleTargetInfo(
+          FullGroupTarget(GroupTarget(g.id), g),
+          name = "",
+          description = "",
+          isEnabled = true,
+          isSystem = false,
+          security = g.security
+        )
+      }),
+      isSystem = false,
+      security = None
+    )
+  }
+
+  def mkRule(security: Option[SecurityTag], targets: Set[RuleTarget]): Rule = {
+    Rule(
+      RuleId(RuleUid("r")),
+      name = "r",
+      categoryId = RuleCategoryId("c"),
+      targets = targets,
+      directiveIds = Set(),
+      shortDescription = "",
+      longDescription = "",
+      isEnabledStatus = true,
+      isSystem = false,
+      security = security
+    )
+  }
+
+  // a group holding all three nodes, `Open` so the target-level filter never drops it: the point of these
+  // cases is the node-level filter.
+  val openGroup: NodeGroup             = mkGroup("all", Some(SecurityTag.Open), Set(nA, nB, nAdmin))
+  val libOpen:   FullNodeGroupCategory = mkGroupLib(List(openGroup))
+  val openTgt:   Set[RuleTarget]       = Set(GroupTarget(openGroup.id))
+
+  "node-level tenant filter" should {
+
+    "let an untagged (admin) rule reach every node" in {
+      ruleValService.getTargetedNodes(mkRule(None, openTgt), libOpen, nodeInfos) ===
+      Set(nA, nB, nAdmin)
+    }
+
+    "let an `Open` rule reach every node" in {
+      ruleValService.getTargetedNodes(mkRule(Some(SecurityTag.Open), openTgt), libOpen, nodeInfos) ===
+      Set(nA, nB, nAdmin)
+    }
+
+    "restrict a single-tenant rule to its own tenant's nodes" in {
+      ruleValService.getTargetedNodes(mkRule(tenants("zoneA"), openTgt), libOpen, nodeInfos) ===
+      Set(nA)
+    }
+
+    "let a multi-tenant rule reach all of its tenants' nodes but not admin-only nodes" in {
+      ruleValService.getTargetedNodes(mkRule(tenants("zoneA", "zoneB"), openTgt), libOpen, nodeInfos) ===
+      Set(nA, nB)
+    }
+
+    "reach nothing for a tenant the rule does not share with any node" in {
+      ruleValService.getTargetedNodes(mkRule(tenants("zoneC"), openTgt), libOpen, nodeInfos) ===
+      Set()
+    }
+  }
+
+  "target-level tenant filter" should {
+
+    // group is zoneB-only; a zoneA rule cannot even see the group, so the target is dropped entirely
+    val zoneBGroup = mkGroup("gB", tenants("zoneB"), Set(nA, nB, nAdmin))
+    val libB       = mkGroupLib(List(zoneBGroup))
+    val bTgt: Set[RuleTarget] = Set(GroupTarget(zoneBGroup.id))
+
+    "drop a group target the rule does not share a tenant with" in {
+      ruleValService.getTargetedNodes(mkRule(tenants("zoneA"), bTgt), libB, nodeInfos) ===
+      Set()
+    }
+
+    "keep a shared group target, then still node-filter its members" in {
+      // zoneB rule sees the zoneB group; among its members only the zoneB node survives the node filter
+      ruleValService.getTargetedNodes(mkRule(tenants("zoneB"), bTgt), libB, nodeInfos) ===
+      Set(nB)
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -212,7 +212,12 @@ class TestBuildNodeConfiguration extends Specification {
     val t1           = System.currentTimeMillis()
     val ruleVal      = {
       ruleValService
-        .buildRuleVal(rule, directiveLib, groupLib, allNodes.view.mapValues(_.rudderSettings.isPolicyServer).toMap)
+        .buildRuleVal(
+          rule,
+          directiveLib,
+          groupLib,
+          allNodes.view.mapValues(n => NodeSecurityInfo(n.rudderSettings.isPolicyServer, n.rudderSettings.security)).toMap
+        )
         .runNow
     }
     val ruleVals     = Seq(ruleVal)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -95,7 +95,8 @@ class TestNodeFactQueryProcessor {
       }).succeed
     }
 
-    override def getGroups: IOResult[Chunk[SubGroupChoice]] = Chunk.fromIterable(groups.keys).succeed
+    override def getGroups(using qc: QueryContext): IOResult[Chunk[SubGroupChoice]] =
+      Chunk.fromIterable(groups.keys).succeed
   }
   val instanceIdService = new InstanceIdService(InstanceId("test-instance-id"))
   val queryData = new NodeQueryCriteriaData(() => subGroupComparatorRepo, instanceIdService)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
@@ -42,6 +42,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.MockGlobalParam
 import com.normation.rudder.MockNodeGroups
 import com.normation.rudder.MockNodes
+import com.normation.rudder.MockTenants
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.reports.NodeComplianceExpiration
@@ -168,8 +169,9 @@ class ComplianceExpirationServiceTest extends Specification {
 
   "Find a property from the mock repos" >> {
     // for correct init of propRepo, we need param, node and group
-    val mockNodes         = new MockNodes
-    val mockGroup         = new MockNodeGroups(mockNodes, new MockGlobalParam)
+    val mockTenants       = new MockTenants()
+    val mockNodes         = new MockNodes(mockTenants)
+    val mockGroup         = new MockNodeGroups(mockNodes, new MockGlobalParam(mockTenants), mockTenants)
     val expirationService = new NodePropertyBasedComplianceExpirationService(
       mockNodes.propRepo,
       NodePropertyBasedComplianceExpirationService.PROP_NAME,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/TenantAccessGrantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/TenantAccessGrantTest.scala
@@ -1,0 +1,201 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.tenants
+
+import org.junit.runner.*
+import org.specs2.mutable.*
+import org.specs2.runner.*
+import zio.Chunk
+
+/*
+ * Test the serialization/parsing of `TenantAccess` / `TenantAccessGrant`, especially the
+ * backward compatibility with the previous `TenantId`-only serialization (a bare tenant id
+ * means `ReadWrite`), and the new read/write permission suffix (`:r`, `:rw`).
+ */
+@RunWith(classOf[JUnitRunner])
+class TenantAccessGrantTest extends Specification {
+
+  import TenantPermission.*
+
+  def access(id:    String, p: TenantPermission) = TenantAccess(TenantId(id), p)
+  def byTenants(ts: TenantAccess*) = TenantAccessGrant.ByTenants(Chunk.fromIterable(ts))
+
+  "TenantAccess serialization" should {
+    "serialize ReadWrite as a bare tenant id (backward compatible)" in {
+      access("zoneA", ReadWrite).serialize must beEqualTo("zoneA")
+    }
+    "serialize Read with the ':r' suffix" in {
+      access("zoneA", Read).serialize must beEqualTo("zoneA:r")
+    }
+    "parse a bare tenant id as ReadWrite (backward compatible)" in {
+      TenantAccess.parse("zoneA") must beSome(access("zoneA", ReadWrite))
+    }
+    "parse ':r' as Read and ':rw' as ReadWrite" in {
+      (TenantAccess.parse("zoneA:r") must beSome(access("zoneA", Read))) and
+      (TenantAccess.parse("zoneA:rw") must beSome(access("zoneA", ReadWrite)))
+    }
+    "refuse an invalid tenant id or permission token" in {
+      (TenantAccess.parse("zone A") must beNone) and
+      (TenantAccess.parse("zoneA:x") must beNone) and
+      (TenantAccess.parse("zoneA:") must beNone)
+    }
+    "round-trip serialize/parse" in {
+      Seq(access("zoneA", ReadWrite), access("zoneB", Read)).map(a => TenantAccess.parse(a.serialize)) must beEqualTo(
+        Seq(Some(access("zoneA", ReadWrite)), Some(access("zoneB", Read)))
+      )
+    }
+  }
+
+  "TenantAccessGrant parsing" should {
+    "parse '*' as All and '-' as None" in {
+      (TenantAccessGrant.parse(Some("*")) must beRight(TenantAccessGrant.All: TenantAccessGrant)) and
+      (TenantAccessGrant.parse(Some("-")) must beRight(TenantAccessGrant.None: TenantAccessGrant))
+    }
+    "parse a previously-serialized list of bare tenant ids as all-ReadWrite (backward compatible)" in {
+      TenantAccessGrant.parse(Some("zoneA,zoneB")) must beRight(
+        byTenants(access("zoneA", ReadWrite), access("zoneB", ReadWrite)): TenantAccessGrant
+      )
+    }
+    "parse a mix of read-only and read-write tenants" in {
+      TenantAccessGrant.parse(Some("zoneA,zoneB:r")) must beRight(
+        byTenants(access("zoneA", ReadWrite), access("zoneB", Read)): TenantAccessGrant
+      )
+    }
+    "serialize a grant back to the compact string form" in {
+      byTenants(access("zoneA", ReadWrite), access("zoneB", Read)).serialize must beEqualTo("zoneA,zoneB:r")
+    }
+    "be stable through serialize then parse" in {
+      val grant = byTenants(access("zoneA", ReadWrite), access("zoneB", Read), access("zoneC", ReadWrite))
+      TenantAccessGrant.parse(Some(grant.serialize)) must beRight(grant: TenantAccessGrant)
+    }
+  }
+
+  "Tenant permission semantics" should {
+    "let ReadWrite read and write, Read only read, None neither" in {
+      (ReadWrite.canRead must beTrue) and (ReadWrite.canWrite must beTrue) and
+      (Read.canRead must beTrue) and (Read.canWrite must beFalse) and
+      (None.canRead must beFalse) and (None.canWrite must beFalse)
+    }
+    "restrict a grant to its write-capable tenants" in {
+      byTenants(access("zoneA", ReadWrite), access("zoneB", Read)).restrictToWrite must beEqualTo(
+        byTenants(access("zoneA", ReadWrite)): TenantAccessGrant
+      )
+    }
+    "restrict a read-only-only grant to None" in {
+      byTenants(access("zoneA", Read)).restrictToWrite must beEqualTo(TenantAccessGrant.None: TenantAccessGrant)
+    }
+  }
+
+  "visibleSecurityTag" should {
+    val zoneATag = SecurityTag.ByTenants(Chunk(TenantId("zoneA")))
+    val twoZones = SecurityTag.ByTenants(Chunk(TenantId("zoneA"), TenantId("zoneB")))
+
+    "pass through None for admin" in {
+      TenantAccessGrant.All.visibleSecurityTag(scala.None: Option[SecurityTag]) must beNone
+    }
+    "pass through Some(Open) for admin" in {
+      TenantAccessGrant.All.visibleSecurityTag(Some(SecurityTag.Open)) must beSome(SecurityTag.Open: SecurityTag)
+    }
+    "pass through ByTenants unchanged for admin" in {
+      TenantAccessGrant.All.visibleSecurityTag(Some(twoZones)) must beSome(twoZones: SecurityTag)
+    }
+    "return None for TenantAccessGrant.None regardless of tag" in {
+      (TenantAccessGrant.None.visibleSecurityTag(scala.None: Option[SecurityTag]) must beNone) and
+      (TenantAccessGrant.None.visibleSecurityTag(Some(SecurityTag.Open)) must beNone) and
+      (TenantAccessGrant.None.visibleSecurityTag(Some(twoZones)) must beNone)
+    }
+    "return None for ByTenants user on untagged object" in {
+      byTenants(access("zoneA", ReadWrite)).visibleSecurityTag(scala.None: Option[SecurityTag]) must beNone
+    }
+    "pass through Open for any ByTenants user" in {
+      byTenants(access("zoneA", ReadWrite)).visibleSecurityTag(Some(SecurityTag.Open)) must beSome(SecurityTag.Open: SecurityTag)
+    }
+    "return intersection of user tenants and object tenants" in {
+      byTenants(access("zoneA", ReadWrite)).visibleSecurityTag(Some(twoZones)) must beSome(zoneATag: SecurityTag)
+    }
+    "return empty ByTenants when intersection is empty" in {
+      byTenants(access("zoneB", ReadWrite)).visibleSecurityTag(Some(zoneATag)) must beSome(
+        SecurityTag.ByTenants(Chunk.empty): SecurityTag
+      )
+    }
+  }
+
+  "canSee" should {
+    val zoneATag = SecurityTag.ByTenants(Chunk(TenantId("zoneA")))
+
+    "allow admin to see any tag" in {
+      (TenantAccessGrant.All.canSee(SecurityTag.Open) must beTrue) and
+      (TenantAccessGrant.All.canSee(zoneATag) must beTrue)
+    }
+    "deny TenantAccessGrant.None for ByTenants but allow Open" in {
+      (TenantAccessGrant.None.canSee(zoneATag) must beFalse) and
+      (TenantAccessGrant.None.canSee(SecurityTag.Open) must beTrue)
+    }
+    "allow ByTenants user to see a matching tenant tag" in {
+      byTenants(access("zoneA", ReadWrite)).canSee(zoneATag) must beTrue
+    }
+    "allow ByTenants user with read-only access to see the tag (read grants visibility)" in {
+      byTenants(access("zoneA", Read)).canSee(zoneATag) must beTrue
+    }
+    "deny ByTenants user for a non-matching tenant tag" in {
+      byTenants(access("zoneB", ReadWrite)).canSee(zoneATag) must beFalse
+    }
+    "only allow admin to see untagged objects (Option[SecurityTag] = None)" in {
+      (TenantAccessGrant.All.canSee(scala.None: Option[SecurityTag]) must beTrue) and
+      (byTenants(access("zoneA", ReadWrite)).canSee(scala.None: Option[SecurityTag]) must beFalse) and
+      (TenantAccessGrant.None.canSee(scala.None: Option[SecurityTag]) must beFalse)
+    }
+  }
+
+  "canModify" should {
+    val zoneATag = SecurityTag.ByTenants(Chunk(TenantId("zoneA")))
+
+    "allow admin to modify anything" in {
+      TenantAccessGrant.All.restrictToWrite.canSee(zoneATag) must beTrue
+    }
+    "deny TenantAccessGrant.None" in {
+      TenantAccessGrant.None.restrictToWrite.canSee(zoneATag) must beFalse
+    }
+    "allow ReadWrite user to modify a matching tenant object" in {
+      byTenants(access("zoneA", ReadWrite)).restrictToWrite.canSee(zoneATag) must beTrue
+    }
+    "deny Read-only user from modifying even a matching tenant object" in {
+      byTenants(access("zoneA", Read)).restrictToWrite.canSee(zoneATag) must beFalse
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestCompletion.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestCompletion.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.rest.OldInternalApiAuthz
 import com.normation.rudder.rest.RudderJsonResponse
 import com.normation.rudder.rest.RudderJsonResponse.ResponseSchema
+import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.users.UserService
 import net.liftweb.common.*
 import net.liftweb.http.rest.RestHelper
@@ -65,10 +66,10 @@ class RestCompletion(
 
       OldInternalApiAuthz.withReadConfig(userService.getCurrentUser) {
         val fetchTags = if (kind == "directive") {
-          completion.findDirectiveTagNames(token)
+          completion.findDirectiveTagNames(token)(using userService.getCurrentQC)
         } else {
           // rule
-          completion.findRuleTagNames(token)
+          completion.findRuleTagNames(token)(using userService.getCurrentQC)
         }
 
         fetchTags match {
@@ -89,10 +90,12 @@ class RestCompletion(
       OldInternalApiAuthz.withReadConfig(userService.getCurrentUser) {
 
         val fetchTags = if (kind == "directive") {
-          completion.findDirectiveTagValues(token, None)
+          completion.findDirectiveTagValues(token, None)(using
+            userService.getCurrentQC
+          )
         } else {
           // rule
-          completion.findRuleTagValues(token, None)
+          completion.findRuleTagValues(token, None)(using userService.getCurrentUser.map(_.qc).getOrElse(QueryContext.systemQC))
         }
 
         fetchTags match {
@@ -114,10 +117,14 @@ class RestCompletion(
       val schema = ResponseSchema("completeTags", None)
 
       val fetchTags = if (kind == "directive") {
-        completion.findDirectiveTagValues(token, Some(key))
+        completion.findDirectiveTagValues(token, Some(key))(using
+          userService.getCurrentQC
+        )
       } else {
         // rule
-        completion.findRuleTagValues(token, Some(key))
+        completion.findRuleTagValues(token, Some(key))(using
+          userService.getCurrentUser.map(_.qc).getOrElse(QueryContext.systemQC)
+        )
       }
 
       fetchTags match {
@@ -139,7 +146,7 @@ class RestCompletionService(
     readDirective: RoDirectiveRepository,
     readRule:      RoRuleRepository
 ) {
-  def findDirectiveTagNames(matching: String): Box[List[String]] = {
+  def findDirectiveTagNames(matching: String)(using qc: QueryContext): Box[List[String]] = {
     for {
       lib <- readDirective.getFullDirectiveLibrary().toBox
     } yield {
@@ -153,7 +160,7 @@ class RestCompletionService(
     }
   }
 
-  def findDirectiveTagValues(matching: String, tagName: Option[String]): Box[List[String]] = {
+  def findDirectiveTagValues(matching: String, tagName: Option[String])(using qc: QueryContext): Box[List[String]] = {
     for {
       lib <- readDirective.getFullDirectiveLibrary().toBox
     } yield {
@@ -168,7 +175,7 @@ class RestCompletionService(
     }
   }
 
-  def findRuleTagNames(matching: String): Box[List[String]] = {
+  def findRuleTagNames(matching: String)(using qc: QueryContext): Box[List[String]] = {
     for {
       rules <- readRule.getAll(false).toBox
     } yield {
@@ -181,7 +188,7 @@ class RestCompletionService(
     }
   }
 
-  def findRuleTagValues(matching: String, tagName: Option[String]): Box[List[String]] = {
+  def findRuleTagValues(matching: String, tagName: Option[String])(using qc: QueryContext): Box[List[String]] = {
     for {
       rules <- readRule.getAll(false).toBox
     } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -107,6 +107,7 @@ class RulesInternalApi(
       * All passed invalid or non existing rule ids are ignored.
       */
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
       val ruleIdsFilter      = req.params
         .get("rules")
         .map(
@@ -159,7 +160,7 @@ class RuleInternalApiService(
       ruleIdsFilter:        Option[Seq[RuleId]], // optional list of rule ids to filter the tree with
       getMissingCategories: (RuleCategory, List[Rule]) => Set[RuleCategory],
       missingCatId:         RuleCategoryId
-  ): IOResult[JRCategoriesRootEntryInfo] = {
+  )(using qc: QueryContext): IOResult[JRCategoriesRootEntryInfo] = {
     for {
       root              <- readRuleCategory.getRootCategory()
       rules             <- ruleIdsFilter match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -108,6 +108,7 @@ import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
+import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.XmlSafe
 import com.normation.zio.*
@@ -626,7 +627,7 @@ class ZipArchiveBuilderService(
       Seq().succeed
     } else {
       ruleCategoryRepo
-        .getRootCategory()
+        .getRootCategory()(using QueryContext.systemQC)
         .map(_.transformInto[JRuleCategories].keepInHierarchy(ids).toJsonPretty)
         .map(json => List(Zippable(path, Some(getJsonZippableContent(json)))))
     }
@@ -642,7 +643,7 @@ class ZipArchiveBuilderService(
       usedNames:   Ref[Map[String, Set[String]]],
       rootDirName: String,
       groupLib:    FullNodeGroupCategory
-  ): IOResult[Seq[Zippable]] = {
+  )(using qc: QueryContext): IOResult[Seq[Zippable]] = {
 
     import com.softwaremill.quicklens.*
 
@@ -695,7 +696,7 @@ class ZipArchiveBuilderService(
         cat:         FullNodeGroupCategory,
         catFileName: String,
         usedNames:   Ref[Map[String, Set[String]]]
-    ): IOResult[Chunk[Zippable]] = {
+    )(using qc: QueryContext): IOResult[Chunk[Zippable]] = {
       for {
         ref   <- Ref.make(Chunk.empty[Zippable])
         _     <- ZIO.foreach(cat.subCategories) { sub =>
@@ -1613,14 +1614,17 @@ class SaveArchiveServicebyRepo(
   }
 
   def saveDirective(eventMetadata: EventMetadata, d: DirectiveArchive): IOResult[Unit] = {
+    // archive import is a system-level operation, see all tenants
+    given cc: ChangeContext =
+      ChangeContext.newFor(eventMetadata.actor, TenantAccessGrant.All, eventMetadata.msg).withModId(eventMetadata.modId)
     for {
       at <-
         roDirectiveRepos
-          .getActiveTechnique(d.technique)
+          .getActiveTechnique(d.technique)(using cc.toQC)
           .notOptional(s"Technique '${d.technique.value}' is used in imported directive ${d.directive.name} but is not in Rudder")
       _  <-
         ApplicationLoggerPure.Archive.debug(s"Adding directive from archive: '${d.directive.name}' (${d.directive.id.serialize})")
-      _  <- woDirectiveRepos.saveDirective(at.id, d.directive, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+      _  <- woDirectiveRepos.saveDirective(at.id, d.directive)
     } yield ()
   }
   def saveGroupCat(
@@ -1635,7 +1639,7 @@ class SaveArchiveServicebyRepo(
        * point that at least all parents exists. But perhaps not that one.
        */
       id       = NodeGroupCategoryId(cat.category.id)
-      exists  <- roGroupRepos.categoryExists(id)
+      exists  <- roGroupRepos.categoryExists(id)(using cc.toQC)
       parentId = catMap.get(File(cat.catPath).parent.pathAsString) match {
                    case Some(p) => p
                    case None    => GroupRootId
@@ -1663,7 +1667,7 @@ class SaveArchiveServicebyRepo(
       // normally, at that point the category of the group exists because we took care to create them before.
       // But we used to have a bug where categories where not exported, so until Rudder 9 we need to check for that
       // if category of group doesn't exist, we need to create one using the UUID as name
-      c <- roGroupRepos.categoryExists(g.category)
+      c <- roGroupRepos.categoryExists(g.category)(using cc.toQC)
       _ <- ZIO.when(!c) {
              woGroupRepos.addGroupCategoryToCategory(
                NodeGroupCategory(
@@ -1694,7 +1698,10 @@ class SaveArchiveServicebyRepo(
     } yield ()
   }
   def saveRuleCategory(eventMetadata: EventMetadata, r: RuleCategoryArchive):    IOResult[Unit] = {
-    roRuleCategoryRepos.getRootCategory().flatMap { root =>
+    // archive import is a system-level operation, see all tenants
+    given cc: ChangeContext =
+      ChangeContext.newFor(eventMetadata.actor, TenantAccessGrant.All, eventMetadata.msg).withModId(eventMetadata.modId)
+    roRuleCategoryRepos.getRootCategory()(using cc.toQC).flatMap { root =>
       val newRoot  = r.toRuleCategory
       val parents  = r.parentCategories
       val children = r.childCategories
@@ -1711,10 +1718,7 @@ class SaveArchiveServicebyRepo(
              ZIO.unlessZIODiscard(alreadyExists(c.id))(
                woRuleCategoryRepos.create(
                  c.toRuleCategory,
-                 parents.get(c).fold(newRoot.id)(_.id),
-                 eventMetadata.modId,
-                 eventMetadata.actor,
-                 eventMetadata.msg
+                 parents.get(c).fold(newRoot.id)(_.id)
                ) *> created.update(_ + c.id) *>
                ApplicationLoggerPure.Archive.trace(
                  s"Created rule category parent from archive: '${c.name}' (${c.id.value})"
@@ -1723,10 +1727,7 @@ class SaveArchiveServicebyRepo(
            } else {
              woRuleCategoryRepos.updateAndMove(
                c.toRuleCategory,
-               parents.get(c).fold(newRoot.id)(_.id),
-               eventMetadata.modId,
-               eventMetadata.actor,
-               eventMetadata.msg
+               parents.get(c).fold(newRoot.id)(_.id)
              ) *> ApplicationLoggerPure.Archive.trace(
                s"Moved rule category parent from archive: '${c.name}' (${c.id.value}) to ${parents(c).id}"
              )
@@ -1740,9 +1741,12 @@ class SaveArchiveServicebyRepo(
     }
   }
   def saveRule(eventMetadata: EventMetadata, mergePolicy: MergePolicy, r: Rule): IOResult[Unit] = {
+    // archive import is a system-level operation, see all tenants
+    given cc: ChangeContext =
+      ChangeContext.newFor(eventMetadata.actor, TenantAccessGrant.All, eventMetadata.msg).withModId(eventMetadata.modId)
     for {
       _ <- ApplicationLoggerPure.Archive.debug(s"Adding rule from archive: '${r.name}' (${r.id.serialize})")
-      x <- roRuleRepos.getOpt(r.id)
+      x <- roRuleRepos.getOpt(r.id)(using cc.toQC)
       _ <- x match {
              case Some(value) =>
                // if merge policy asks for that, update rule from archive with existing groups before saving so
@@ -1752,12 +1756,12 @@ class SaveArchiveServicebyRepo(
                    r.copy(targets = value.targets)
                  } else r
                }
-               woRuleRepos.update(ruleToSave, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+               woRuleRepos.update(ruleToSave)
              case None        =>
                val ruleToSave = if (mergePolicy == MergePolicy.IgnoreSourceTargets) {
                  r.copy(targets = Set())
                } else r
-               woRuleRepos.create(ruleToSave, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+               woRuleRepos.create(ruleToSave)
            }
     } yield ()
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -1651,7 +1651,7 @@ class SaveArchiveServicebyRepo(
                    Nil,
                    Nil,
                    isSystem = false,
-                   security = cc.accessGrant.toSecurityTag
+                   security = cc.accessGrant.restrictToWrite.toSecurityTag
                  )
       _       <- if (exists) {
                    woGroupRepos.saveGroupCategory(category, parentId)
@@ -1677,7 +1677,7 @@ class SaveArchiveServicebyRepo(
                  Nil,
                  Nil,
                  isSystem = false,
-                 security = cc.accessGrant.toSecurityTag
+                 security = cc.accessGrant.restrictToWrite.toSecurityTag
                ),
                GroupRootId
              )

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -1370,7 +1370,7 @@ class ComplianceAPIService(
   /**
    * Get the compliance for everything
    */
-  private def getSystemRules()  = {
+  private def getSystemRules()(using qc: QueryContext)  = {
     for {
       allRules  <- rulesRepo.getAll(true)
       userRules <- rulesRepo.getAll()
@@ -1378,7 +1378,7 @@ class ComplianceAPIService(
       allRules.diff(userRules)
     }
   }
-  private def getAllUserRules() = {
+  private def getAllUserRules()(using qc: QueryContext) = {
     rulesRepo.getAll()
   }
   private def getByNodesCompliance(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -403,7 +403,7 @@ class DirectiveApiService14(
                                "",
                                None,
                                _isEnabled = true,
-                               security = cc.accessGrant.toSecurityTag
+                               security = cc.accessGrant.restrictToWrite.toSecurityTag
                              )
           result          <- actualDirectiveCreation(restDirective, baseDirective, activeTechnique, technique)
         } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -72,6 +72,7 @@ import com.normation.rudder.services.workflows.DGModAction
 import com.normation.rudder.services.workflows.DirectiveChangeRequest
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.model.DirectiveEditor
 import com.normation.rudder.web.services.DirectiveEditorService
 import com.normation.utils.Control.*
@@ -107,7 +108,7 @@ class DirectiveApi(
   object ListDirective extends LiftApiModule0 {
     val schema:                                                                                                API.ListDirectives.type = API.ListDirectives
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse            = {
-      service.listDirectives().toLiftResponseList(params, schema)
+      service.listDirectives()(using authzToken.qc).toLiftResponseList(params, schema)
     }
   }
   object DirectiveTree extends LiftApiModule0 {
@@ -115,7 +116,7 @@ class DirectiveApi(
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse           = {
       (for {
         includeSystem <- zioJsonExtractor.extractIncludeSystem(req).toIO
-        res           <- service.directiveTree(includeSystem.getOrElse(false))
+        res           <- service.directiveTree(includeSystem.getOrElse(false))(using authzToken.qc)
       } yield {
         res
       }).toLiftResponseOne(params, schema, _ => None)
@@ -134,7 +135,7 @@ class DirectiveApi(
     ): LiftResponse = {
       (for {
         did <- DirectiveId.parse(id).toIO
-        res <- service.directiveDetails(did)
+        res <- service.directiveDetails(did)(using authzToken.qc)
       } yield res).toLiftResponseOne(params, schema, d => Some(d.id))
     }
   }
@@ -165,8 +166,7 @@ class DirectiveApi(
         result        <- service.createOrCloneDirective(
                            restDirective,
                            restDirective.id.map(_.uid).getOrElse(DirectiveUid(uuidGen.newUuid)),
-                           restDirective.source,
-                           params
+                           restDirective.source
                          )
       } yield {
         val action = if (restDirective.source.nonEmpty) "cloneDirective" else schema.name
@@ -226,7 +226,7 @@ class DirectiveApi(
       val directiveId = DirectiveUid(id)
       (for {
         restDirective <- zioJsonExtractor.extractDirective(req).chainError(s"Could not extract values from request.").toIO
-        result        <- service.checkDirective(directiveId, restDirective)
+        result        <- service.checkDirective(directiveId, restDirective)(using authzToken.qc)
       } yield {
         result
       }).toLiftResponseOne(params, schema, s => Some(s.id))
@@ -269,7 +269,7 @@ class DirectiveApiService14(
     techniqueRepository:  TechniqueRepository
 ) {
 
-  def directiveTree(includeSystem: Boolean): IOResult[JRDirectiveTreeCategory] = {
+  def directiveTree(includeSystem: Boolean)(using qc: QueryContext): IOResult[JRDirectiveTreeCategory] = {
     def filterSystem(cat: FullActiveTechniqueCategory): FullActiveTechniqueCategory = {
       cat.copy(
         subCategories = cat.subCategories.filter(c => includeSystem || !c.isSystem).map(filterSystem).sortBy(_.name),
@@ -285,7 +285,7 @@ class DirectiveApiService14(
       JRDirectiveTreeCategory.fromActiveTechniqueCategory(filterSystem(root))
     }
   }
-  def listDirectives():                      IOResult[List[JRDirective]]       = {
+  def listDirectives()(using qc: QueryContext):                      IOResult[List[JRDirective]]       = {
     for {
       fullLibrary <- readDirective.getFullDirectiveLibrary().chainError("Could not fetch Directives")
       directives  <- ZIO.foreach(fullLibrary.allDirectives.values.filter(!_._2.isSystem).toList.sortBy(_._2.id.debugString)) {
@@ -327,21 +327,19 @@ class DirectiveApiService14(
   def createOrCloneDirective(
       restDirective: JQDirective,
       directiveId:   DirectiveUid,
-      source:        Option[DirectiveId],
-      params:        DefaultParams
+      source:        Option[DirectiveId]
   )(implicit cc: ChangeContext): IOResult[JRDirective] = {
     def actualDirectiveCreation(
         restDirective:   JQDirective,
         baseDirective:   Directive,
         activeTechnique: ActiveTechnique,
-        technique:       Technique,
-        params:          DefaultParams
+        technique:       Technique
     )(implicit cc: ChangeContext): IOResult[JRDirective] = {
       val newDirective = restDirective.updateDirective(baseDirective)
       val modId        = ModificationId(uuidGen.newUuid)
       for {
         // Check if a directive exists with the current id
-        _     <- readDirective.getDirective(newDirective.id.uid).flatMap {
+        _     <- readDirective.getDirective(newDirective.id.uid)(using cc.toQC).flatMap {
                    case None    => ZIO.unit
                    case Some(_) =>
                      Inconsistency(s"Cannot create a new Directive with id '${newDirective.id.uid.value}' already exists").fail
@@ -353,14 +351,14 @@ class DirectiveApiService14(
                    checkedParameters <- traverse(paramEditor.mapValueSeq.toSeq)(checkParameters(paramEditor))
                  } yield { checkedParameters.toMap }).toIO.chainError(s"Error with directive Parameters")
         saved <- writeDirective
-                   .saveDirective(activeTechnique.id, newDirective, modId, cc.actor, params.reason)
+                   .saveDirective(activeTechnique.id, newDirective)
                    .chainError(s"Could not save Directive ${newDirective.id.uid.value}")
         // We need to deploy only if there is a saveDiff, that says that a deployment is needed
         _     <- ZIO.when(saved.map(_.needDeployment).getOrElse(false)) {
                    IOResult.attempt(asyncDeploymentAgent ! AutomaticStartDeployment(modId, cc.actor))
                  }
       } yield {
-        JRDirective.fromDirective(technique, newDirective, None)
+        JRDirective.fromDirective(technique, newDirective, None)(using cc.toQC)
       }
     }
     source match {
@@ -370,7 +368,9 @@ class DirectiveApiService14(
                              _.size > 3,
                              _ => "'displayName' is mandatory and must be at least 3 char long"
                            )
-          ad            <- configRepository.getDirective(cloneId).notOptional(s"Can not find directive to clone: ${cloneId.debugString}")
+          ad            <- configRepository
+                             .getDirective(cloneId)(using cc.toQC)
+                             .notOptional(s"Can not find directive to clone: ${cloneId.debugString}")
           // technique version: by default, directive one. It techniqueVersion is given, use that. If techniqueRevision is specified, use it.
           techVersion    = restDirective.techniqueVersion.getOrElse(ad.directive.techniqueVersion)
           techId         = TechniqueId(ad.activeTechnique.techniqueName, techVersion)
@@ -378,7 +378,7 @@ class DirectiveApiService14(
           (_, technique) = tuple
           newDirective   = restDirective.copy(enabled = Some(false), techniqueVersion = Some(techId.version))
           baseDirective  = ad.directive.modify(_.id.uid).setTo(directiveId)
-          result        <- actualDirectiveCreation(newDirective, baseDirective, ad.activeTechnique, technique, params)
+          result        <- actualDirectiveCreation(newDirective, baseDirective, ad.activeTechnique, technique)
         } yield {
           result
         }
@@ -392,7 +392,9 @@ class DirectiveApiService14(
                                s"Technique is not correctly defined in request data."
                              )
           activeTechnique <-
-            readDirective.getActiveTechnique(technique.id.name).notOptional(s"Technique ${technique.id.name} cannot be found.")
+            readDirective
+              .getActiveTechnique(technique.id.name)(using cc.toQC)
+              .notOptional(s"Technique ${technique.id.name} cannot be found.")
           baseDirective    = Directive(
                                DirectiveId(directiveId, GitVersion.DEFAULT_REV),
                                technique.id.version,
@@ -403,7 +405,7 @@ class DirectiveApiService14(
                                _isEnabled = true,
                                security = cc.accessGrant.toSecurityTag
                              )
-          result          <- actualDirectiveCreation(restDirective, baseDirective, activeTechnique, technique, params)
+          result          <- actualDirectiveCreation(restDirective, baseDirective, activeTechnique, technique)
         } yield {
           result
         }
@@ -436,7 +438,7 @@ class DirectiveApiService14(
                     .chainError(s"Could not start workflow for change request creation on Directive '${change.newDirective.name}'")
     } yield {
       val optCrId = if (workflow.needExternalValidation()) Some(id) else None
-      JRDirective.fromDirective(technique, change.newDirective, optCrId)
+      JRDirective.fromDirective(technique, change.newDirective, optCrId)(using cc.toQC)
     }
   }
 
@@ -445,7 +447,7 @@ class DirectiveApiService14(
   ): IOResult[JRDirective] = {
     for {
       id              <- restDirective.id.notOptional(s"Directive id is mandatory in update")
-      directiveUpdate <- updateDirectiveModel(id.uid, restDirective)
+      directiveUpdate <- updateDirectiveModel(id.uid, restDirective)(using cc.toQC)
       updatedTechnique = directiveUpdate.after.technique
       updatedDirective = directiveUpdate.after.directive
       oldTechnique     = directiveUpdate.before.technique
@@ -469,7 +471,7 @@ class DirectiveApiService14(
       cc: ChangeContext
   ): IOResult[JRDirective] = {
     // TODO: manage rev
-    readDirective.getDirectiveWithContext(id).flatMap {
+    readDirective.getDirectiveWithContext(id)(using cc.toQC).flatMap {
       case Some((technique, activeTechnique, directive)) =>
         val change = DirectiveChangeRequest(
           DGModAction.Delete,
@@ -487,7 +489,7 @@ class DirectiveApiService14(
     }
   }
 
-  def directiveDetails(id: DirectiveId): IOResult[JRDirective] = {
+  def directiveDetails(id: DirectiveId)(using qc: QueryContext): IOResult[JRDirective] = {
     for {
       at <- configRepository.getDirective(id).notOptional(s"Directive with id '${id.debugString}' was not found")
       tid = TechniqueId(at.activeTechnique.techniqueName, at.directive.techniqueVersion)
@@ -517,9 +519,13 @@ class DirectiveApiService14(
     }
   }
 
-  private def updateDirectiveModel(directiveId: DirectiveUid, restDirective: JQDirective): IOResult[DirectiveUpdate] = {
+  private def updateDirectiveModel(directiveId: DirectiveUid, restDirective: JQDirective)(using
+      qc: QueryContext
+  ): IOResult[DirectiveUpdate] = {
     for {
-      triple                                       <- readDirective.getDirectiveWithContext(directiveId).notOptional(s"Could not find Directive ${directiveId.value}")
+      triple                                       <- readDirective
+                                                        .getDirectiveWithContext(directiveId)
+                                                        .notOptional(s"Could not find Directive ${directiveId.value}")
       (oldTechnique, activeTechnique, oldDirective) = triple
       // Check if Technique version is changed (migration)
       updatedTechniqueId                            = TechniqueId(oldTechnique.id.name, restDirective.techniqueVersion.getOrElse(oldTechnique.id.version))
@@ -547,7 +553,7 @@ class DirectiveApiService14(
     }
   }
 
-  def checkDirective(directiveId: DirectiveUid, restDirective: JQDirective): IOResult[JRDirective] = {
+  def checkDirective(directiveId: DirectiveUid, restDirective: JQDirective)(using qc: QueryContext): IOResult[JRDirective] = {
     for {
       directiveUpdate <- updateDirectiveModel(directiveId, restDirective)
     } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -538,7 +538,7 @@ class GroupApiService14(
               isDynamic = true,
               serverList = Set(),
               _isEnabled = defaultEnabled,
-              security = cc.accessGrant.toSecurityTag
+              security = cc.accessGrant.restrictToWrite.toSecurityTag
             )
           }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -460,7 +460,9 @@ class GroupApiService14(
       id       <- workflow.startWorkflow(cr)
     } yield {
       val optCrId = if (workflow.needExternalValidation()) Some(id) else None
-      JRGroup.fromGroup(change.newGroup, change.category.getOrElse(readGroup.getRootCategory().id), optCrId)
+      JRGroup.fromGroup(change.newGroup, change.category.getOrElse(readGroup.getRootCategory()(using cc.toQC).id), optCrId)(using
+        cc.toQC
+      )
     }
   }
 
@@ -480,7 +482,7 @@ class GroupApiService14(
   )(implicit cc: ChangeContext): ZIO[Any, RudderError, JRGroup] = {
     def actualGroupCreation(change: NodeGroupChangeRequest, groupId: NodeGroupId) = {
       (for {
-        rootCat  <- readGroup.getRootCategoryPure()
+        rootCat  <- readGroup.getRootCategoryPure()(using cc.toQC)
         cat       = change.category.getOrElse(rootCat.id)
         saveDiff <- writeGroup.create(change.newGroup, cat)
         // after group creation, its properties should be computed and resolved
@@ -490,7 +492,7 @@ class GroupApiService14(
           // Trigger a deployment only if it is needed
           asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, cc.actor)
         }
-        JRGroup.fromGroup(saveDiff.group, cat, None)
+        JRGroup.fromGroup(saveDiff.group, cat, None)(using cc.toQC)
       }).chainError(s"Could not create group '${change.newGroup.name}' (id:${groupId.serialize}).")
     }
 
@@ -600,7 +602,7 @@ class GroupApiService14(
               .chainError(s"Could not reload Group ${sid} details")
 
           case None =>
-            JRGroup.fromGroup(group, cat, None).succeed
+            JRGroup.fromGroup(group, cat, None)(using qc).succeed
         }
     }
   }
@@ -654,7 +656,7 @@ class GroupApiService14(
     }
     readGroup
       .getFullGroupLibrary()
-      .map(c => JRFullGroupCategory.fromCategory(filterSystem(c), None))
+      .map(c => JRFullGroupCategory.fromCategory(filterSystem(c), None)(using qc))
   }
 
   def getCategoryDetails(id: NodeGroupCategoryId)(implicit qc: QueryContext): IOResult[JRMinimalGroupCategory] = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -56,6 +56,7 @@ import com.normation.rudder.services.workflows.GlobalParamChangeRequest
 import com.normation.rudder.services.workflows.GlobalParamModAction
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import zio.syntax.*
@@ -80,7 +81,7 @@ class ParameterApi(
   object ListParameters extends LiftApiModule0 {
     val schema:                                                                                                API.ListParameters.type = API.ListParameters
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse            = {
-      service.listParameters().toLiftResponseList(params, schema)
+      service.listParameters()(using authzToken.qc).toLiftResponseList(params, schema)
     }
   }
 
@@ -94,7 +95,7 @@ class ParameterApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      service.parameterDetails(id).toLiftResponseOne(params, schema, s => Some(s.id))
+      service.parameterDetails(id)(using authzToken.qc).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
 
@@ -174,23 +175,21 @@ class ParameterApiService14(
       id       <- workflow.startWorkflow(cr)
     } yield {
       val optCrId = if (workflow.needExternalValidation()) Some(id) else None
-      JRGlobalParameter.fromGlobalParameter(parameter, optCrId)
+      JRGlobalParameter.fromGlobalParameter(parameter, optCrId)(using cc.toQC)
     }
   }
 
-  def listParameters(): IOResult[Seq[JRGlobalParameter]] = {
+  def listParameters()(using qc: QueryContext): IOResult[Seq[JRGlobalParameter]] = {
     readParameter
       .getAllGlobalParameters()
-      .map(_.filter(_.visibility == Visibility.Displayed).sortBy(_.name).map(JRGlobalParameter.fromGlobalParameter(_, None)))
+      .map(_.filter(_.visibility == Visibility.Displayed).sortBy(_.name).map(p => JRGlobalParameter.fromGlobalParameter(p, None)))
   }
 
-  def parameterDetails(id: String): IOResult[JRGlobalParameter] = {
+  def parameterDetails(id: String)(using qc: QueryContext): IOResult[JRGlobalParameter] = {
     readParameter
       .getGlobalParameter(id)
       .notOptional(s"Could not find Parameter ${id}")
-      .map(
-        JRGlobalParameter.fromGlobalParameter(_, None)
-      )
+      .map(p => JRGlobalParameter.fromGlobalParameter(p, None))
   }
 
   def createParameter(restParameter: JQGlobalParameter, params: DefaultParams, actor: EventActor)(implicit
@@ -213,7 +212,7 @@ class ParameterApiService14(
   ): IOResult[JRGlobalParameter] = {
     for {
       id          <- restParameter.id.notOptional("Parameter name is mandatory for update")
-      param       <- readParameter.getGlobalParameter(id).notOptional(s"Could not find Parameter '${id}''")
+      param       <- readParameter.getGlobalParameter(id)(using cc.toQC).notOptional(s"Could not find Parameter '${id}''")
       updatedParam = restParameter.updateParameter(param)
       diff         = ModifyToGlobalParameterDiff(updatedParam)
       change       = GlobalParamChangeRequest(GlobalParamModAction.Update, Some(param))
@@ -226,7 +225,7 @@ class ParameterApiService14(
   def deleteParameter(id: String, params: DefaultParams, actor: EventActor)(implicit
       cc: ChangeContext
   ): IOResult[JRGlobalParameter] = {
-    readParameter.getGlobalParameter(id).flatMap {
+    readParameter.getGlobalParameter(id)(using cc.toQC).flatMap {
       case None            => // already deleted
         JRGlobalParameter.empty(id).succeed
       case Some(parameter) =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -586,7 +586,7 @@ class RuleApiService14(
         case None =>
           // create from scratch - base rule is the same with default values
           val category       = restRule.categoryId.getOrElse("rootRuleCategory")
-          val baseRule       = Rule(ruleId, name, RuleCategoryId(category), security = cc.accessGrant.toSecurityTag)
+          val baseRule       = Rule(ruleId, name, RuleCategoryId(category), security = cc.accessGrant.restrictToWrite.toSecurityTag)
           // If enable is missing in parameter consider it to true
           val defaultEnabled = restRule.enabled.getOrElse(true)
 
@@ -895,7 +895,7 @@ class RuleApiService14(
                     name,
                     restData.description.getOrElse(""),
                     Nil,
-                    security = cc.accessGrant.toSecurityTag
+                    security = cc.accessGrant.restrictToWrite.toSecurityTag
                   )
       parent    = restData.parent.getOrElse("rootRuleCategory")
       _        <- writeRuleCategory.create(update, RuleCategoryId(parent))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -147,9 +147,7 @@ class RuleApi(
         result   <- service.createRule(
                       restRule,
                       restRule.id.getOrElse(RuleId(RuleUid(uuidGen.newUuid))),
-                      restRule.source,
-                      params,
-                      authzToken.qc.actor
+                      restRule.source
                     )
       } yield {
         val action = if (restRule.source.nonEmpty) "cloneRule" else schema.name
@@ -217,7 +215,9 @@ class RuleApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      service.getCategoryDetails(RuleCategoryId(id)).toLiftResponseOne(params, schema, s => Some(s.ruleCategories.id))
+      service
+        .getCategoryDetails(RuleCategoryId(id))(using authzToken.qc)
+        .toLiftResponseOne(params, schema, s => Some(s.ruleCategories.id))
     }
   }
 
@@ -227,7 +227,7 @@ class RuleApi(
       implicit val cc: ChangeContext = authzToken.qc.newCC(params.reason)
       (for {
         cat <- zioJsonExtractor.extractRuleCategory(req).toIO
-        res <- service.createCategory(cat, () => uuidGen.newUuid, params, authzToken.qc.actor)
+        res <- service.createCategory(cat, () => uuidGen.newUuid, params)
       } yield {
         res
       }).toLiftResponseOne(params, schema, s => Some(s.ruleCategories.id))
@@ -246,7 +246,7 @@ class RuleApi(
     ): LiftResponse = {
       (for {
         cat <- zioJsonExtractor.extractRuleCategory(req).toIO
-        res <- service.updateCategory(RuleCategoryId(id), cat, params, authzToken.qc.actor)
+        res <- service.updateCategory(RuleCategoryId(id), cat, params, authzToken.qc.actor)(using authzToken.qc)
       } yield {
         res
       }).toLiftResponseOne(params, schema, s => Some(s.ruleCategories.id))
@@ -264,7 +264,7 @@ class RuleApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       service
-        .deleteCategory(RuleCategoryId(id), params, authzToken.qc.actor)
+        .deleteCategory(RuleCategoryId(id), params, authzToken.qc.actor)(using authzToken.qc)
         .toLiftResponseOne(params, schema, s => Some(s.ruleCategories.id))
     }
   }
@@ -298,9 +298,11 @@ class RuleApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      given cc: ChangeContext = authzToken.qc.newCC(params.reason)
+
       (for {
         rid <- RuleId.parse(id).toIO
-        res <- service.unloadRule(rid, params, authzToken.qc.actor)
+        res <- service.unloadRule(rid)
       } yield res).toLiftResponseOne(params, schema, s => Some(s.serialize))
     }
   }
@@ -559,9 +561,7 @@ class RuleApiService14(
   def createRule(
       restRule: JQRule,
       ruleId:   RuleId,
-      clone:    Option[RuleId],
-      params:   DefaultParams,
-      actor:    EventActor
+      clone:    Option[RuleId]
   )(implicit cc: ChangeContext): IOResult[JRRule] = {
     // decide if we should create a new rule or clone an existing one
     // Return the source rule to use in each case.
@@ -569,9 +569,7 @@ class RuleApiService14(
         name:     String,
         restRule: JQRule,
         ruleId:   RuleId,
-        clone:    Option[RuleId],
-        params:   DefaultParams,
-        actor:    EventActor
+        clone:    Option[RuleId]
     )(implicit cc: ChangeContext): IOResult[RuleChangeRequest] = {
       clone match {
         case Some(sourceId) =>
@@ -579,7 +577,7 @@ class RuleApiService14(
           for {
             rule <-
               readRule
-                .get(sourceId)
+                .get(sourceId)(using cc.toQC)
                 .chainError(s"Could not create rule '${name}' (id:${ruleId.serialize}) by cloning rule '${sourceId.serialize}')")
           } yield {
             RuleChangeRequest(RuleModAction.Create, restRule.updateRule(rule).copy(id = ruleId), Some(rule))
@@ -604,7 +602,7 @@ class RuleApiService14(
            */
           for {
             workflow <- workflowLevelService
-                          .getForRule(actor, change)
+                          .getForRule(cc.actor, change)
                           .chainError("Could not find workflow status for that rule creation")
           } yield {
             // we don't actually start a workflow, we only disable the rule if a workflow should be
@@ -618,18 +616,17 @@ class RuleApiService14(
 
     (for {
       name   <- restRule.displayName.notOptional("Missing manadatory parameter 'displayName'")
-      change <- createOrClone(name, restRule, ruleId, clone, params, actor)
-      modId   = ModificationId(uuidGen.newUuid)
-      _      <- writeRule.create(change.newRule, modId, actor, params.reason)
+      change <- createOrClone(name, restRule, ruleId, clone)
+      _      <- writeRule.create(change.newRule)
 
-      directiveLib <- readDirectives.getFullDirectiveLibrary()
+      directiveLib <- readDirectives.getFullDirectiveLibrary()(using cc.toQC)
       groupLib     <- readGroup.getFullGroupLibrary()(using cc.toQC)
       nodesLib     <- nodeFactRepos.getAll()(using cc.toQC)
       globalMode   <- getGlobalPolicyMode()
     } yield {
       val status = getRuleApplicationStatus(change.newRule, groupLib, directiveLib, nodesLib, globalMode)
-      asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
-      JRRule.fromRule(change.newRule, None, Some(status.policyMode.name), Some(status.applicationStatusDetails))
+      asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, cc.actor)
+      JRRule.fromRule(change.newRule, None, Some(status.policyMode.name), Some(status.applicationStatusDetails))(using cc.toQC)
     }).chainError(s"Error when creating new rule")
   }
 
@@ -668,7 +665,7 @@ class RuleApiService14(
              )
          // perhaps that will need to go throught change requests
          modId         = ModificationId(uuidGen.newUuid)
-         ldap         <- writeRule.load(rule, modId, actor, params.reason)
+         ldap         <- writeRule.load(rule)(using qc.newCC(params.reason).withModId(modId))
          _            <-
            ConfigurationLoggerPure.info(
              s"Revision '${id.rev.value}' for rule with id '${id.uid.serialize}' loaded. It will be used in comming policy generations."
@@ -685,20 +682,19 @@ class RuleApiService14(
      })
   }
 
-  def unloadRule(id: RuleId, params: DefaultParams, actor: EventActor): IOResult[RuleId] = {
+  def unloadRule(id: RuleId)(using cc: ChangeContext): IOResult[RuleId] = {
     (if (id.rev == GitVersion.DEFAULT_REV) {
        Inconsistency(s"The default revision can not be specifically loaded for generation (it is always loaded)").fail
      } else {
-       val modId = ModificationId(uuidGen.newUuid)
        for {
          // perhaps that will need to go throught change requests
-         ldap <- writeRule.unload(id, modId, actor, params.reason)
+         ldap <- writeRule.unload(id)
          _    <-
            ConfigurationLoggerPure.info(
              s"Revision '${id.rev.value}' for rule with id '${id.uid.serialize}' unloaded. It will not be used anymore in comming policy generations."
            )
        } yield {
-         asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
+         asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, cc.actor)
          id
        }
      })
@@ -792,7 +788,7 @@ class RuleApiService14(
     }
   }
 
-  def getCategoryDetails(id: RuleCategoryId): IOResult[JRCategoriesRootEntrySimple] = {
+  def getCategoryDetails(id: RuleCategoryId)(using qc: QueryContext): IOResult[JRCategoriesRootEntrySimple] = {
     // returns (parent, child)
     def recFind(root: RuleCategory, id: RuleCategoryId): Option[(RuleCategory, RuleCategory)] = {
       root.childs.foldLeft(Option.empty[(RuleCategory, RuleCategory)]) {
@@ -843,7 +839,10 @@ class RuleApiService14(
     }
   }
 
-  def deleteCategory(id: RuleCategoryId, params: DefaultParams, actor: EventActor): IOResult[JRCategoriesRootEntrySimple] = {
+  def deleteCategory(id: RuleCategoryId, params: DefaultParams, actor: EventActor)(using
+      qc: QueryContext
+  ): IOResult[JRCategoriesRootEntrySimple] = {
+    given cc: ChangeContext = ChangeContext.newFor(actor, qc.accessGrant, params.reason)
     for {
       root              <- readRuleCategory.getRootCategory()
       found             <- root.find(id).toIO
@@ -853,7 +852,7 @@ class RuleApiService14(
                              Inconsistency(s"Cannot delete category '${category.name}' since that category is not empty").fail
                            }
       category          <- getCategoryDetails(id)
-      _                 <- writeRuleCategory.delete(id, ModificationId(uuidGen.newUuid), actor, params.reason)
+      _                 <- writeRuleCategory.delete(id)
     } yield {
       category
     }
@@ -864,19 +863,19 @@ class RuleApiService14(
       restData: JQRuleCategory,
       params:   DefaultParams,
       actor:    EventActor
-  ): IOResult[JRCategoriesRootEntrySimple] = {
+  )(using qc: QueryContext): IOResult[JRCategoriesRootEntrySimple] = {
+    given cc: ChangeContext = ChangeContext.newFor(actor, qc.accessGrant, params.reason)
     for {
       root                <- readRuleCategory.getRootCategory()
       found               <- root.find(id).toIO
       (category, parentId) = found
       rules               <- readRule.getAll()
       update               = restData.update(category)
-      modId                = ModificationId(uuidGen.newUuid)
       _                   <- restData.parent match {
                                case Some(parent) =>
-                                 writeRuleCategory.updateAndMove(update, RuleCategoryId(parent), modId, actor, params.reason)
+                                 writeRuleCategory.updateAndMove(update, RuleCategoryId(parent))
                                case None         =>
-                                 writeRuleCategory.updateAndMove(update, parentId, modId, actor, params.reason)
+                                 writeRuleCategory.updateAndMove(update, parentId)
                              }
       category            <- getCategoryDetails(id)
     } yield {
@@ -887,8 +886,7 @@ class RuleApiService14(
   def createCategory(
       restData:  JQRuleCategory,
       defaultId: () => String,
-      params:    DefaultParams,
-      actor:     EventActor
+      params:    DefaultParams
   )(implicit cc: ChangeContext): IOResult[JRCategoriesRootEntrySimple] = {
     for {
       name     <- restData.name.checkMandatory(_.size > 3, _ => "'displayName' is mandatory and must be at least 3 char long")
@@ -900,9 +898,8 @@ class RuleApiService14(
                     security = cc.accessGrant.toSecurityTag
                   )
       parent    = restData.parent.getOrElse("rootRuleCategory")
-      modId     = ModificationId(uuidGen.newUuid)
-      _        <- writeRuleCategory.create(update, RuleCategoryId(parent), modId, actor, params.reason)
-      category <- getCategoryDetails(update.id)
+      _        <- writeRuleCategory.create(update, RuleCategoryId(parent))
+      category <- getCategoryDetails(update.id)(using cc.toQC)
     } yield {
       category
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.repository.xml.TechniqueRevisionRepository
 import com.normation.rudder.rest.{TechniqueApi as API, *}
 import com.normation.rudder.rest.lift.TechniqueApi.QueryFormat
 import com.normation.rudder.rest.syntax.*
+import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.FileUtils
 import com.normation.utils.ParseVersion
 import com.normation.utils.StringUuidGenerator
@@ -284,7 +285,7 @@ class TechniqueApi(
     val schema: API.GetTechniques.type = API.GetTechniques
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      service.getTechniquesWithData().toLiftResponseList(params, schema)
+      service.getTechniquesWithData()(using authzToken.qc).toLiftResponseList(params, schema)
     }
 
   }
@@ -502,7 +503,7 @@ class TechniqueApi(
     val schema: API.ListTechniques.type = API.ListTechniques
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      service.listTechniques.toLiftResponseList(params, schema)
+      service.listTechniques(using authzToken.qc).toLiftResponseList(params, schema)
     }
   }
 
@@ -518,7 +519,7 @@ class TechniqueApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       val techniqueName = TechniqueName(name)
-      service.listDirectives(techniqueName, None).toLiftResponseList(params, schema)
+      service.listDirectives(techniqueName, None)(using authzToken.qc).toLiftResponseList(params, schema)
     }
   }
 
@@ -537,7 +538,7 @@ class TechniqueApi(
 
       val directives = TechniqueVersion.parse(version) match {
         case Right(techniqueVersion) =>
-          service.listDirectives(techniqueName, Some(techniqueVersion :: Nil))
+          service.listDirectives(techniqueName, Some(techniqueVersion :: Nil))(using authzToken.qc)
         case Left(error)             =>
           Inconsistency(
             s"Could not find list of directives based on '${techniqueName.value}' technique, because we could not parse '${version}' as a valid technique version"
@@ -559,7 +560,7 @@ class TechniqueApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       val techniqueName = TechniqueName(name)
-      service.getTechniqueWithData(techniqueName, None, QueryFormat.Json).toLiftResponseList(params, schema)
+      service.getTechniqueWithData(techniqueName, None, QueryFormat.Json)(using authzToken.qc).toLiftResponseList(params, schema)
     }
   }
 
@@ -580,7 +581,7 @@ class TechniqueApi(
         req.params.get("format").flatMap(_.map(QueryFormat.parse).headOption).getOrElse(QueryFormat.Json)
       val json = TechniqueVersion.parse(version) match {
         case Right(techniqueVersion) =>
-          service.getTechniqueWithData(techniqueName, Some(techniqueVersion), format)
+          service.getTechniqueWithData(techniqueName, Some(techniqueVersion), format)(using authzToken.qc)
         case Left(error)             =>
           Inconsistency(
             s"Could not find technique '${techniqueName.value}' details, because we could not parse '${version}' as a valid technique version"
@@ -633,7 +634,7 @@ class TechniqueAPIService14(
     )
   }
 
-  def listTechniques: IOResult[Seq[JRActiveTechnique]] = {
+  def listTechniques(using qc: QueryContext): IOResult[Seq[JRActiveTechnique]] = {
     for {
       lib             <- readDirective.getFullDirectiveLibrary()
       activeTechniques = lib.allActiveTechniques.values.toSeq
@@ -643,7 +644,9 @@ class TechniqueAPIService14(
     }
   }
 
-  def listDirectives(techniqueName: TechniqueName, wantedVersions: Option[List[TechniqueVersion]]): IOResult[Seq[JRDirective]] = {
+  def listDirectives(techniqueName: TechniqueName, wantedVersions: Option[List[TechniqueVersion]])(using
+      qc: QueryContext
+  ): IOResult[Seq[JRDirective]] = {
     def serializeDirectives(
         directives:     Seq[Directive],
         techniques:     SortedMap[TechniqueVersion, Technique],
@@ -724,7 +727,7 @@ class TechniqueAPIService14(
       techniqueName: TechniqueName,
       version:       Option[TechniqueVersion],
       format:        TechniqueApi.QueryFormat
-  ): ZIO[Any, RudderError, Seq[Json]] = {
+  )(using qc: QueryContext): ZIO[Any, RudderError, Seq[Json]] = {
     for {
       lib            <- readDirective.getFullDirectiveLibrary()
       activeTechnique = lib.allActiveTechniques.values.find(_.techniqueName == techniqueName).toSeq
@@ -767,7 +770,7 @@ class TechniqueAPIService14(
     }
   }
 
-  def getTechniquesWithData(): IOResult[Seq[Json]] = {
+  def getTechniquesWithData()(using qc: QueryContext): IOResult[Seq[Json]] = {
     for {
       lib             <- readDirective.getFullDirectiveLibrary()
       activeTechniques = lib.allActiveTechniques.values.toSeq

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -731,7 +731,7 @@ class UserManagementApiImpl(
     nodePerms match {
       case TenantAccessGrant.All                => "all"
       case TenantAccessGrant.None               => "none"
-      case TenantAccessGrant.ByTenants(tenants) => tenants.map(_.value).mkString(",")
+      case TenantAccessGrant.ByTenants(tenants) => tenants.map(_.serialize).mkString(",")
     }
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserService.scala
@@ -37,9 +37,12 @@
 
 package com.normation.rudder.users
 
+import com.normation.rudder.tenants.QueryContext
+
 /**
  * A minimalistic definition of a service that give access to currently logged user, if any.
  */
 trait UserService {
   def getCurrentUser: Option[AuthenticatedUser]
+  def getCurrentQC:   QueryContext = getCurrentUser.map(_.qc).getOrElse(QueryContext.noneQC)
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
@@ -144,7 +144,7 @@ class LinkUtil(
     override def toJsCmd: String = s"window.location = ${encJs(where)} ;"
   }
 
-  def createRuleLink(id: RuleId): Elem = {
+  def createRuleLink(id: RuleId)(using qc: QueryContext): Elem = {
     roRuleRepository.get(id).either.runNow match {
       case Right(rule) => <span> <a href={baseRuleLink(id)}>{rule.name}</a> (Rudder ID: {id.serialize})</span>
       case Left(err)   =>
@@ -162,7 +162,7 @@ class LinkUtil(
     }
   }
 
-  def createDirectiveLink(id: DirectiveUid): Elem = {
+  def createDirectiveLink(id: DirectiveUid)(using qc: QueryContext): Elem = {
     roDirectiveRepository.getDirective(id).either.runNow match {
       case Right(Some(directive)) => <span> <a href={baseDirectiveLink(id)}>{directive.name}</a> (Rudder ID: {id.value})</span>
       case Right(None)            =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
@@ -170,13 +170,13 @@ object DiffDisplayer {
 
 class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
 
-  implicit private def displayDirective(directiveId: DirectiveId): Elem = {
+  implicit private def displayDirective(directiveId: DirectiveId)(using qc: QueryContext): Elem = {
     <span> Directive {linkUtil.createDirectiveLink(directiveId.uid)}</span>
   }
   def displayDirectiveChangeList(
       oldDirectives: Seq[DirectiveId],
       newDirectives: Seq[DirectiveId]
-  ): NodeSeq = {
+  )(using qc: QueryContext): NodeSeq = {
 
     // First, find unchanged and deleted (have find no clean way to make a 3 way partition)
     val (unchanged, deleted) = oldDirectives.partition(newDirectives.contains)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_directives.yml
@@ -1,0 +1,1410 @@
+---
+description: Admin sees full security tag on tenant-restricted directive
+user: admin
+method: GET
+url: /api/latest/directives/directive2
+response:
+  code: 200
+  content: >-
+    {
+      "action": "directiveDetails",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "directive2",
+            "shortDescription": "",
+            "longDescription": "",
+            "techniqueName": "rpmPackageInstallation",
+            "techniqueVersion": "7.0",
+            "parameters": {
+              "section": {
+                "name": "sections",
+                "sections": [
+                  {
+                    "section": {
+                      "name": "Check interval",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                            "value": "5"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "RHEL/CentOS/SuSE packages",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDACTION",
+                            "value": "add"
+                          }
+                        },
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDLIST",
+                            "value": "vim"
+                          }
+                        }
+                      ],
+                      "sections": [
+                        {
+                          "section": {
+                            "name": "Package version",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_CRITERION",
+                                  "value": "=="
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                                  "value": "default"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section": {
+                            "name": "Post-modification hook",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                                  "value": "false"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "ZMD process"
+                    }
+                  }
+                ]
+              }
+            },
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "default",
+            "tags": [],
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneAB user sees both zoneA and zoneB in security tag
+user: zoneAB
+method: GET
+url: /api/latest/directives/directive2
+response:
+  code: 200
+  content: >-
+    {
+      "action": "directiveDetails",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "directive2",
+            "shortDescription": "",
+            "longDescription": "",
+            "techniqueName": "rpmPackageInstallation",
+            "techniqueVersion": "7.0",
+            "parameters": {
+              "section": {
+                "name": "sections",
+                "sections": [
+                  {
+                    "section": {
+                      "name": "Check interval",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                            "value": "5"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "RHEL/CentOS/SuSE packages",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDACTION",
+                            "value": "add"
+                          }
+                        },
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDLIST",
+                            "value": "vim"
+                          }
+                        }
+                      ],
+                      "sections": [
+                        {
+                          "section": {
+                            "name": "Package version",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_CRITERION",
+                                  "value": "=="
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                                  "value": "default"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section": {
+                            "name": "Post-modification hook",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                                  "value": "false"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "ZMD process"
+                    }
+                  }
+                ]
+              }
+            },
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "default",
+            "tags": [],
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneB user (read-only) sees only zoneB in security tag
+user: zoneB
+method: GET
+url: /api/latest/directives/directive2
+response:
+  code: 200
+  content: >-
+    {
+      "action": "directiveDetails",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "directive2",
+            "shortDescription": "",
+            "longDescription": "",
+            "techniqueName": "rpmPackageInstallation",
+            "techniqueVersion": "7.0",
+            "parameters": {
+              "section": {
+                "name": "sections",
+                "sections": [
+                  {
+                    "section": {
+                      "name": "Check interval",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                            "value": "5"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "RHEL/CentOS/SuSE packages",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDACTION",
+                            "value": "add"
+                          }
+                        },
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDLIST",
+                            "value": "vim"
+                          }
+                        }
+                      ],
+                      "sections": [
+                        {
+                          "section": {
+                            "name": "Package version",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_CRITERION",
+                                  "value": "=="
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                                  "value": "default"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section": {
+                            "name": "Post-modification hook",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                                  "value": "false"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "ZMD process"
+                    }
+                  }
+                ]
+              }
+            },
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "default",
+            "tags": [],
+            "security": {
+              "tenants": [
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneC user sees nothing (no object has zoneC tenant)
+user: zoneC
+method: GET
+url: /api/latest/directives/directive2
+response:
+  code: 500
+  content: >-
+    {
+      "action": "directiveDetails",
+      "result": "error",
+      "errorDetails": "Directive with id 'directive2' was not found"
+    }
+---
+description: User with no tenant grant sees nothing
+user: noTenant
+method: GET
+url: /api/latest/directives/directive2
+response:
+  code: 500
+  content: >-
+    {
+      "action": "directiveDetails",
+      "result": "error",
+      "errorDetails": "Directive with id 'directive2' was not found"
+    }
+---
+description: zoneB (read-only) cannot update the directive
+user: zoneB
+method: POST
+url: /api/latest/directives/directive2
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayName": "directive2",
+    "shortDescription": "updated by test",
+    "longDescription": "",
+    "enabled": false,
+    "techniqueName": "rpmPackageInstallation",
+    "techniqueVersion": "7.0",
+    "parameters": {
+      "section": {
+        "name": "sections",
+        "sections": [
+          {
+            "section": {
+              "name": "Check interval",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                    "value": "5"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "RHEL/CentOS/SuSE packages",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDACTION",
+                    "value": "add"
+                  }
+                },
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDLIST",
+                    "value": "vim"
+                  }
+                }
+              ],
+              "sections": [
+                {
+                  "section": {
+                    "name": "Package version",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_CRITERION",
+                          "value": "=="
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                          "value": "default"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "section": {
+                    "name": "Post-modification hook",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                          "value": "false"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "ZMD process"
+            }
+          }
+        ]
+      }
+    },
+    "policyMode": "default",
+    "tags": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateDirective",
+      "result": "error",
+      "errorDetails": "Could not start workflow for change request creation on Directive 'directive2'; cause was: Unexpected: Inconsistency: Object 'rpmPackageInstallation' can't be modified in current security context"
+    }
+---
+description: zoneC cannot update the directive (object not visible)
+user: zoneC
+method: POST
+url: /api/latest/directives/directive2
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayName": "directive2",
+    "shortDescription": "updated by test",
+    "longDescription": "",
+    "enabled": false,
+    "techniqueName": "rpmPackageInstallation",
+    "techniqueVersion": "7.0",
+    "parameters": {
+      "section": {
+        "name": "sections",
+        "sections": [
+          {
+            "section": {
+              "name": "Check interval",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                    "value": "5"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "RHEL/CentOS/SuSE packages",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDACTION",
+                    "value": "add"
+                  }
+                },
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDLIST",
+                    "value": "vim"
+                  }
+                }
+              ],
+              "sections": [
+                {
+                  "section": {
+                    "name": "Package version",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_CRITERION",
+                          "value": "=="
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                          "value": "default"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "section": {
+                    "name": "Post-modification hook",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                          "value": "false"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "ZMD process"
+            }
+          }
+        ]
+      }
+    },
+    "policyMode": "default",
+    "tags": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateDirective",
+      "result": "error",
+      "errorDetails": "Could not find Directive directive2"
+    }
+---
+description: noTenant cannot update the directive (object not visible)
+user: noTenant
+method: POST
+url: /api/latest/directives/directive2
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayName": "directive2",
+    "shortDescription": "updated by test",
+    "longDescription": "",
+    "enabled": false,
+    "techniqueName": "rpmPackageInstallation",
+    "techniqueVersion": "7.0",
+    "parameters": {
+      "section": {
+        "name": "sections",
+        "sections": [
+          {
+            "section": {
+              "name": "Check interval",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                    "value": "5"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "RHEL/CentOS/SuSE packages",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDACTION",
+                    "value": "add"
+                  }
+                },
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDLIST",
+                    "value": "vim"
+                  }
+                }
+              ],
+              "sections": [
+                {
+                  "section": {
+                    "name": "Package version",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_CRITERION",
+                          "value": "=="
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                          "value": "default"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "section": {
+                    "name": "Post-modification hook",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                          "value": "false"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "ZMD process"
+            }
+          }
+        ]
+      }
+    },
+    "policyMode": "default",
+    "tags": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateDirective",
+      "result": "error",
+      "errorDetails": "Could not find Directive directive2"
+    }
+---
+description: zoneAB can update the directive, tag preserved
+user: zoneAB
+method: POST
+url: /api/latest/directives/directive2
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayName": "directive2",
+    "shortDescription": "updated by test",
+    "longDescription": "",
+    "enabled": false,
+    "techniqueName": "rpmPackageInstallation",
+    "techniqueVersion": "7.0",
+    "parameters": {
+      "section": {
+        "name": "sections",
+        "sections": [
+          {
+            "section": {
+              "name": "Check interval",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                    "value": "5"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "RHEL/CentOS/SuSE packages",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDACTION",
+                    "value": "add"
+                  }
+                },
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDLIST",
+                    "value": "vim"
+                  }
+                }
+              ],
+              "sections": [
+                {
+                  "section": {
+                    "name": "Package version",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_CRITERION",
+                          "value": "=="
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                          "value": "default"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "section": {
+                    "name": "Post-modification hook",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                          "value": "false"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "ZMD process"
+            }
+          }
+        ]
+      }
+    },
+    "policyMode": "default",
+    "tags": []
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateDirective",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "directive2",
+            "shortDescription": "updated by test",
+            "longDescription": "",
+            "techniqueName": "rpmPackageInstallation",
+            "techniqueVersion": "7.0",
+            "parameters": {
+              "section": {
+                "name": "sections",
+                "sections": [
+                  {
+                    "section": {
+                      "name": "Check interval",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                            "value": "5"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "RHEL/CentOS/SuSE packages",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDACTION",
+                            "value": "add"
+                          }
+                        },
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDLIST",
+                            "value": "vim"
+                          }
+                        }
+                      ],
+                      "sections": [
+                        {
+                          "section": {
+                            "name": "Package version",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_CRITERION",
+                                  "value": "=="
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                                  "value": "default"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section": {
+                            "name": "Post-modification hook",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                                  "value": "false"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "ZMD process"
+                    }
+                  }
+                ]
+              }
+            },
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "default",
+            "tags": [],
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: admin can update the directive
+user: admin
+method: POST
+url: /api/latest/directives/directive2
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayName": "directive2",
+    "shortDescription": "updated by test",
+    "longDescription": "",
+    "enabled": false,
+    "techniqueName": "rpmPackageInstallation",
+    "techniqueVersion": "7.0",
+    "parameters": {
+      "section": {
+        "name": "sections",
+        "sections": [
+          {
+            "section": {
+              "name": "Check interval",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                    "value": "5"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "RHEL/CentOS/SuSE packages",
+              "vars": [
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDACTION",
+                    "value": "add"
+                  }
+                },
+                {
+                  "var": {
+                    "name": "RPM_PACKAGE_REDLIST",
+                    "value": "vim"
+                  }
+                }
+              ],
+              "sections": [
+                {
+                  "section": {
+                    "name": "Package version",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_CRITERION",
+                          "value": "=="
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                          "value": "default"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "section": {
+                    "name": "Post-modification hook",
+                    "vars": [
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                          "value": ""
+                        }
+                      },
+                      {
+                        "var": {
+                          "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                          "value": "false"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "section": {
+              "name": "ZMD process"
+            }
+          }
+        ]
+      }
+    },
+    "policyMode": "default",
+    "tags": []
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateDirective",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "directive2",
+            "shortDescription": "updated by test",
+            "longDescription": "",
+            "techniqueName": "rpmPackageInstallation",
+            "techniqueVersion": "7.0",
+            "parameters": {
+              "section": {
+                "name": "sections",
+                "sections": [
+                  {
+                    "section": {
+                      "name": "Check interval",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                            "value": "5"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "RHEL/CentOS/SuSE packages",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDACTION",
+                            "value": "add"
+                          }
+                        },
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDLIST",
+                            "value": "vim"
+                          }
+                        }
+                      ],
+                      "sections": [
+                        {
+                          "section": {
+                            "name": "Package version",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_CRITERION",
+                                  "value": "=="
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                                  "value": "default"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section": {
+                            "name": "Post-modification hook",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                                  "value": "false"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "ZMD process"
+                    }
+                  }
+                ]
+              }
+            },
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "default",
+            "tags": [],
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneB (read-only) cannot delete the directive
+user: zoneB
+method: DELETE
+url: /api/latest/directives/directive2
+response:
+  code: 500
+  content: >-
+    {
+      "action": "deleteDirective",
+      "result": "error",
+      "errorDetails": "Could not start workflow for change request creation on Directive 'directive2'; cause was: Error when deleting policy instance with ID 'directive2'.; cause was: Unexpected: Inconsistency: Object 'directive2' can't be deleted by zoneB"
+    }
+---
+description: zoneC delete is a no-op (object not visible)
+user: zoneC
+method: DELETE
+url: /api/latest/directives/directive2
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteDirective",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "",
+            "shortDescription": "",
+            "longDescription": "",
+            "techniqueName": "",
+            "techniqueVersion": "",
+            "parameters": {},
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "",
+            "tags": []
+          }
+        ]
+      }
+    }
+---
+description: noTenant delete is a no-op (object not visible)
+user: noTenant
+method: DELETE
+url: /api/latest/directives/directive2
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteDirective",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "",
+            "shortDescription": "",
+            "longDescription": "",
+            "techniqueName": "",
+            "techniqueVersion": "",
+            "parameters": {},
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "",
+            "tags": []
+          }
+        ]
+      }
+    }
+---
+description: admin can delete the directive
+user: admin
+method: DELETE
+url: /api/latest/directives/directive2
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteDirective",
+      "id": "directive2",
+      "result": "success",
+      "data": {
+        "directives": [
+          {
+            "id": "directive2",
+            "displayName": "directive2",
+            "shortDescription": "updated by test",
+            "longDescription": "",
+            "techniqueName": "rpmPackageInstallation",
+            "techniqueVersion": "7.0",
+            "parameters": {
+              "section": {
+                "name": "sections",
+                "sections": [
+                  {
+                    "section": {
+                      "name": "Check interval",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_CHECK_INTERVAL",
+                            "value": "5"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "RHEL/CentOS/SuSE packages",
+                      "vars": [
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDACTION",
+                            "value": "add"
+                          }
+                        },
+                        {
+                          "var": {
+                            "name": "RPM_PACKAGE_REDLIST",
+                            "value": "vim"
+                          }
+                        }
+                      ],
+                      "sections": [
+                        {
+                          "section": {
+                            "name": "Package version",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_CRITERION",
+                                  "value": "=="
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_VERSION_DEFINITION",
+                                  "value": "default"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section": {
+                            "name": "Post-modification hook",
+                            "vars": [
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_COMMAND",
+                                  "value": ""
+                                }
+                              },
+                              {
+                                "var": {
+                                  "name": "RPM_PACKAGE_POST_HOOK_RUN",
+                                  "value": "false"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "section": {
+                      "name": "ZMD process"
+                    }
+                  }
+                ]
+              }
+            },
+            "priority": 5,
+            "enabled": false,
+            "system": false,
+            "policyMode": "default",
+            "tags": [],
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_directives.yml
@@ -515,7 +515,7 @@ response:
     {
       "action": "updateDirective",
       "result": "error",
-      "errorDetails": "Could not start workflow for change request creation on Directive 'directive2'; cause was: Unexpected: Inconsistency: Object 'rpmPackageInstallation' can't be modified in current security context"
+      "errorDetails": "Could not start workflow for change request creation on Directive 'directive2'; cause was: Unexpected: Inconsistency: Objects can't be created or moved under 'rpmPackageInstallation' in the current security context"
     }
 ---
 description: zoneC cannot update the directive (object not visible)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_groups.yml
@@ -323,7 +323,7 @@ response:
     {
       "action": "deleteGroup",
       "result": "error",
-      "errorDetails": "Error when deleting target GroupTarget(NodeGroupId(NodeGroupUid(tenant-group-1),Revision(default))). All dependent rules where updated (); cause was: Unexpected: Inconsistency: Object 'tenant-group-1' can't be deleted by zoneB"
+      "errorDetails": "Error when deleting target 'group:tenant-group-1'. All dependent rules where updated: (); cause was: Unexpected: Inconsistency: Object 'tenant-group-1' can't be deleted by zoneB"
     }
 ---
 description: zoneC delete is a no-op (object not visible)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_groups.yml
@@ -1,0 +1,426 @@
+---
+description: Admin sees full security tag on tenant-restricted group
+user: admin
+method: GET
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "groupDetails",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "Tenant test group",
+            "description": "a tenant-restricted group",
+            "categoryId": "GroupRoot",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": true,
+            "groupClass": [
+              "group_tenant_group_1",
+              "group_tenant_test_group"
+            ],
+            "properties": [],
+            "target": "group:tenant-group-1",
+            "system": false,
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneAB user sees both zoneA and zoneB in security tag
+user: zoneAB
+method: GET
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "groupDetails",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "Tenant test group",
+            "description": "a tenant-restricted group",
+            "categoryId": "GroupRoot",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": true,
+            "groupClass": [
+              "group_tenant_group_1",
+              "group_tenant_test_group"
+            ],
+            "properties": [],
+            "target": "group:tenant-group-1",
+            "system": false,
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneB user (read-only) sees only zoneB in security tag
+user: zoneB
+method: GET
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "groupDetails",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "Tenant test group",
+            "description": "a tenant-restricted group",
+            "categoryId": "GroupRoot",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": true,
+            "groupClass": [
+              "group_tenant_group_1",
+              "group_tenant_test_group"
+            ],
+            "properties": [],
+            "target": "group:tenant-group-1",
+            "system": false,
+            "security": {
+              "tenants": [
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneC user sees nothing (no object has zoneC tenant)
+user: zoneC
+method: GET
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 500
+  content: >-
+    {
+      "action": "groupDetails",
+      "result": "error",
+      "errorDetails": "Group with id 'tenant-group-1' was not found'"
+    }
+---
+description: User with no tenant grant sees nothing
+user: noTenant
+method: GET
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 500
+  content: >-
+    {
+      "action": "groupDetails",
+      "result": "error",
+      "errorDetails": "Group with id 'tenant-group-1' was not found'"
+    }
+---
+description: zoneB (read-only) cannot update the group
+user: zoneB
+method: POST
+url: /api/latest/groups/tenant-group-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-group-1",
+    "displayName": "Tenant test group",
+    "description": "updated by test",
+    "enabled": true,
+    "system": false,
+    "properties": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateGroup",
+      "result": "error",
+      "errorDetails": "Inconsistency: Object 'tenant-group-1' [zoneA,zoneB] can't be modified by 'zoneB' (perm:tags:[zoneB:r])"
+    }
+---
+description: zoneC cannot update the group (object not visible)
+user: zoneC
+method: POST
+url: /api/latest/groups/tenant-group-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-group-1",
+    "displayName": "Tenant test group",
+    "description": "updated by test",
+    "enabled": true,
+    "system": false,
+    "properties": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateGroup",
+      "result": "error",
+      "errorDetails": "Group with id 'tenant-group-1' was not found'"
+    }
+---
+description: noTenant cannot update the group (object not visible)
+user: noTenant
+method: POST
+url: /api/latest/groups/tenant-group-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-group-1",
+    "displayName": "Tenant test group",
+    "description": "updated by test",
+    "enabled": true,
+    "system": false,
+    "properties": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateGroup",
+      "result": "error",
+      "errorDetails": "Group with id 'tenant-group-1' was not found'"
+    }
+---
+description: zoneAB can update the group, tag preserved
+user: zoneAB
+method: POST
+url: /api/latest/groups/tenant-group-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-group-1",
+    "displayName": "Tenant test group",
+    "description": "updated by test",
+    "enabled": true,
+    "system": false,
+    "properties": []
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateGroup",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "Tenant test group",
+            "description": "updated by test",
+            "categoryId": "GroupRoot",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": true,
+            "groupClass": [
+              "group_tenant_group_1",
+              "group_tenant_test_group"
+            ],
+            "properties": [],
+            "target": "group:tenant-group-1",
+            "system": false,
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: admin can update the group, tag preserved when not specified
+user: admin
+method: POST
+url: /api/latest/groups/tenant-group-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-group-1",
+    "displayName": "Tenant test group",
+    "description": "updated by test",
+    "enabled": true,
+    "system": false,
+    "properties": []
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateGroup",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "Tenant test group",
+            "description": "updated by test",
+            "categoryId": "GroupRoot",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": true,
+            "groupClass": [
+              "group_tenant_group_1",
+              "group_tenant_test_group"
+            ],
+            "properties": [],
+            "target": "group:tenant-group-1",
+            "system": false,
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneB (read-only) cannot delete the group
+user: zoneB
+method: DELETE
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 500
+  content: >-
+    {
+      "action": "deleteGroup",
+      "result": "error",
+      "errorDetails": "Error when deleting target GroupTarget(NodeGroupId(NodeGroupUid(tenant-group-1),Revision(default))). All dependent rules where updated (); cause was: Unexpected: Inconsistency: Object 'tenant-group-1' can't be deleted by zoneB"
+    }
+---
+description: zoneC delete is a no-op (object not visible)
+user: zoneC
+method: DELETE
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteGroup",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "",
+            "description": "",
+            "categoryId": "",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": false,
+            "groupClass": [],
+            "properties": [],
+            "target": "",
+            "system": false
+          }
+        ]
+      }
+    }
+---
+description: noTenant delete is a no-op (object not visible)
+user: noTenant
+method: DELETE
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteGroup",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "",
+            "description": "",
+            "categoryId": "",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": false,
+            "groupClass": [],
+            "properties": [],
+            "target": "",
+            "system": false
+          }
+        ]
+      }
+    }
+---
+description: admin can delete the group
+user: admin
+method: DELETE
+url: /api/latest/groups/tenant-group-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteGroup",
+      "id": "tenant-group-1",
+      "result": "success",
+      "data": {
+        "groups": [
+          {
+            "id": "tenant-group-1",
+            "displayName": "Tenant test group",
+            "description": "updated by test",
+            "categoryId": "GroupRoot",
+            "nodeIds": [],
+            "dynamic": false,
+            "enabled": true,
+            "groupClass": [
+              "group_tenant_group_1",
+              "group_tenant_test_group"
+            ],
+            "properties": [],
+            "target": "group:tenant-group-1",
+            "system": false,
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_laws.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_laws.yml
@@ -1,0 +1,613 @@
+---
+description: LAW4 admin creates a parameter with the exact tenant he chose
+user: admin
+method: PUT
+url: /api/latest/parameters
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "lawParamAdmin",
+    "value": "v",
+    "description": "d",
+    "security": {
+      "tenants": [
+        "zoneA"
+      ]
+    }
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "createParameter",
+      "id": "lawParamAdmin",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamAdmin",
+            "value": "v",
+            "description": "d",
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW4 the parameter created by admin really has tenant zoneA
+user: admin
+method: GET
+url: /api/latest/parameters/lawParamAdmin
+response:
+  code: 200
+  content: >-
+    {
+      "action": "parameterDetails",
+      "id": "lawParamAdmin",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamAdmin",
+            "value": "v",
+            "description": "d",
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW6 zoneA creates a parameter, gets its own tenant
+user: zoneA
+method: PUT
+url: /api/latest/parameters
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "lawParamZoneA",
+    "value": "v",
+    "description": "d"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "createParameter",
+      "id": "lawParamZoneA",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamZoneA",
+            "value": "v",
+            "description": "d"
+          }
+        ]
+      }
+    }
+---
+description: LAW6 the parameter created by zoneA is tagged zoneA
+user: admin
+method: GET
+url: /api/latest/parameters/lawParamZoneA
+response:
+  code: 200
+  content: >-
+    {
+      "action": "parameterDetails",
+      "id": "lawParamZoneA",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamZoneA",
+            "value": "v",
+            "description": "d",
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW6 zoneAB creates a parameter, gets both its tenants
+user: zoneAB
+method: PUT
+url: /api/latest/parameters
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "lawParamZoneAB",
+    "value": "v",
+    "description": "d"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "createParameter",
+      "id": "lawParamZoneAB",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamZoneAB",
+            "value": "v",
+            "description": "d"
+          }
+        ]
+      }
+    }
+---
+description: LAW6 the parameter created by zoneAB is tagged zoneA and zoneB
+user: admin
+method: GET
+url: /api/latest/parameters/lawParamZoneAB
+response:
+  code: 200
+  content: >-
+    {
+      "action": "parameterDetails",
+      "id": "lawParamZoneAB",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamZoneAB",
+            "value": "v",
+            "description": "d",
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW6 noTenant user can not create a parameter
+user: noTenant
+method: PUT
+url: /api/latest/parameters
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "lawParamNoTenant",
+    "value": "v",
+    "description": "d"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "createParameter",
+      "result": "error",
+      "errorDetails": "Inconsistency: Object 'lawParamNoTenant' [*] can't be modified by 'noTenant' (perm:none)"
+    }
+---
+description: LAW7 zoneA only sees its own tenant on a zoneA+zoneB object
+user: zoneA
+method: GET
+url: /api/latest/rules/law-rule-shared
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "law-rule-shared",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "law-rule-shared",
+            "displayName": "law shared rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "Not applied",
+              "details": "No policy defined, Empty groups"
+            },
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW7 zoneA can not change the tenant list (drop zoneB is ignored)
+user: zoneA
+method: POST
+url: /api/latest/rules/law-rule-shared
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "law-rule-shared",
+    "security": {
+      "tenants": [
+        "zoneA"
+      ]
+    }
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateRule",
+      "id": "law-rule-shared",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "law-rule-shared",
+            "displayName": "law shared rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "Not applied",
+              "details": "No policy defined, Empty groups"
+            },
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW7 admin confirms zoneB was preserved after zoneA attempt
+user: admin
+method: GET
+url: /api/latest/rules/law-rule-shared
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "law-rule-shared",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "law-rule-shared",
+            "displayName": "law shared rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "In application"
+            },
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW8 zoneA can not remove the last tenant it sees (empty is ignored)
+user: zoneA
+method: POST
+url: /api/latest/rules/law-rule-shared
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "law-rule-shared",
+    "security": {
+      "tenants": []
+    }
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateRule",
+      "id": "law-rule-shared",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "law-rule-shared",
+            "displayName": "law shared rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "Not applied",
+              "details": "No policy defined, Empty groups"
+            },
+            "security": {
+              "tenants": []
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW8 admin confirms the tenant list is still zoneA and zoneB
+user: admin
+method: GET
+url: /api/latest/rules/law-rule-shared
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "law-rule-shared",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "law-rule-shared",
+            "displayName": "law shared rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "In application"
+            },
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW admin can change the tenant list (drop zoneB)
+user: admin
+method: POST
+url: /api/latest/rules/law-rule-shared
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "law-rule-shared",
+    "security": {
+      "tenants": [
+        "zoneA"
+      ]
+    }
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateRule",
+      "id": "law-rule-shared",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "law-rule-shared",
+            "displayName": "law shared rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "In application"
+            },
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: LAW admin confirms tenant list is now only zoneA
+user: admin
+method: GET
+url: /api/latest/rules/law-rule-shared
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "law-rule-shared",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "law-rule-shared",
+            "displayName": "law shared rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "In application"
+            },
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: cleanup lawParamAdmin
+user: admin
+method: DELETE
+url: /api/latest/parameters/lawParamAdmin
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteParameter",
+      "id": "lawParamAdmin",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamAdmin",
+            "value": "v",
+            "description": "d",
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: cleanup lawParamZoneA
+user: admin
+method: DELETE
+url: /api/latest/parameters/lawParamZoneA
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteParameter",
+      "id": "lawParamZoneA",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamZoneA",
+            "value": "v",
+            "description": "d",
+            "security": {
+              "tenants": [
+                "zoneA"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: cleanup lawParamZoneAB
+user: admin
+method: DELETE
+url: /api/latest/parameters/lawParamZoneAB
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteParameter",
+      "id": "lawParamZoneAB",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "lawParamZoneAB",
+            "value": "v",
+            "description": "d",
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_parameters.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_parameters.yml
@@ -16,7 +16,12 @@ response:
             "id": "tenantParam",
             "value": "tenant-value",
             "description": "a tenant-restricted param",
-            "security": {"tenants": ["zoneA", "zoneB"]}
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
           }
         ]
       }
@@ -39,7 +44,12 @@ response:
             "id": "tenantParam",
             "value": "tenant-value",
             "description": "a tenant-restricted param",
-            "security": {"tenants": ["zoneA", "zoneB"]}
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
           }
         ]
       }
@@ -62,7 +72,11 @@ response:
             "id": "tenantParam",
             "value": "tenant-value",
             "description": "a tenant-restricted param",
-            "security": {"tenants": ["zoneB"]}
+            "security": {
+              "tenants": [
+                "zoneB"
+              ]
+            }
           }
         ]
       }
@@ -78,7 +92,7 @@ response:
     {
       "action": "parameterDetails",
       "result": "error",
-      "errorDetails" : "Could not find Parameter tenantParam"
+      "errorDetails": "Could not find Parameter tenantParam"
     }
 ---
 description: User with no tenant grant sees no security tag
@@ -91,5 +105,220 @@ response:
     {
       "action": "parameterDetails",
       "result": "error",
-      "errorDetails" : "Could not find Parameter tenantParam"
+      "errorDetails": "Could not find Parameter tenantParam"
+    }
+---
+description: zoneB (read-only) cannot update the parameter
+user: zoneB
+method: POST
+url: /api/latest/parameters/tenantParam
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "description": "updated by test",
+    "value": "tenant-value"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateParameter",
+      "result": "error",
+      "errorDetails": "Inconsistency: Object 'tenantParam' [zoneA,zoneB] can't be modified by 'zoneB' (perm:tags:[zoneB:r])"
+    }
+---
+description: zoneC cannot update the parameter (object not visible)
+user: zoneC
+method: POST
+url: /api/latest/parameters/tenantParam
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "description": "updated by test",
+    "value": "tenant-value"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateParameter",
+      "result": "error",
+      "errorDetails": "Could not find Parameter 'tenantParam''"
+    }
+---
+description: noTenant cannot update the parameter (object not visible)
+user: noTenant
+method: POST
+url: /api/latest/parameters/tenantParam
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "description": "updated by test",
+    "value": "tenant-value"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateParameter",
+      "result": "error",
+      "errorDetails": "Could not find Parameter 'tenantParam''"
+    }
+---
+description: zoneAB can update the parameter, tag preserved
+user: zoneAB
+method: POST
+url: /api/latest/parameters/tenantParam
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "description": "updated by test",
+    "value": "tenant-value"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateParameter",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "tenant-value",
+            "description": "updated by test",
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: admin can update the parameter
+user: admin
+method: POST
+url: /api/latest/parameters/tenantParam
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "description": "updated by test",
+    "value": "tenant-value"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateParameter",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "tenant-value",
+            "description": "updated by test",
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneB (read-only) cannot delete the parameter
+user: zoneB
+method: DELETE
+url: /api/latest/parameters/tenantParam
+response:
+  code: 500
+  content: >-
+    {
+      "action": "deleteParameter",
+      "result": "error",
+      "errorDetails": "Inconsistency: Object 'tenantParam' can't be deleted by zoneB"
+    }
+---
+description: zoneC delete is a no-op (object not visible)
+user: zoneC
+method: DELETE
+url: /api/latest/parameters/tenantParam
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteParameter",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "",
+            "description": ""
+          }
+        ]
+      }
+    }
+---
+description: noTenant delete is a no-op (object not visible)
+user: noTenant
+method: DELETE
+url: /api/latest/parameters/tenantParam
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteParameter",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "",
+            "description": ""
+          }
+        ]
+      }
+    }
+---
+description: admin can delete the parameter
+user: admin
+method: DELETE
+url: /api/latest/parameters/tenantParam
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteParameter",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "tenant-value",
+            "description": "updated by test",
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_parameters.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_parameters.yml
@@ -1,0 +1,95 @@
+---
+description: Admin sees full security tag on tenant-restricted parameter
+user: admin
+method: GET
+url: /api/latest/parameters/tenantParam
+response:
+  code: 200
+  content: >-
+    {
+      "action": "parameterDetails",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "tenant-value",
+            "description": "a tenant-restricted param",
+            "security": {"tenants": ["zoneA", "zoneB"]}
+          }
+        ]
+      }
+    }
+---
+description: zoneA user sees only zoneAB in security tag
+user: zoneAB
+method: GET
+url: /api/latest/parameters/tenantParam
+response:
+  code: 200
+  content: >-
+    {
+      "action": "parameterDetails",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "tenant-value",
+            "description": "a tenant-restricted param",
+            "security": {"tenants": ["zoneA", "zoneB"]}
+          }
+        ]
+      }
+    }
+---
+description: zoneA user sees only zoneB in security tag
+user: zoneB
+method: GET
+url: /api/latest/parameters/tenantParam
+response:
+  code: 200
+  content: >-
+    {
+      "action": "parameterDetails",
+      "id": "tenantParam",
+      "result": "success",
+      "data": {
+        "parameters": [
+          {
+            "id": "tenantParam",
+            "value": "tenant-value",
+            "description": "a tenant-restricted param",
+            "security": {"tenants": ["zoneB"]}
+          }
+        ]
+      }
+    }
+---
+description: zoneC user sees nothing
+user: zoneC
+method: GET
+url: /api/latest/parameters/tenantParam
+response:
+  code: 500
+  content: >-
+    {
+      "action": "parameterDetails",
+      "result": "error",
+      "errorDetails" : "Could not find Parameter tenantParam"
+    }
+---
+description: User with no tenant grant sees no security tag
+user: noTenant
+method: GET
+url: /api/latest/parameters/tenantParam
+response:
+  code: 500
+  content: >-
+    {
+      "action": "parameterDetails",
+      "result": "error",
+      "errorDetails" : "Could not find Parameter tenantParam"
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_rules.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_rules.yml
@@ -18,14 +18,25 @@ response:
             "categoryId": "rootRuleCategory",
             "shortDescription": "A rule for tenant testing",
             "longDescription": "",
-            "directives": ["directive1"],
-            "targets": ["special:all"],
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
             "enabled": true,
             "system": false,
             "tags": [],
             "policyMode": "enforce",
-            "status": {"value": "In application"},
-            "security": {"tenants": ["zoneA", "zoneB"]}
+            "status": {
+              "value": "In application"
+            },
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
           }
         ]
       }
@@ -50,14 +61,26 @@ response:
             "categoryId": "rootRuleCategory",
             "shortDescription": "A rule for tenant testing",
             "longDescription": "",
-            "directives": ["directive1"],
-            "targets": ["special:all"],
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
             "enabled": true,
             "system": false,
             "tags": [],
             "policyMode": "enforce",
-            "status": {"value": "Not applied", "details": "No policy defined, Empty groups"},
-            "security": {"tenants": ["zoneA", "zoneB"]}
+            "status": {
+              "value": "Not applied",
+              "details": "No policy defined, Empty groups"
+            },
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
           }
         ]
       }
@@ -82,14 +105,25 @@ response:
             "categoryId": "rootRuleCategory",
             "shortDescription": "A rule for tenant testing",
             "longDescription": "",
-            "directives": ["directive1"],
-            "targets": ["special:all"],
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
             "enabled": true,
             "system": false,
             "tags": [],
             "policyMode": "enforce",
-            "status": {"value": "Not applied", "details": "No policy defined, Empty groups"},
-            "security": {"tenants": ["zoneB"]}
+            "status": {
+              "value": "Not applied",
+              "details": "No policy defined, Empty groups"
+            },
+            "security": {
+              "tenants": [
+                "zoneB"
+              ]
+            }
           }
         ]
       }
@@ -114,14 +148,25 @@ response:
             "categoryId": "rootRuleCategory",
             "shortDescription": "A rule for tenant testing",
             "longDescription": "",
-            "directives": ["directive1"],
-            "targets": ["special:all"],
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              "special:all"
+            ],
             "enabled": true,
             "system": false,
             "tags": [],
             "policyMode": "enforce",
-            "status": {"value": "Not applied", "details": "No policy defined, Empty groups"},
-            "security": {"tenants": ["zoneB"]}
+            "status": {
+              "value": "Not applied",
+              "details": "No policy defined, Empty groups"
+            },
+            "security": {
+              "tenants": [
+                "zoneB"
+              ]
+            }
           }
         ]
       }
@@ -136,6 +181,358 @@ response:
   content: >-
     {
       "action": "ruleDetails",
-      "result" : "error",
-      "errorDetails" : "Rule with id 'tenant-rule-1' was not found"
+      "result": "error",
+      "errorDetails": "Rule with id 'tenant-rule-1' was not found"
+    }
+---
+description: zoneB (read-only) cannot update the rule
+user: zoneB
+method: POST
+url: /api/latest/rules/tenant-rule-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-rule-1",
+    "displayName": "Tenant test rule",
+    "shortDescription": "updated by test",
+    "directives": [
+      "directive1"
+    ],
+    "targets": [
+      "special:all"
+    ],
+    "enabled": true,
+    "system": false,
+    "tags": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateRule",
+      "result": "error",
+      "errorDetails": "Inconsistency: Object 'tenant-rule-1' [zoneA,zoneB] can't be modified by 'zoneB' (perm:tags:[zoneB:r])"
+    }
+---
+description: zoneC cannot update the rule (object not visible)
+user: zoneC
+method: POST
+url: /api/latest/rules/tenant-rule-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-rule-1",
+    "displayName": "Tenant test rule",
+    "shortDescription": "updated by test",
+    "directives": [
+      "directive1"
+    ],
+    "targets": [
+      "special:all"
+    ],
+    "enabled": true,
+    "system": false,
+    "tags": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateRule",
+      "result": "error",
+      "errorDetails": "Rule with id 'tenant-rule-1' was not found"
+    }
+---
+description: noTenant cannot update the rule (object not visible)
+user: noTenant
+method: POST
+url: /api/latest/rules/tenant-rule-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-rule-1",
+    "displayName": "Tenant test rule",
+    "shortDescription": "updated by test",
+    "directives": [
+      "directive1"
+    ],
+    "targets": [
+      "special:all"
+    ],
+    "enabled": true,
+    "system": false,
+    "tags": []
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateRule",
+      "result": "error",
+      "errorDetails": "Rule with id 'tenant-rule-1' was not found"
+    }
+---
+description: zoneAB can update the rule, tag preserved
+user: zoneAB
+method: POST
+url: /api/latest/rules/tenant-rule-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-rule-1",
+    "displayName": "Tenant test rule",
+    "shortDescription": "updated by test",
+    "directives": [
+      "directive1"
+    ],
+    "targets": [
+      "special:all"
+    ],
+    "enabled": true,
+    "system": false,
+    "tags": []
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateRule",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "Tenant test rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "updated by test",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              {
+                "include": {
+                  "or": [
+                    "special:all"
+                  ]
+                },
+                "exclude": {
+                  "or": []
+                }
+              }
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "Not applied",
+              "details": "No policy defined, Empty groups"
+            },
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: admin can update the rule
+user: admin
+method: POST
+url: /api/latest/rules/tenant-rule-1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "tenant-rule-1",
+    "displayName": "Tenant test rule",
+    "shortDescription": "updated by test",
+    "directives": [
+      "directive1"
+    ],
+    "targets": [
+      "special:all"
+    ],
+    "enabled": true,
+    "system": false,
+    "tags": []
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action": "updateRule",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "Tenant test rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "updated by test",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              {
+                "include": {
+                  "or": [
+                    "special:all"
+                  ]
+                },
+                "exclude": {
+                  "or": []
+                }
+              }
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "In application"
+            },
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneB (read-only) cannot delete the rule
+user: zoneB
+method: DELETE
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 500
+  content: >-
+    {
+      "action": "deleteRule",
+      "result": "error",
+      "errorDetails": "Inconsistency: Object 'tenant-rule-1' can't be deleted by zoneB"
+    }
+---
+description: zoneC delete is a no-op (object not visible)
+user: zoneC
+method: DELETE
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteRule",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "",
+            "categoryId": "",
+            "shortDescription": "",
+            "longDescription": "",
+            "directives": [],
+            "targets": [],
+            "enabled": false,
+            "system": false,
+            "tags": []
+          }
+        ]
+      }
+    }
+---
+description: noTenant delete is a no-op (object not visible)
+user: noTenant
+method: DELETE
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteRule",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "",
+            "categoryId": "",
+            "shortDescription": "",
+            "longDescription": "",
+            "directives": [],
+            "targets": [],
+            "enabled": false,
+            "system": false,
+            "tags": []
+          }
+        ]
+      }
+    }
+---
+description: admin can delete the rule
+user: admin
+method: DELETE
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "deleteRule",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "Tenant test rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "updated by test",
+            "longDescription": "",
+            "directives": [
+              "directive1"
+            ],
+            "targets": [
+              {
+                "include": {
+                  "or": [
+                    "special:all"
+                  ]
+                },
+                "exclude": {
+                  "or": []
+                }
+              }
+            ],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {
+              "value": "In application"
+            },
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_rules.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_rules.yml
@@ -1,0 +1,141 @@
+---
+description: Admin sees full security tag on tenant-restricted rule
+user: admin
+method: GET
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "Tenant test rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": ["directive1"],
+            "targets": ["special:all"],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {"value": "In application"},
+            "security": {"tenants": ["zoneA", "zoneB"]}
+          }
+        ]
+      }
+    }
+---
+description: zoneA user sees only zoneAB in security tag
+user: zoneAB
+method: GET
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "Tenant test rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": ["directive1"],
+            "targets": ["special:all"],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {"value": "Not applied", "details": "No policy defined, Empty groups"},
+            "security": {"tenants": ["zoneA", "zoneB"]}
+          }
+        ]
+      }
+    }
+---
+description: zoneA user sees only zoneA in security tag
+user: zoneB
+method: GET
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "Tenant test rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": ["directive1"],
+            "targets": ["special:all"],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {"value": "Not applied", "details": "No policy defined, Empty groups"},
+            "security": {"tenants": ["zoneB"]}
+          }
+        ]
+      }
+    }
+---
+description: zoneB user sees only zoneB in security tag
+user: zoneB
+method: GET
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "ruleDetails",
+      "id": "tenant-rule-1",
+      "result": "success",
+      "data": {
+        "rules": [
+          {
+            "id": "tenant-rule-1",
+            "displayName": "Tenant test rule",
+            "categoryId": "rootRuleCategory",
+            "shortDescription": "A rule for tenant testing",
+            "longDescription": "",
+            "directives": ["directive1"],
+            "targets": ["special:all"],
+            "enabled": true,
+            "system": false,
+            "tags": [],
+            "policyMode": "enforce",
+            "status": {"value": "Not applied", "details": "No policy defined, Empty groups"},
+            "security": {"tenants": ["zoneB"]}
+          }
+        ]
+      }
+    }
+---
+description: User with no tenant grant sees no security tag
+user: noTenant
+method: GET
+url: /api/latest/rules/tenant-rule-1
+response:
+  code: 500
+  content: >-
+    {
+      "action": "ruleDetails",
+      "result" : "error",
+      "errorDetails" : "Rule with id 'tenant-rule-1' was not found"
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_techniques.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_techniques.yml
@@ -1,0 +1,253 @@
+---
+description: Admin sees all active techniques, tenant one carries full tag
+user: admin
+method: GET
+url: /api/latest/techniques/versions
+response:
+  code: 200
+  content: >-
+    {
+      "action": "listTechniques",
+      "result": "success",
+      "data": {
+        "techniques": [
+          {
+            "name": "inventory",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "technique_with_blocks",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "test-migrate-select",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "server-roles",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "technique_by_Rudder",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "technique_any",
+            "versions": [
+              "1.0",
+              "2.0"
+            ]
+          },
+          {
+            "name": "server-common",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "packageManagement",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "common",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "rudder-service-relayd",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "rudder-service-webapp",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "test_import_export_archive",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "rudder-service-apache",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "distributePolicy",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "a_simple_yaml_technique",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "rudder-service-postgresql",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "rpmPackageInstallation",
+            "versions": [
+              "7.0"
+            ],
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          },
+          {
+            "name": "test_18205",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "copyGitFile",
+            "versions": [
+              "2.3"
+            ]
+          },
+          {
+            "name": "clockConfiguration",
+            "versions": [
+              "3.0"
+            ]
+          },
+          {
+            "name": "Create_file",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "fileTemplate",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "rudder-service-slapd",
+            "versions": [
+              "1.0"
+            ]
+          },
+          {
+            "name": "genericVariableDefinition",
+            "versions": [
+              "1.0",
+              "2.0"
+            ]
+          }
+        ]
+      }
+    }
+---
+description: zoneAB user sees the tenant active technique with both zoneA and zoneB
+user: zoneAB
+method: GET
+url: /api/latest/techniques/versions
+response:
+  code: 200
+  content: >-
+    {
+      "action": "listTechniques",
+      "result": "success",
+      "data": {
+        "techniques": [
+          {
+            "name": "rpmPackageInstallation",
+            "versions": [
+              "7.0"
+            ],
+            "security": {
+              "tenants": [
+                "zoneA",
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneB user (read-only) sees the tenant active technique with only zoneB
+user: zoneB
+method: GET
+url: /api/latest/techniques/versions
+response:
+  code: 200
+  content: >-
+    {
+      "action": "listTechniques",
+      "result": "success",
+      "data": {
+        "techniques": [
+          {
+            "name": "rpmPackageInstallation",
+            "versions": [
+              "7.0"
+            ],
+            "security": {
+              "tenants": [
+                "zoneB"
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: zoneC user sees no active technique (no object has zoneC tenant)
+user: zoneC
+method: GET
+url: /api/latest/techniques/versions
+response:
+  code: 200
+  content: >-
+    {
+      "action": "listTechniques",
+      "result": "success",
+      "data": {
+        "techniques": []
+      }
+    }
+---
+description: User with no tenant grant sees no active technique
+user: noTenant
+method: GET
+url: /api/latest/techniques/versions
+response:
+  code: 200
+  content: >-
+    {
+      "action": "listTechniques",
+      "result": "success",
+      "data": {
+        "techniques": []
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -184,7 +184,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
       .map(g => (g.id, Chunk.fromIterable(g.serverList)))
       .toMap
 
-    override def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
+    override def getAllNodeIdsChunk()(using qc: QueryContext): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
       nodesByGroup.succeed
     }
 
@@ -204,31 +204,33 @@ class MockCompliance(mockDirectives: MockDirectives) {
           FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, g.description, g.isEnabled, g.isSystem, g.security)
         }),
         isSystem = true,
-        security = None
+        security = Some(SecurityTag.Open) // root must be opn
       ).succeed
     }
 
-    def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[NodeGroup]] = nodeGroups.filter(x => ids.contains(x.id)).succeed
+    def getAllByIds(ids: Seq[NodeGroupId])(using qc: QueryContext): IOResult[Seq[NodeGroup]] =
+      nodeGroups.filter(x => ids.contains(x.id)).succeed
 
-    def getGroupCategory(id: NodeGroupCategoryId): IOResult[NodeGroupCategory] =
+    def getGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory] =
       getFullGroupLibrary()(using QueryContext.testQC).map(_.toNodeGroupCategory)
 
-    def categoryExists(id:       NodeGroupCategoryId): IOResult[Boolean]           = ???
-    def getNodeGroupCategory(id: NodeGroupId):         IOResult[NodeGroupCategory] = ???
-    def getAll():        IOResult[Seq[NodeGroup]]                = ???
-    def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] = ???
+    def categoryExists(id:                   NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean]                = ???
+    def getNodeGroupCategory(id:             NodeGroupId)(using qc:         QueryContext): IOResult[NodeGroupCategory]      = ???
+    def getAll()(using qc:                   QueryContext): IOResult[Seq[NodeGroup]] = ???
+    def getAllNodeIds()(using qc:            QueryContext): IOResult[Map[NodeGroupId, Set[NodeId]]] = ???
     def getGroupsByCategory(includeSystem: Boolean)(implicit
         qc: QueryContext
     ): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
-    def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
-    def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
-    def getRootCategory():     NodeGroupCategory                                                 = ???
-    def getRootCategoryPure(): IOResult[NodeGroupCategory]                                       = ???
-    def getCategoryHierarchy:  IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = ???
-    def getAllGroupCategories(includeSystem: Boolean):             IOResult[Seq[NodeGroupCategory]]  = ???
-    def getParentGroupCategory(id:           NodeGroupCategoryId): IOResult[NodeGroupCategory]       = ???
-    def getParents_NodeGroupCategory(id:     NodeGroupCategoryId): IOResult[List[NodeGroupCategory]] = ???
-    def getAllNonSystemCategories(): IOResult[Seq[NodeGroupCategory]] = ???
+    def findGroupWithAnyMember(nodeIds:      Seq[NodeId])(using qc:         QueryContext): IOResult[Seq[NodeGroupId]]       = ???
+    def findGroupWithAllMember(nodeIds:      Seq[NodeId])(using qc:         QueryContext): IOResult[Seq[NodeGroupId]]       = ???
+    def getRootCategory()(using qc:          QueryContext): NodeGroupCategory = ???
+    def getRootCategoryPure()(using qc:      QueryContext): IOResult[NodeGroupCategory] = ???
+    def getCategoryHierarchy(using qc:       QueryContext): IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = ???
+    def getAllGroupCategories(includeSystem: Boolean)(using qc:             QueryContext): IOResult[Seq[NodeGroupCategory]] = ???
+    def getParentGroupCategory(id:           NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory]      = ???
+    def getParents_NodeGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[List[NodeGroupCategory]] =
+      ???
+    def getAllNonSystemCategories()(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] = ???
   }
 
   object nodeFactRepo extends NodeFactRepository {
@@ -250,16 +252,16 @@ class MockCompliance(mockDirectives: MockDirectives) {
       ).map(n => (n.id, n)).toMap.view.succeed
     }
 
-    override def getNumberOfManagedNodes(): IOResult[RuntimeFlags] = 8.succeed
-    def registerChangeCallbackAction(callback: NodeFactChangeEventCallback): IOResult[Unit] = ???
-    def getStatus(id:                          NodeId)(implicit qc:   QueryContext): IOResult[InventoryStatus] = ???
-    def get(nodeId:                            NodeId)(implicit qc:   QueryContext, status:    SelectNodeStatus): IOResult[Option[CoreNodeFact]]  = ???
+    override def getNumberOfManagedNodes()(using qc: QueryContext): IOResult[RuntimeFlags] = 8.succeed
+    def registerChangeCallbackAction(callback:       NodeFactChangeEventCallback): IOResult[Unit] = ???
+    def getStatus(id:                                NodeId)(implicit qc:   QueryContext): IOResult[InventoryStatus] = ???
+    def get(nodeId:                                  NodeId)(implicit qc:   QueryContext, status:    SelectNodeStatus): IOResult[Option[CoreNodeFact]]  = ???
     def slowGet(
         nodeId: NodeId
     )(implicit qc: QueryContext, status: SelectNodeStatus, attrs: SelectFacts): IOResult[Option[NodeFact]] = ???
-    def getNodesBySoftwareName(softName:       String): IOResult[List[(NodeId, Software)]] = ???
-    def slowGetAll()(implicit qc:              QueryContext, status:  SelectNodeStatus, attrs: SelectFacts):      IOStream[NodeFact]              = ???
-    def save(nodeFact:                         NodeFact)(implicit cc: ChangeContext, attrs:    SelectFacts):      IOResult[NodeFactChangeEventCC] = ???
+    def getNodesBySoftwareName(softName:             String)(using qc:      QueryContext): IOResult[List[(NodeId, Software)]] = ???
+    def slowGetAll()(implicit qc:                    QueryContext, status:  SelectNodeStatus, attrs: SelectFacts):      IOStream[NodeFact]              = ???
+    def save(nodeFact:                               NodeFact)(implicit cc: ChangeContext, attrs:    SelectFacts):      IOResult[NodeFactChangeEventCC] = ???
     def setSecurityTag(nodeId: NodeId, tag: Option[SecurityTag])(implicit cc: ChangeContext): IOResult[NodeFactChangeEventCC] =
       ???
     def updateInventory(inventory: FullInventory, software: Option[Iterable[Software]])(implicit
@@ -272,37 +274,21 @@ class MockCompliance(mockDirectives: MockDirectives) {
 
   // We want to ignore rules that are defined in `MockRules` because they may target all nodes and pollute our compliance tests
   private def rulesRepo(rules: List[Rule]) = new RoRuleRepository with WoRuleRepository {
-    override def getOpt(ruleId: RuleId):         IOResult[Option[Rule]] = {
+    override def getOpt(ruleId: RuleId)(using qc: QueryContext):         IOResult[Option[Rule]] = {
       rules.find(_.id == ruleId).succeed
     }
-    override def getAll(includeSystem: Boolean): IOResult[Seq[Rule]]    = {
+    override def getAll(includeSystem: Boolean)(using qc: QueryContext): IOResult[Seq[Rule]]    = {
       rules.succeed
     }
 
-    override def getIds(includeSystem:            Boolean): IOResult[Set[RuleId]] = ???
-    override def create(rule:                     Rule, modId:   ModificationId, actor: EventActor, reason: Option[String]): IOResult[AddRuleDiff] = ???
-    override def update(
-        rule:   Rule,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[ModifyRuleDiff]] = ???
-    override def load(rule:                       Rule, modId:   ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]        = ???
-    override def unload(ruleId:                   RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]        = ???
-    override def updateSystem(
-        rule:   Rule,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[ModifyRuleDiff]] = ???
-    override def delete(id: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[DeleteRuleDiff] =
-      ???
-    override def deleteSystemRule(
-        id:     RuleId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[DeleteRuleDiff] = ???
+    override def getIds(includeSystem:            Boolean)(using qc: QueryContext):  IOResult[Set[RuleId]]            = ???
+    override def create(rule:                     Rule)(using cc:    ChangeContext): IOResult[AddRuleDiff]            = ???
+    override def update(rule:                     Rule)(using cc:    ChangeContext): IOResult[Option[ModifyRuleDiff]] = ???
+    override def load(rule:                       Rule)(using cc:    ChangeContext): IOResult[Unit]                   = ???
+    override def unload(ruleId:                   RuleId)(using cc:  ChangeContext): IOResult[Unit]                   = ???
+    override def updateSystem(rule:               Rule)(using cc:    ChangeContext): IOResult[Option[ModifyRuleDiff]] = ???
+    override def delete(id:                       RuleId)(using cc:  ChangeContext): IOResult[DeleteRuleDiff]         = ???
+    override def deleteSystemRule(id:             RuleId)(using cc:  ChangeContext): IOResult[DeleteRuleDiff]         = ???
     override def swapRules(newRules:              Seq[Rule]): IOResult[RuleArchiveId] = ???
     override def deleteSavedRuleArchiveId(saveId: RuleArchiveId): IOResult[Unit] = ???
   }
@@ -897,7 +883,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
   val argon2Params              = Argon2EncoderParams(Argon2Memory(0), Argon2Iterations(0), Argon2Parallelism(0))
   val passwordEncoderDispatcher = new PasswordEncoderDispatcher(0, argon2Params)
 
-  val userService: FileUserDetailListProvider = {
+  val fileUserDetailListProvider: FileUserDetailListProvider = {
     val usersFile = UserFile(usersConfigFile.pathAsString, usersInputStream)
 
     val roleApiMapping = new RoleApiMapping(new ExtensibleAuthorizationApiMapping(Nil))
@@ -911,7 +897,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
   val userManagementService: UserManagementService = {
     new UserManagementService(
       userRepo,
-      userService,
+      fileUserDetailListProvider,
       passwordEncoderDispatcher,
       UserFile(usersConfigFile.pathAsString, usersInputStream).succeed
     )
@@ -920,11 +906,6 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
   val providerRoleExtension: Map[String, ProviderRoleExtension] = Map("file" -> ProviderRoleExtension.WithOverride)
   val authBackendProviders:  Set[String]                        = Set("file")
 
-  object tenantRepo extends TenantService {
-    override def tenantsEnabled: Boolean           = false
-    override def getStatus:      UIO[TenantStatus] = TenantStatus.Disabled.succeed
-    override def updateTenants(ids: Set[TenantId]): IOResult[Unit] = ???
-  }
 }
 
 object MockUserManagement {
@@ -1060,7 +1041,7 @@ class MockApiAccountService(userService: com.normation.rudder.users.UserService)
         isEnabled = true,
         creationDate = accountCreationDate,
         lastAuthentication = AccountLastAuthentication.AtDate(accountCreationDate.plus(1.minute)),
-        TenantAccessGrant.ByTenants(Chunk(TenantId("zone1")))
+        TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zone1"))))
       )
     ).map(a => (a.id, a)).toMap
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -43,8 +43,6 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.errors.IOResult
 import com.normation.errors.effectUioUnit
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.MockDirectives
 import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockTechniques
@@ -105,7 +103,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
   val mockGitRepo   = new MockGitConfigRepo("")
 
   val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
-  val mockDirectives = new MockDirectives(mockTechniques)
+  val mockDirectives = new MockDirectives(mockTechniques, restTestSetUp.mockTenants)
 
   val testDir: File = File(
     s"/tmp/test-rudder-response-content-${DateFormaterService.serializeOffsetDateTime(OffsetDateTime.now(ZoneOffset.UTC))}"
@@ -239,11 +237,8 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
       _ <- restTestSetUp.archiveAPIModule.rootDirName.set(archiveName)
       r <- restTestSetUp.mockRules.ruleRepo.getOpt(RuleId(RuleUid("rule1"))).notOptional(s"test")
       _ <- restTestSetUp.mockRules.ruleRepo.update(
-             r.copy(categoryId = RuleCategoryId("category1")),
-             ModificationId("rule"),
-             EventActor("test"),
-             None
-           )
+             r.copy(categoryId = RuleCategoryId("category1"))
+           )(using qc.newCC())
     } yield {}).runNow
 
     restTest.testGETResponse("/api/latest/archives/export?rules=rule1&include=groups,techniques") {
@@ -1096,7 +1091,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
       r <- restTestSetUp.mockRules.ruleRepo.getOpt(RuleId(RuleUid(ruleId))).notOptional(s"missing ${ruleId} in test")
       _ <-
         restTestSetUp.mockRules.ruleRepo
-          .update(r.copy(shortDescription = newDesc), ModificationId("rule"), EventActor("test"), None)
+          .update(r.copy(shortDescription = newDesc))(using qc.newCC())
     } yield ()).runNow
     // update technique
     val techniqueId = "Create_file/1.0"

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.MockDirectives
 import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockRules
 import com.normation.rudder.MockTechniques
+import com.normation.rudder.MockTenants
 import com.normation.rudder.apidata.JsonQueryObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.JRRuleTarget.*
@@ -59,9 +60,10 @@ import zio.test.junit.ZTestJUnitRunner
 class RestDataExtractorTest extends ZIOSpecDefault {
 
   val mockGitRepo = new MockGitConfigRepo("")
+  val mockTenants = new MockTenants()
   val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
-  val mockDirectives = new MockDirectives(mockTechniques)
-  val mockRules      = new MockRules()
+  val mockDirectives = new MockDirectives(mockTechniques, mockTenants)
+  val mockRules      = new MockRules(mockTenants)
 
   override def spec: Spec[TestEnvironment & Scope, Any] = {
     suite("All tests")(

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -234,7 +234,11 @@ class TestUserService extends UserService {
 
   private val users = Map(
     "admin"    -> makeUser("test-user", TenantAccessGrant.All),
-    "zoneAB"    -> makeUser(
+    "zoneA"    -> makeUser(
+      "zoneA",
+      TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA"), TenantPermission.ReadWrite)))
+    ),
+    "zoneAB"   -> makeUser(
       "zoneAB",
       TenantAccessGrant.ByTenants(
         Chunk(

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -152,9 +152,7 @@ import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestServi
 import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestServiceImpl
 import com.normation.rudder.services.workflows.DefaultWorkflowLevel
 import com.normation.rudder.services.workflows.NoWorkflowServiceImpl
-import com.normation.rudder.tenants.ChangeContext
-import com.normation.rudder.tenants.QueryContext
-import com.normation.rudder.tenants.TenantAccessGrant
+import com.normation.rudder.tenants.*
 import com.normation.rudder.users.*
 import com.normation.rudder.web.model.DirectiveField
 import com.normation.rudder.web.model.LinkUtil
@@ -220,20 +218,53 @@ import zio.test.*
  */
 
 /**
- * A stub user service with full rights to API
+ * A stub user service with full rights to API.
+ * This is a special user service where we can choose which is current user by name.
+ * This only work because all API tests are sequential.
  */
 class TestUserService extends UserService {
-  val user:                    AuthenticatedUser         = new AuthenticatedUser {
-    override val account:     RudderAccount     = RudderAccount.User("test-user", UserPassword.unsafeHashed("pass"))
+  def makeUser(n: String, grant: TenantAccessGrant) = new AuthenticatedUser {
+    override val account:     RudderAccount     = RudderAccount.User(n, UserPassword.unsafeHashed("pass"))
     override val authz:       Rights            = Rights.AnyRights
     override val apiAuthz:    ApiAuthz          = ApiAuthz.allAuthz
-    override val accessGrant: TenantAccessGrant = TenantAccessGrant.All
-
-    override def actorIp: Option[String] = None
-
+    override val accessGrant: TenantAccessGrant = grant
+    override def actorIp:     Option[String]    = None
     override def checkRights(auth: AuthorizationType): Boolean = true
   }
-  override val getCurrentUser: Option[AuthenticatedUser] = Some(user)
+
+  private val users = Map(
+    "admin"    -> makeUser("test-user", TenantAccessGrant.All),
+    "zoneAB"    -> makeUser(
+      "zoneAB",
+      TenantAccessGrant.ByTenants(
+        Chunk(
+          TenantAccess(TenantId("zoneA"), TenantPermission.ReadWrite),
+          TenantAccess(TenantId("zoneB"), TenantPermission.ReadWrite)
+        )
+      )
+    ),
+    "zoneB"    -> makeUser(
+      "zoneB",
+      TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneB"), TenantPermission.Read)))
+    ),
+    "zoneC"    -> makeUser(
+      "zoneC",
+      TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneC"), TenantPermission.ReadWrite)))
+    ),
+    "noTenant" -> makeUser("noTenant", TenantAccessGrant.None)
+  )
+
+  // it's a var, but it should be used only in sequential set-up for rest tests
+  private var currentUser = users("admin")
+
+  def setCurrentUser(name: String): Unit = {
+    users.get(name) match {
+      case Some(u) => currentUser = u
+      case None    => throw new IllegalArgumentException(s"Unknown user '${name}'; known users: '${users.keys.mkString("','")}'")
+    }
+  }
+
+  override def getCurrentUser: Option[AuthenticatedUser] = Some(currentUser)
 }
 
 /*
@@ -243,7 +274,7 @@ class TestUserService extends UserService {
 class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiVersions) {
   import RestTestSetUp.*
 
-  implicit val userService: TestUserService = new TestUserService
+  given userService: UserService = new TestUserService
 
   // Instantiate Service needed to feed System API constructor
 
@@ -254,13 +285,14 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     def registerCallback(callback: TechniquesLibraryUpdateNotification): Unit = {}
   }
 
+  val mockTenants = new MockTenants()
   val mockGitRepo = new MockGitConfigRepo("")
   val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
-  val mockDirectives                                 = new MockDirectives(mockTechniques)
-  val mockRules                                      = new MockRules()
-  val mockParameters                                 = new MockGlobalParam()
-  val mockNodes                                      = new MockNodes()
-  val mockNodeGroups                                 = new MockNodeGroups(mockNodes, mockParameters)
+  val mockDirectives                                 = new MockDirectives(mockTechniques, mockTenants)
+  val mockRules                                      = new MockRules(mockTenants)
+  val mockParameters                                 = new MockGlobalParam(mockTenants)
+  val mockNodes                                      = new MockNodes(mockTenants)
+  val mockNodeGroups                                 = new MockNodeGroups(mockNodes, mockParameters, mockTenants)
   val mockLdapQueryParsing                           = new MockLdapQueryParsing(mockGitRepo, mockNodeGroups)
   val uuidGen                                        = new StringUuidGeneratorImpl()
   val mockConfigRepo                                 = new MockConfigRepo(mockTechniques, mockDirectives, mockRules, mockNodeGroups, mockLdapQueryParsing)
@@ -1069,9 +1101,9 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     ),
     new UserManagementApiImpl(
       mockUserManagement.userRepo,
-      mockUserManagement.userService,
+      mockUserManagement.fileUserDetailListProvider,
       mockUserManagement.userManagementService,
-      mockUserManagement.tenantRepo,
+      mockTenants.tenantRepo,
       () => mockUserManagement.providerRoleExtension,
       () => mockUserManagement.authBackendProviders
     ),
@@ -1084,7 +1116,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     new RecentChangesAPI(fakeNodeChangesService)
   )
 
-  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, Some(userService))
+  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, userService)
 
   // RestHelpers
   liftRules.statelessDispatch.append(RestStatus)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
@@ -41,8 +41,6 @@ import better.files.File
 import com.normation.cfclerk.domain.TechniqueVersionHelper
 import com.normation.errors
 import com.normation.errors.*
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.FullInventory
 import com.normation.inventory.domain.InventoryStatus
 import com.normation.inventory.domain.NodeId
@@ -50,6 +48,7 @@ import com.normation.inventory.domain.Software
 import com.normation.rudder.MockDirectives
 import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockTechniques
+import com.normation.rudder.MockTenants
 import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
@@ -128,9 +127,10 @@ object RunTestCompliance {
 
 class SetUpCompliance(numNodes: Int, numRules: Int) {
 
-  private val mockGitRepo    = new MockGitConfigRepo("")
-  private val mockTechniques = MockTechniques(mockGitRepo)
-  private val mockDirectives = new MockDirectives(mockTechniques)
+  private val mockGitRepo = new MockGitConfigRepo("")
+  private val mockTenants = new MockTenants()
+  private val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
+  private val mockDirectives = new MockDirectives(mockTechniques, mockTenants)
   private val directives     = mockDirectives.directives
 
   private val kindNodes = 6
@@ -145,7 +145,7 @@ class SetUpCompliance(numNodes: Int, numRules: Int) {
   private def nodeGroupsRepo(nodeGroups: List[NodeGroup]) = new RoNodeGroupRepository {
     val nodesByGroup: Map[NodeGroupId, Chunk[NodeId]] = nodeGroups.map(g => (g.id, Chunk.fromIterable(g.serverList))).toMap
 
-    override def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
+    override def getAllNodeIdsChunk()(using qc: QueryContext): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
       nodesByGroup.succeed
     }
 
@@ -165,28 +165,29 @@ class SetUpCompliance(numNodes: Int, numRules: Int) {
           FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, g.description, g.isEnabled, g.isSystem, g.security)
         }),
         isSystem = true,
-        security = None
+        security = Some(SecurityTag.Open) // root must be open
       ).succeed
     }
 
-    def categoryExists(id:       NodeGroupCategoryId): IOResult[Boolean]           = ???
-    def getNodeGroupCategory(id: NodeGroupId):         IOResult[NodeGroupCategory] = ???
-    def getAll(): IOResult[Seq[NodeGroup]] = ???
-    def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[NodeGroup]] = ???
-    def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] = ???
+    def categoryExists(id:                   NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean]                = ???
+    def getNodeGroupCategory(id:             NodeGroupId)(using qc:         QueryContext): IOResult[NodeGroupCategory]      = ???
+    def getAll()(using qc:                   QueryContext): IOResult[Seq[NodeGroup]] = ???
+    def getAllByIds(ids:                     Seq[NodeGroupId])(using qc:    QueryContext): IOResult[Seq[NodeGroup]]         = ???
+    def getAllNodeIds()(using qc:            QueryContext): IOResult[Map[NodeGroupId, Set[NodeId]]] = ???
     def getGroupsByCategory(includeSystem: Boolean)(implicit
         qc: QueryContext
     ): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
-    def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
-    def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
-    def getRootCategory():     NodeGroupCategory                                                 = ???
-    def getRootCategoryPure(): IOResult[NodeGroupCategory]                                       = ???
-    def getCategoryHierarchy:  IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = ???
-    def getAllGroupCategories(includeSystem: Boolean):             IOResult[Seq[NodeGroupCategory]]  = ???
-    def getGroupCategory(id:                 NodeGroupCategoryId): IOResult[NodeGroupCategory]       = ???
-    def getParentGroupCategory(id:           NodeGroupCategoryId): IOResult[NodeGroupCategory]       = ???
-    def getParents_NodeGroupCategory(id:     NodeGroupCategoryId): IOResult[List[NodeGroupCategory]] = ???
-    def getAllNonSystemCategories(): IOResult[Seq[NodeGroupCategory]] = ???
+    def findGroupWithAnyMember(nodeIds:      Seq[NodeId])(using qc:         QueryContext): IOResult[Seq[NodeGroupId]]       = ???
+    def findGroupWithAllMember(nodeIds:      Seq[NodeId])(using qc:         QueryContext): IOResult[Seq[NodeGroupId]]       = ???
+    def getRootCategory()(using qc:          QueryContext): NodeGroupCategory = ???
+    def getRootCategoryPure()(using qc:      QueryContext): IOResult[NodeGroupCategory] = ???
+    def getCategoryHierarchy(using qc:       QueryContext): IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = ???
+    def getAllGroupCategories(includeSystem: Boolean)(using qc:             QueryContext): IOResult[Seq[NodeGroupCategory]] = ???
+    def getGroupCategory(id:                 NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory]      = ???
+    def getParentGroupCategory(id:           NodeGroupCategoryId)(using qc: QueryContext): IOResult[NodeGroupCategory]      = ???
+    def getParents_NodeGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[List[NodeGroupCategory]] =
+      ???
+    def getAllNonSystemCategories()(using qc: QueryContext): IOResult[Seq[NodeGroupCategory]] = ???
   }
 
   object nodeFactRepo extends NodeFactRepository {
@@ -210,14 +211,14 @@ class SetUpCompliance(numNodes: Int, numRules: Int) {
       nodes.map(n => (n.id, n)).toMap.view.succeed
     }
 
-    def getNumberOfManagedNodes(): IOResult[RuntimeFlags] = ???
+    def getNumberOfManagedNodes()(using qc:    QueryContext): IOResult[RuntimeFlags] = ???
     def registerChangeCallbackAction(callback: NodeFactChangeEventCallback): IOResult[Unit] = ???
     def getStatus(id:                          NodeId)(implicit qc:   QueryContext): IOResult[InventoryStatus] = ???
     def get(nodeId:                            NodeId)(implicit qc:   QueryContext, status:    SelectNodeStatus): IOResult[Option[CoreNodeFact]]  = ???
     def slowGet(
         nodeId: NodeId
     )(implicit qc: QueryContext, status: SelectNodeStatus, attrs: SelectFacts): IOResult[Option[NodeFact]] = ???
-    def getNodesBySoftwareName(softName:       String): IOResult[List[(NodeId, Software)]] = ???
+    def getNodesBySoftwareName(softName:       String)(using qc:      QueryContext): IOResult[List[(NodeId, Software)]] = ???
     def slowGetAll()(implicit qc:              QueryContext, status:  SelectNodeStatus, attrs: SelectFacts):      errors.IOStream[NodeFact]       = ???
     def save(nodeFact:                         NodeFact)(implicit cc: ChangeContext, attrs:    SelectFacts):      IOResult[NodeFactChangeEventCC] = ???
     def setSecurityTag(nodeId: NodeId, tag: Option[SecurityTag])(implicit cc: ChangeContext): IOResult[NodeFactChangeEventCC] =
@@ -232,37 +233,21 @@ class SetUpCompliance(numNodes: Int, numRules: Int) {
 
   // We want to ignore rules that are defined in `MockRules` because they may target all nodes and pollute our compliance tests
   private def rulesRepo(rules: List[Rule]) = new RoRuleRepository with WoRuleRepository {
-    override def getOpt(ruleId: RuleId):         IOResult[Option[Rule]] = {
+    override def getOpt(ruleId: RuleId)(using qc: QueryContext):         IOResult[Option[Rule]] = {
       rules.find(_.id == ruleId).succeed
     }
-    override def getAll(includeSystem: Boolean): IOResult[Seq[Rule]]    = {
+    override def getAll(includeSystem: Boolean)(using qc: QueryContext): IOResult[Seq[Rule]]    = {
       rules.succeed
     }
 
-    override def getIds(includeSystem:            Boolean): IOResult[Set[RuleId]] = ???
-    override def create(rule:                     Rule, modId:   ModificationId, actor: EventActor, reason: Option[String]): IOResult[AddRuleDiff] = ???
-    override def update(
-        rule:   Rule,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[ModifyRuleDiff]] = ???
-    override def load(rule:                       Rule, modId:   ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]        = ???
-    override def unload(ruleId:                   RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]        = ???
-    override def updateSystem(
-        rule:   Rule,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[Option[ModifyRuleDiff]] = ???
-    override def delete(id: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[DeleteRuleDiff] =
-      ???
-    override def deleteSystemRule(
-        id:     RuleId,
-        modId:  ModificationId,
-        actor:  EventActor,
-        reason: Option[String]
-    ): IOResult[DeleteRuleDiff] = ???
+    override def getIds(includeSystem:            Boolean)(using qc: QueryContext):  IOResult[Set[RuleId]]            = ???
+    override def create(rule:                     Rule)(using cc:    ChangeContext): IOResult[AddRuleDiff]            = ???
+    override def update(rule:                     Rule)(using cc:    ChangeContext): IOResult[Option[ModifyRuleDiff]] = ???
+    override def load(rule:                       Rule)(using cc:    ChangeContext): IOResult[Unit]                   = ???
+    override def unload(ruleId:                   RuleId)(using cc:  ChangeContext): IOResult[Unit]                   = ???
+    override def updateSystem(rule:               Rule)(using cc:    ChangeContext): IOResult[Option[ModifyRuleDiff]] = ???
+    override def delete(id:                       RuleId)(using cc:  ChangeContext): IOResult[DeleteRuleDiff]         = ???
+    override def deleteSystemRule(id:             RuleId)(using cc:  ChangeContext): IOResult[DeleteRuleDiff]         = ???
     override def swapRules(newRules:              Seq[Rule]): IOResult[RuleArchiveId] = ???
     override def deleteSavedRuleArchiveId(saveId: RuleArchiveId): IOResult[Unit] = ???
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SaveArchiveServiceTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SaveArchiveServiceTest.scala
@@ -45,6 +45,7 @@ import com.normation.cfclerk.services.TechniquesInfo
 import com.normation.cfclerk.services.TechniquesLibraryUpdateType
 import com.normation.errors.IOResult
 import com.normation.rudder.MockRules
+import com.normation.rudder.MockTenants
 import com.normation.rudder.rest.lift.JRuleCategories
 import com.normation.rudder.rest.lift.MergePolicy
 import com.normation.rudder.rest.lift.PolicyArchive
@@ -71,7 +72,7 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
 
   implicit val qc: QueryContext = QueryContext.testQC
 
-  val mockRules = new MockRules()
+  val mockRules = new MockRules(new MockTenants)
 
   val rootRuleCategory            = mockRules.rootRuleCategory
   val ruleCategory2               = RuleCategory(RuleCategoryId("category2"), "Category 2", "", Nil, security = None)
@@ -155,7 +156,7 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
     )
     for {
       _    <- save(archiveSaver)
-      root <- ruleCategoryRepo.getRootCategory()
+      root <- ruleCategoryRepo.getRootCategory()(using QueryContext.systemQC)
     } yield {
       assert(transform(root))(assertion)
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -92,6 +92,7 @@ class TestRestFromFileDef extends ZIOSpecDefault {
                yamlSourceDirectory,
                yamlDestTmpDirectory,
                restTestSetUp.liftRules,
+               restTestSetUp.userService,
                Nil,
                transformations
              )

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
@@ -181,7 +181,8 @@ class TestRestPluginInfo extends Specification with JsonSpecMatcher {
   val pluginApi = new PluginApi(pluginSettingsService, pluginService, pluginInfo.succeed)
   val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema & SortIndex]] = List(pluginApi)
 
-  val (handlers, rules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, List(ApiVersion(42, deprecated = false)), None)
+  val (handlers, rules) =
+    TraitTestApiFromYamlFiles.buildLiftRules(apiModules, List(ApiVersion(42, deprecated = false)), new TestUserService)
   val test              = new RestTest(rules)
 
   sequential

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
@@ -68,7 +68,7 @@ class TestRestPlusInPath extends Specification with BeforeAfterAll {
   val env = RestTestSetUp.newEnv
   import com.softwaremill.quicklens.*
   val rule: Rule = env.mockRules.ruleRepo
-    .get(RuleId(RuleUid("ff44fb97-b65e-43c4-b8c2-0df8d5e8549f")))
+    .get(RuleId(RuleUid("ff44fb97-b65e-43c4-b8c2-0df8d5e8549f")))(using QueryContext.systemQC)
     .runNow
     .modify(_.id.rev)
     .setTo(Revision("gitrevision"))

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestTenantFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestTenantFromFileDef.scala
@@ -1,6 +1,6 @@
 /*
  *************************************************************************************
- * Copyright 2024 Normation SAS
+ * Copyright 2025 Normation SAS
  *************************************************************************************
  *
  * This file is part of Rudder.
@@ -40,97 +40,92 @@ package com.normation.rudder.rest
 import better.files.*
 import com.normation.GitVersion
 import com.normation.errors.*
-import com.normation.rudder.domain.nodes.NodeGroupId
-import com.normation.rudder.domain.properties.GenericProperty.StringToConfigValue
+import com.normation.rudder.domain.policies.AllTarget
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.DirectiveUid
+import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.policies.Tags
+import com.normation.rudder.domain.properties.GenericProperty.*
 import com.normation.rudder.domain.properties.GlobalParameter
-import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.properties.Visibility
-import com.normation.rudder.tenants.ChangeContext
-import com.normation.rudder.tenants.QueryContext
-import com.normation.zio.*
+import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.tenants.SecurityTag
+import com.normation.rudder.tenants.TenantId
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
 import zio.test.junit.ZTestJUnitRunner
 
 @RunWith(classOf[ZTestJUnitRunner])
-class TestInheritedProperties extends ZIOSpecDefault {
+class TestRestTenantFromFileDef extends ZIOSpecDefault {
 
-  val restTestSetUp = RestTestSetUp.newEnv
-
-  // let's say that's /var/rudder/share
-  val tmpApiTemplate: File = restTestSetUp.baseTempDirectory / "apiTemplates"
-  tmpApiTemplate.createDirectories()
-
-  // nodeXX appears at several places
-
-  def yamlSourceDirectory:  String = "api_inherited_prop"
-  def yamlDestTmpDirectory: File   = tmpApiTemplate
-
-  val transformations: Map[String, String => String] = Map()
-
-  // there is some tests that need change in data model, that we don't want to have in all plugins.
-  // For ex, the tests for inherited values
-  val badOverrideType: GlobalParameter = {
-    GlobalParameter(
-      "badOverrideType",
-      GitVersion.DEFAULT_REV,
-      "a string".toConfigValue,
-      None,
-      "a string at first",
-      None,
-      Visibility.default,
-      security = None
-    )
-  }
-  restTestSetUp.mockParameters.paramsRepo.paramsMap.update(m => m + (badOverrideType.name -> badOverrideType)).runNow
-
-  val gProp: GroupProperty = GroupProperty
-    .parse(
-      "badOverrideType",
-      GitVersion.DEFAULT_REV,
-      """{ "now":"a json" }""",
-      None,
-      None
-    )
-    .getOrElse(null) // for test
-
-  import com.softwaremill.quicklens.*
-
-  implicit val qc: QueryContext  = QueryContext.testQC
-  implicit val cc: ChangeContext = qc.newCC()
-
-  val g0Id: NodeGroupId = restTestSetUp.mockNodeGroups.g0.id
-  (for {
-    g <- restTestSetUp.mockNodeGroups.groupsRepo.getNodeGroupOpt(g0Id).notOptional("test")
-    up = g._1.modify(_.properties).using(_.appended(gProp))
-    _ <- restTestSetUp.mockNodeGroups.groupsRepo.update(up)
-    _ <- restTestSetUp.mockNodeGroups.propService.updateAll() // the properties also need to be recomputed after group is updated
-  } yield ()).runNow
-
-  // we are testing error cases, so we don't want to output error log for them
+  // suppress expected error logs from REST utils
   org.slf4j.LoggerFactory
     .getLogger("com.normation.rudder.rest.RestUtils")
     .asInstanceOf[ch.qos.logback.classic.Logger]
     .setLevel(ch.qos.logback.classic.Level.OFF)
+  org.slf4j.LoggerFactory
+    .getLogger("tenants")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.TRACE)
+
+  // A single shared test setup — all user variants read from the same mock repos
+  val restTestSetUp: RestTestSetUp = RestTestSetUp.newEnv
+
+  // ─── seed tenant-tagged objects ───────────────────────────────────────────
+
+  // Rule restricted to zoneA + zoneB, using the enabled clockDirective so that
+  // getRuleApplicationStatus returns "In application"
+  val tenantRule: Rule = Rule(
+    RuleId(RuleUid("tenant-rule-1")),
+    "Tenant test rule",
+    RuleCategoryId("rootRuleCategory"),
+    Set(AllTarget),
+    Set(DirectiveId(DirectiveUid("directive1"))),
+    "A rule for tenant testing",
+    "",
+    isEnabledStatus = true,
+    isSystem = false,
+    Tags(Set()),
+    security = Some(SecurityTag.ByTenants(zio.Chunk(TenantId("zoneA"), TenantId("zoneB"))))
+  )
+
+  // Global parameter restricted to zoneA + zoneB
+  val tenantParam: GlobalParameter = GlobalParameter(
+    "tenantParam",
+    GitVersion.DEFAULT_REV,
+    "tenant-value".toConfigValue,
+    None,
+    "a tenant-restricted param",
+    None,
+    Visibility.default,
+    security = Some(SecurityTag.ByTenants(zio.Chunk(TenantId("zoneA"), TenantId("zoneB"))))
+  )
+
+  val tmpTenantTemplate: File = restTestSetUp.baseTempDirectory / "tenantApiTemplates"
+  tmpTenantTemplate.createDirectories()
 
   override def spec: Spec[TestEnvironment & Scope, Any] = {
-    (suite("All REST tests defined in files") {
-
+    suite("Tenant-aware REST API tests (multi-user)") {
       for {
+        _ <- restTestSetUp.mockParameters.paramsRepo.paramsMap.update(_ + (tenantParam.name -> tenantParam))
+        _ <- restTestSetUp.mockRules.ruleRepo.rulesMap.update(_ + (tenantRule.id -> tenantRule))
+        _ <- restTestSetUp.mockTenants.tenantRepo.setTenantEnabled(true)
         s <- TraitTestApiFromYamlFiles.doTest(
-               yamlSourceDirectory,
-               yamlDestTmpDirectory,
+               "api-tenant",
+               tmpTenantTemplate,
                restTestSetUp.liftRules,
                restTestSetUp.userService,
                Nil,
-               transformations
+               Map.empty
              )
         _ <- effectUioUnit(
                if (java.lang.System.getProperty("tests.clean.tmp") != "false") IOResult.attempt(restTestSetUp.cleanup())
                else ZIO.unit
              )
       } yield s
-    }) // @@ TestAspect.ignore
+    } @@ TestAspect.sequential
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestTenantFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestTenantFromFileDef.scala
@@ -40,7 +40,13 @@ package com.normation.rudder.rest
 import better.files.*
 import com.normation.GitVersion
 import com.normation.errors.*
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.ActiveTechniqueId
 import com.normation.rudder.domain.policies.AllTarget
+import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.Rule
@@ -50,9 +56,14 @@ import com.normation.rudder.domain.policies.Tags
 import com.normation.rudder.domain.properties.GenericProperty.*
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.Visibility
+import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
 import com.normation.rudder.tenants.TenantId
+import com.normation.zio.*
+import com.softwaremill.quicklens.*
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -92,6 +103,14 @@ class TestRestTenantFromFileDef extends ZIOSpecDefault {
     security = Some(SecurityTag.ByTenants(zio.Chunk(TenantId("zoneA"), TenantId("zoneB"))))
   )
 
+  // A second zoneA+zoneB rule, never deleted by the test files, used to probe the create/update laws
+  // (law 7/8) with the single-tenant `zoneA` user.
+  val lawRule: Rule = tenantRule
+    .modify(_.id)
+    .setTo(RuleId(RuleUid("law-rule-shared")))
+    .modify(_.name)
+    .setTo("law shared rule")
+
   // Global parameter restricted to zoneA + zoneB
   val tenantParam: GlobalParameter = GlobalParameter(
     "tenantParam",
@@ -104,27 +123,92 @@ class TestRestTenantFromFileDef extends ZIOSpecDefault {
     security = Some(SecurityTag.ByTenants(zio.Chunk(TenantId("zoneA"), TenantId("zoneB"))))
   )
 
+  // the security tag shared by all tenant-restricted test objects
+  val tenantTag: SecurityTag = SecurityTag.ByTenants(zio.Chunk(TenantId("zoneA"), TenantId("zoneB")))
+
+  // Node group restricted to zoneA + zoneB
+  val tenantGroup: NodeGroup = NodeGroup(
+    NodeGroupId(NodeGroupUid("tenant-group-1")),
+    name = "Tenant test group",
+    description = "a tenant-restricted group",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = Set(),
+    _isEnabled = true,
+    security = Some(tenantTag)
+  )
+
+  // We restrict an *existing* active technique + directive to zoneA + zoneB rather than the ones
+  // used by `tenantRule` (clockConfiguration / directive1), so that the rule application status
+  // assertions stay stable. We tag `rpmPackageInstallation` and its `directive2`.
+  // The active-technique listing filters on the *category* visibility, so we also tag the category
+  // that directly holds the technique, otherwise tenant users would not see it at all.
+  def tagTenantTree(c: FullActiveTechniqueCategory): FullActiveTechniqueCategory = {
+    val hasRpm = c.activeTechniques.exists(_.techniqueName.value == "rpmPackageInstallation")
+    val tagged = c
+      .modify(_.subCategories)
+      .using(_.map(tagTenantTree))
+      .modify(_.activeTechniques)
+      .using(_.map { at =>
+        if (at.techniqueName.value == "rpmPackageInstallation") {
+          at.modify(_.security)
+            .setTo(Some(tenantTag))
+            .modify(_.directives)
+            .using(_.map(d => if (d.id.uid.value == "directive2") d.modify(_.security).setTo(Some(tenantTag)) else d))
+        } else at
+      })
+    if (hasRpm) tagged.modify(_.security).setTo(Some(tenantTag)) else tagged
+  }
+
+  // snapshot of the untagged `directive2` taken once, before any test mutates it, so that the
+  // destructive delete tests can be restored on a subsequent (idempotent) evaluation of `spec`.
+  val origDirective2: Option[(ActiveTechniqueId, Directive)] = restTestSetUp.mockDirectives.directiveRepoImpl
+    .getActiveTechniqueAndDirective(DirectiveId(DirectiveUid("directive2")))(using QueryContext.systemQC)
+    .runNow
+    .map { case (at, d) => (at.id, d) }
+
   val tmpTenantTemplate: File = restTestSetUp.baseTempDirectory / "tenantApiTemplates"
   tmpTenantTemplate.createDirectories()
 
   override def spec: Spec[TestEnvironment & Scope, Any] = {
     suite("Tenant-aware REST API tests (multi-user)") {
       for {
-        _ <- restTestSetUp.mockParameters.paramsRepo.paramsMap.update(_ + (tenantParam.name -> tenantParam))
-        _ <- restTestSetUp.mockRules.ruleRepo.rulesMap.update(_ + (tenantRule.id -> tenantRule))
-        _ <- restTestSetUp.mockTenants.tenantRepo.setTenantEnabled(true)
-        s <- TraitTestApiFromYamlFiles.doTest(
-               "api-tenant",
-               tmpTenantTemplate,
-               restTestSetUp.liftRules,
-               restTestSetUp.userService,
-               Nil,
-               Map.empty
-             )
-        _ <- effectUioUnit(
-               if (java.lang.System.getProperty("tests.clean.tmp") != "false") IOResult.attempt(restTestSetUp.cleanup())
-               else ZIO.unit
-             )
+        _      <- restTestSetUp.mockParameters.paramsRepo.paramsMap.update(_ + (tenantParam.name -> tenantParam))
+        _      <- restTestSetUp.mockRules.ruleRepo.rulesMap.update(_ + (tenantRule.id -> tenantRule))
+        _      <- restTestSetUp.mockRules.ruleRepo.rulesMap.update(_ + (lawRule.id -> lawRule))
+        // seeding must be idempotent: `spec` may be evaluated more than once by the test runner
+        exists <- restTestSetUp.mockNodeGroups.groupsRepoImpl.categories.get.map(_.allGroups.contains(tenantGroup.id))
+        _      <-
+          ZIO.unless(exists)(
+            restTestSetUp.mockNodeGroups.groupsRepoImpl
+              .create(tenantGroup, NodeGroupCategoryId("GroupRoot"))(using ChangeContext.newForRudder(Some("seed tenant group")))
+          )
+        // restore directive2 if a previous evaluation deleted it, then (re)apply the tenant tags
+        dirOk  <- restTestSetUp.mockDirectives.directiveRepoImpl
+                    .getActiveTechniqueAndDirective(DirectiveId(DirectiveUid("directive2")))(using QueryContext.systemQC)
+                    .map(_.isDefined)
+        _      <- ZIO.unless(dirOk)(
+                    ZIO.foreachDiscard(origDirective2.toList) {
+                      case (atId, d) =>
+                        restTestSetUp.mockDirectives.directiveRepoImpl
+                          .saveDirective(atId, d)(using ChangeContext.newForRudder(Some("restore directive2")))
+                    }
+                  )
+        _      <- restTestSetUp.mockDirectives.rootActiveTechniqueCategory.update(tagTenantTree)
+        _      <- restTestSetUp.mockTenants.tenantRepo.setTenantEnabled(true)
+        s      <- TraitTestApiFromYamlFiles.doTest(
+                    "api-tenant",
+                    tmpTenantTemplate,
+                    restTestSetUp.liftRules,
+                    restTestSetUp.userService,
+                    Nil,
+                    Map.empty
+                  )
+        _      <- effectUioUnit(
+                    if (java.lang.System.getProperty("tests.clean.tmp") != "false") IOResult.attempt(restTestSetUp.cleanup())
+                    else ZIO.unit
+                  )
       } yield s
     } @@ TestAspect.sequential
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -90,7 +90,8 @@ final case class TestRequest(
     params:          List[(String, String)],
     responseType:    ResponseType,
     responseCode:    Int,
-    responseContent: String
+    responseContent: String,
+    user:            String
 )
 
 object TraitTestApiFromYamlFiles {
@@ -98,12 +99,8 @@ object TraitTestApiFromYamlFiles {
   def buildLiftRules[A <: GenericLiftApiModuleProvider[? <: EndpointSchema]](
       modules:     List[A],
       versions:    List[ApiVersion],
-      userService: Option[UserService]
+      userService: UserService
   ): (LiftHandler, LiftRules) = {
-    implicit val userServiceImp = userService match {
-      case None    => new TestUserService
-      case Some(u) => u
-    }
 
     val apiDispatcher                = new RudderEndpointDispatcher(LiftApiProcessingLogger)
     val apiAuthorizationLevelService = new DefaultApiAuthorizationLevel(LiftApiProcessingLogger)
@@ -112,7 +109,7 @@ object TraitTestApiFromYamlFiles {
     val rudderApi = new LiftHandler(
       apiDispatcher,
       versions,
-      new AclApiAuthorization(LiftApiProcessingLogger, userServiceImp, () => apiAuthorizationLevelService.aclEnabled),
+      new AclApiAuthorization(LiftApiProcessingLogger, userService, () => apiAuthorizationLevelService.aclEnabled),
       None
     )
     modules.foreach(module => rudderApi.addModules(module.getLiftEndpoints()))
@@ -261,7 +258,8 @@ object TraitTestApiFromYamlFiles {
             case x      => throw new IllegalArgumentException(s"Unrecognized response type: '${x}'. Use 'json' or 'text'")
           },
           response.safe("code", None, _.asInstanceOf[Int]),
-          response.safe("content", None, _.asInstanceOf[String])
+          response.safe("content", None, _.asInstanceOf[String]),
+          data.safe("user", Some("admin"), _.asInstanceOf[String])
         )
       }
     }
@@ -316,6 +314,7 @@ object TraitTestApiFromYamlFiles {
       yamlDestTmpDirectory: File,
       // the liftRules to use for API
       liftRules:            LiftRules,
+      userService:          UserService,
 
       // we have two kinds of files:
       // - yml files directly under /api are considered "use as it" (no post processing)
@@ -373,6 +372,11 @@ object TraitTestApiFromYamlFiles {
                     // query string may have already set some params
                     mockReq.parameters = mockReq.parameters ++ test.params
                     mockReq.contentType = mockReq.headers.get("Content-Type").flatMap(_.headOption).getOrElse("text/plain")
+
+                    userService match {
+                      case tus: TestUserService => tus.setCurrentUser(test.user)
+                      case _ => // do nothing
+                    }
 
                     restTest.execRequestResponseZioTest(mockReq) { response =>
                       (for {

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
@@ -8,6 +8,7 @@ import NaturalOrdering as N
 import Rudder.Filters exposing (SearchFilterState)
 import Rudder.Table exposing (Model)
 import Set
+import Tenants.SecurityTag exposing (SecurityTag)
 import Time
 import Ui.Datatable exposing (Category, SubCategories(..), TableFilters, getAllElems)
 
@@ -51,6 +52,7 @@ type alias Group =
     , dynamic : Bool
     , enabled : Bool
     , target : String
+    , security : Maybe SecurityTag
     }
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
@@ -5,6 +5,7 @@ import GroupCompliance.DataTypes exposing (GroupId)
 import Groups.DataTypes exposing (..)
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
+import Tenants.SecurityTag exposing (decodeSecurityTag)
 import Ui.Datatable exposing (Category, SubCategories(..))
 
 
@@ -65,6 +66,7 @@ decodeGroup =
         |> required "dynamic" bool
         |> required "enabled" bool
         |> required "target" string
+        |> optional "security" (map Just decodeSecurityTag) Nothing
 
 
 decodeTarget : Decoder Group
@@ -77,3 +79,4 @@ decodeTarget =
         |> hardcoded True
         |> required "enabled" bool
         |> required "target" string
+        |> optional "security" (map Just decodeSecurityTag) Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
@@ -11,6 +11,7 @@ import NaturalOrdering as N
 import Rudder.Filters
 import Rudder.Table
 import String
+import Tenants.SecurityTag exposing (badgeSecurityTags)
 import Ui.Datatable exposing (Category, filterSearch, generateLoadingTable)
 import Utils.TooltipUtils exposing (buildTooltipContent)
 
@@ -66,6 +67,7 @@ view model =
                                        )
                                 )
                             ]
+                        , badgeSecurityTags item.security
                         , badgeDisabled
                         ]
                     ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -562,7 +562,7 @@ update msg model =
         NewRule id ->
             let
                 rule =
-                    Rule id "" "rootRuleCategory" "" "" True False [] [] "" (RuleStatus "" Nothing) [] Nothing
+                    Rule id "" "rootRuleCategory" "" "" True False [] [] "" (RuleStatus "" Nothing) [] Nothing Nothing
 
                 ruleDetails =
                     RuleDetails Nothing rule Information { defaultRulesUI | editGroups = True, editDirectives = True } Nothing Nothing Nothing []
@@ -1149,6 +1149,7 @@ toRuleWithCompliance model rule =
     , compliance = getRuleCompliance model rule.id
     , changes = countRecentChanges rule.id model.changes
     , tags = rule.tags
+    , security = rule.security
     }
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -6,6 +6,7 @@ import Dict exposing (Dict)
 import Http exposing (Error)
 import Rudder.Table
 import Rules.ChangeRequest exposing (ChangeRequest, ChangeRequestSettings)
+import Tenants.SecurityTag exposing (SecurityTag)
 import Time.ZonedDateTime exposing (ZonedDateTime)
 import Ui.Datatable exposing (Category, SortOrder, TableFilters, getAllCats, getAllElems, getSubElems)
 
@@ -83,6 +84,7 @@ type alias Rule =
     , status : RuleStatus
     , tags : List Tag
     , changeRequestId : Maybe String
+    , security : Maybe SecurityTag
     }
 
 
@@ -251,6 +253,7 @@ type alias RuleWithCompliance =
     , compliance : Maybe RuleComplianceGlobal
     , changes : Float
     , tags : List Tag
+    , security : Maybe SecurityTag
     }
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
@@ -13,6 +13,7 @@ import Rudder.Table exposing (Column, ColumnName(..), FilterOptionsType(..), bui
 import Rules.ApiCalls exposing (..)
 import Rules.DataTypes exposing (..)
 import Rules.ViewUtils exposing (badgePolicyModeNoGlobal, buildTagsTree)
+import Tenants.SecurityTag exposing (badgeSecurityTags)
 import Ui.Datatable exposing (Category, SubCategories(..), defaultTableFilters)
 import Utils.TooltipUtils exposing (buildTooltipContent)
 
@@ -88,6 +89,7 @@ initTable =
                             [ badgePolicyModeNoGlobal rule.policyMode
                             , text rule.name
                             , buildTagsTree rule.tags
+                            , badgeSecurityTags rule.security
                             ]
                 , ordering = Ordering.byField (.name >> String.toLower)
                 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
@@ -7,6 +7,7 @@ import Json.Decode exposing (..)
 import Json.Decode.Field exposing (require)
 import Json.Decode.Pipeline exposing (..)
 import Rules.DataTypes exposing (..)
+import Tenants.SecurityTag exposing (decodeSecurityTag)
 import Time.Iso8601
 import Time.Iso8601ErrorMsg
 import Time.TimeZones exposing (utc)
@@ -106,6 +107,7 @@ decodeRule =
         |> required "status" decodeStatus
         |> required "tags" (list (keyValuePairs string) |> andThen toTags)
         |> optional "changeRequestId" (map Just string) Nothing
+        |> optional "security" (map Just decodeSecurityTag) Nothing
 
 
 toTags : List (List ( String, String )) -> Decoder (List Tag)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
@@ -18,6 +18,7 @@ import Rules.ViewRuleDetails exposing (..)
 import Rules.ViewRulesTable exposing (..)
 import Rules.ViewUtils exposing (..)
 import String
+import Tenants.SecurityTag exposing (badgeSecurityTags)
 import Ui.Datatable exposing (Category, filterSearch, generateLoadingTable, getSubElems)
 
 
@@ -61,6 +62,7 @@ view model =
                         , text item.name
                         , badgeDisabled
                         , buildTagsTree item.tags
+                        , badgeSecurityTags item.security
                         ]
                     ]
                 ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
@@ -10,6 +10,7 @@ import NaturalOrdering
 import Rules.DataTypes exposing (..)
 import Rules.ViewUtils exposing (..)
 import String
+import Tenants.SecurityTag exposing (badgeSecurityTags)
 import Ui.Datatable exposing (SortOrder(..), filterSearch)
 import Utils.TooltipUtils exposing (buildTooltipContent)
 
@@ -148,6 +149,7 @@ buildRulesTable model rules =
                     [ badgePolicyMode model.policyMode r.policyMode
                     , text r.name
                     , buildTagsTree r.tags
+                    , badgeSecurityTags r.security
                     ]
                 , td [] [ categoryName ]
                 , td [] [ displayStatus ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Tenants/SecurityTag.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Tenants/SecurityTag.elm
@@ -1,0 +1,74 @@
+module Tenants.SecurityTag exposing (SecurityTag(..), badgeSecurityTags, decodeSecurityTag)
+
+{-| The security tag (tenants) attached to a configuration object, shared across the Elm apps so that the
+model, its JSON decoder and its badge are defined only once.
+
+  - `Nothing` (no tag) means the object has no tenant and is only visible to an administrator.
+  - `Just Open` means it is visible to everyone.
+  - `Just (ByTenants tenants)` means it is visible to the listed tenants.
+
+-}
+
+import Html exposing (Html, b, i, span, text)
+import Html.Attributes exposing (attribute, class, title)
+import Json.Decode exposing (Decoder, andThen, fail, field, list, map, oneOf, string, succeed)
+
+
+type SecurityTag
+    = Open
+    | ByTenants (List String)
+
+
+decodeSecurityTag : Decoder SecurityTag
+decodeSecurityTag =
+    oneOf
+        [ string
+            |> andThen
+                (\s ->
+                    if s == "open" then
+                        succeed Open
+
+                    else
+                        fail ("Unknown security tag value: " ++ s)
+                )
+        , map ByTenants (field "tenants" (list string))
+        ]
+
+
+{-| A small badge showing the number of tenants an object belongs to, with the tenant list as tooltip.
+`Nothing` and `Open` render nothing (the object is not tenant-scoped for display purposes).
+It is polymorphic in `msg` since it emits no message, so it can be used from any app.
+-}
+badgeSecurityTags : Maybe SecurityTag -> Html msg
+badgeSecurityTags mTag =
+    case mTag of
+        Nothing ->
+            text ""
+
+        Just Open ->
+            text ""
+
+        Just (ByTenants tenants) ->
+            let
+                tenantNames =
+                    String.join ", " tenants
+
+                nbTenants =
+                    List.length tenants
+
+                label =
+                    if nbTenants == 0 then
+                        "no tenants"
+
+                    else
+                        tenantNames
+            in
+            span
+                [ class "tenants-label"
+                , attribute "data-bs-toggle" "tooltip"
+                , attribute "data-bs-placement" "top"
+                , title ("Tenants: " ++ label)
+                ]
+                [ i [ class "fa fa-building" ] []
+                , b [] [ text (String.fromInt nbTenants) ]
+                ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1432,8 +1432,8 @@ object RudderConfig extends Loggable {
   val roApiAccountRepository:              RoApiAccountRepository                   = rci.roApiAccountRepository
   val roDirectiveRepository:               RoDirectiveRepository                    = rci.roDirectiveRepository
   val roLDAPConnectionProvider:            LDAPConnectionProvider[RoLDAPConnection] = rci.roLDAPConnectionProvider
-  val roLDAPParameterRepository:           RoLDAPParameterRepository                = rci.roLDAPParameterRepository
-  val woLDAPParameterRepository:           WoLDAPParameterRepository                = rci.woLDAPParameterRepository
+  val roLDAPParameterRepository:           RoParameterRepository                    = rci.roLDAPParameterRepository
+  val woLDAPParameterRepository:           WoParameterRepository                    = rci.woLDAPParameterRepository
   val roNodeGroupRepository:               RoNodeGroupRepository                    = rci.roNodeGroupRepository
   val roParameterService:                  RoParameterService                       = rci.roParameterService
   val roRuleCategoryRepository:            RoRuleCategoryRepository                 = rci.roRuleCategoryRepository
@@ -1618,8 +1618,8 @@ case class RudderServiceApi(
     rwLdap:                              LDAPConnectionProvider[RwLDAPConnection],
     apiAuthorizationLevelService:        DefaultApiAuthorizationLevel,
     tokenGenerator:                      TokenGeneratorImpl,
-    roLDAPParameterRepository:           RoLDAPParameterRepository,
-    woLDAPParameterRepository:           WoLDAPParameterRepository,
+    roLDAPParameterRepository:           RoParameterRepository,
+    woLDAPParameterRepository:           WoParameterRepository,
     interpolationCompiler:               InterpolatedValueCompilerImpl,
     policyGenerationHookService:         PolicyGenerationHookService,
     campaignEventRepo:                   CampaignEventRepositoryImpl,
@@ -1755,9 +1755,17 @@ object RudderConfigInit {
       }
     }
 
-    lazy val roRuleCategoryRepository: RoRuleCategoryRepository = roLDAPRuleCategoryRepository
+    lazy val roRuleCategoryRepository: RoRuleCategoryRepository =
+      new RoTenantRuleCategoryRepo(tenantCheckLogic, roLDAPRuleCategoryRepository)
     lazy val ruleCategoryService:      RuleCategoryService      = new RuleCategoryService()
-    lazy val woRuleCategoryRepository: WoRuleCategoryRepository = woLDAPRuleCategoryRepository
+    lazy val woRuleCategoryRepository: WoRuleCategoryRepository = {
+      new WoTenantRuleCategoryRepo(
+        tenantCheckLogic,
+        tenantService,
+        woLDAPRuleCategoryRepository,
+        roLDAPRuleCategoryRepository
+      )
+    }
 
     lazy val changeRequestEventLogService: ChangeRequestEventLogService = new ChangeRequestEventLogServiceImpl(eventLogRepository)
     lazy val secretEventLogService:        SecretEventLogService        = new SecretEventLogServiceImpl(eventLogRepository)
@@ -2945,9 +2953,17 @@ object RudderConfigInit {
     lazy val ruleReadWriteMutex      = new ZioTReentrantLock("rule-lock")
     lazy val ruleCatReadWriteMutex   = new ZioTReentrantLock("rule-cat-lock")
 
-    lazy val roLdapDirectiveRepository =
-      new RoLDAPDirectiveRepository(rudderDitImpl, roLdap, ldapEntityMapper, techniqueRepositoryImpl, uptLibReadWriteMutex)
-    lazy val roDirectiveRepository: RoDirectiveRepository = roLdapDirectiveRepository
+    lazy val roLdapDirectiveRepository = {
+      new RoLDAPDirectiveRepository(
+        rudderDitImpl,
+        roLdap,
+        ldapEntityMapper,
+        techniqueRepositoryImpl,
+        uptLibReadWriteMutex
+      )
+    }
+    lazy val roDirectiveRepository: RoDirectiveRepository =
+      new RoTenantDirectiveRepo(tenantCheckLogic, roLdapDirectiveRepository)
     lazy val woLdapDirectiveRepository = {
       val repo = new WoLDAPDirectiveRepository(
         roLdapDirectiveRepository,
@@ -2979,13 +2995,21 @@ object RudderConfigInit {
 
       repo
     }
-    lazy val woDirectiveRepository: WoDirectiveRepository = woLdapDirectiveRepository
+    lazy val woDirectiveRepository: WoDirectiveRepository = {
+      new WoTenantDirectiveRepo(
+        tenantCheckLogic,
+        tenantService,
+        woLdapDirectiveRepository,
+        roLdapDirectiveRepository
+      )
+    }
 
     lazy val roLdapRuleRepository =
       new RoLDAPRuleRepository(rudderDitImpl, roLdap, ldapEntityMapper, ruleReadWriteMutex)
-    lazy val roRuleRepository: RoRuleRepository = roLdapRuleRepository
+    lazy val roRuleRepository: RoRuleRepository =
+      new RoTenantRuleRepo(tenantCheckLogic, roLdapRuleRepository)
 
-    lazy val woLdapRuleRepository: WoRuleRepository = new WoLDAPRuleRepository(
+    lazy val woLdapRuleRepository = new WoLDAPRuleRepository(
       roLdapRuleRepository,
       rwLdap,
       ldapDiffMapper,
@@ -2995,7 +3019,8 @@ object RudderConfigInit {
       personIdentServiceImpl,
       RUDDER_AUTOARCHIVEITEMS
     )
-    lazy val woRuleRepository = woLdapRuleRepository
+    lazy val woRuleRepository: WoRuleRepository =
+      new WoTenantRuleRepo(tenantCheckLogic, tenantService, woLdapRuleRepository, roLdapRuleRepository)
 
     lazy val roLdapNodeGroupRepository = new RoLDAPNodeGroupRepository(
       rudderDitImpl,
@@ -3004,7 +3029,8 @@ object RudderConfigInit {
       nodeFactRepository,
       groupLibReadWriteMutex
     )
-    lazy val roNodeGroupRepository: RoNodeGroupRepository = roLdapNodeGroupRepository
+    lazy val roNodeGroupRepository: RoNodeGroupRepository =
+      new RoTenantNodeGroupRepo(tenantCheckLogic, roLdapNodeGroupRepository)
 
     lazy val woLdapNodeGroupRepository = new WoLDAPNodeGroupRepository(
       roLdapNodeGroupRepository,
@@ -3013,11 +3039,16 @@ object RudderConfigInit {
       logRepository,
       gitNodeGroupArchiver,
       personIdentServiceImpl,
-      tenantCheckLogic,
-      tenantService,
       RUDDER_AUTOARCHIVEITEMS
     )
-    lazy val woNodeGroupRepository: WoNodeGroupRepository = woLdapNodeGroupRepository
+    lazy val woNodeGroupRepository: WoNodeGroupRepository = {
+      new WoTenantNodeGroupRepo(
+        tenantCheckLogic,
+        tenantService,
+        woLdapNodeGroupRepository,
+        roLdapNodeGroupRepository
+      )
+    }
 
     lazy val roLDAPRuleCategoryRepository = {
       new RoLDAPRuleCategoryRepository(
@@ -3039,15 +3070,17 @@ object RudderConfigInit {
       )
     }
 
-    lazy val roLDAPParameterRepository = new RoLDAPParameterRepository(
+    lazy val roLdapParameterRepository = new RoLDAPParameterRepository(
       rudderDitImpl,
       roLdap,
       ldapEntityMapper,
       parameterReadWriteMutex
     )
+    lazy val roLDAPParameterRepository: RoParameterRepository =
+      new RoTenantParameterRepo(tenantCheckLogic, roLdapParameterRepository)
 
-    lazy val woLDAPParameterRepository = new WoLDAPParameterRepository(
-      roLDAPParameterRepository,
+    lazy val woLdapParameterRepository = new WoLDAPParameterRepository(
+      roLdapParameterRepository,
       rwLdap,
       ldapDiffMapper,
       logRepository,
@@ -3055,6 +3088,14 @@ object RudderConfigInit {
       personIdentServiceImpl,
       RUDDER_AUTOARCHIVEITEMS
     )
+    lazy val woLDAPParameterRepository: WoParameterRepository = {
+      new WoTenantParameterRepo(
+        tenantCheckLogic,
+        tenantService,
+        woLdapParameterRepository,
+        roLdapParameterRepository
+      )
+    }
 
     lazy val itemArchiveManagerImpl = new ItemArchiveManagerImpl(
       roLdapRuleRepository,
@@ -3062,8 +3103,8 @@ object RudderConfigInit {
       roLDAPRuleCategoryRepository,
       roLdapDirectiveRepository,
       roLdapNodeGroupRepository,
-      roLDAPParameterRepository,
-      woLDAPParameterRepository,
+      roLdapParameterRepository,
+      woLdapParameterRepository,
       gitConfigRepo,
       gitRuleArchiver,
       gitRuleCategoryArchiver,
@@ -3857,7 +3898,7 @@ object RudderConfigInit {
         val subGroup = new SubGroupComparatorRepository {
           override def getNodeIds(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Chunk[NodeId]] = Chunk.empty.succeed
 
-          override def getGroups: IOResult[Chunk[SubGroupChoice]] = Chunk.empty.succeed
+          override def getGroups(using qc: QueryContext): IOResult[Chunk[SubGroupChoice]] = Chunk.empty.succeed
         }
         new InternalLDAPQueryProcessor(
           roLdap,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3019,8 +3019,15 @@ object RudderConfigInit {
       personIdentServiceImpl,
       RUDDER_AUTOARCHIVEITEMS
     )
-    lazy val woRuleRepository: WoRuleRepository =
-      new WoTenantRuleRepo(tenantCheckLogic, tenantService, woLdapRuleRepository, roLdapRuleRepository)
+    lazy val woRuleRepository: WoRuleRepository = {
+      new WoTenantRuleRepo(
+        tenantCheckLogic,
+        tenantService,
+        woLdapRuleRepository,
+        roLdapRuleRepository,
+        roLDAPRuleCategoryRepository
+      )
+    }
 
     lazy val roLdapNodeGroupRepository = new RoLDAPNodeGroupRepository(
       rudderDitImpl,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/RemoveFaultyLdapEntries.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/RemoveFaultyLdapEntries.scala
@@ -39,11 +39,10 @@ package bootstrap.liftweb.checks.endconfig.action
 
 import bootstrap.liftweb.BootstrapChecks
 import bootstrap.liftweb.BootstrapLogger
-import com.normation.eventlog.ModificationId
-import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.policies.ActiveTechniqueId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.repository.WoDirectiveRepository
+import com.normation.rudder.tenants.ChangeContext
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio.*
 
@@ -55,18 +54,13 @@ class RemoveFaultyLdapEntries(
   override val description = "Remove LDAP entries breaking directive api, see https://issues.rudder.io/issues/22314"
 
   override def checks(): Unit = {
+    given cc: ChangeContext = ChangeContext.newForRudder()
     (for {
       directive <- woLDAPDirectiveRepository.delete(
-                     DirectiveUid.apply("test_import_export_archive_directive"),
-                     ModificationId(uuidGen.newUuid),
-                     RudderEventActor,
-                     None
+                     DirectiveUid.apply("test_import_export_archive_directive")
                    )
       technique <- woLDAPDirectiveRepository.deleteActiveTechnique(
-                     ActiveTechniqueId("test_import_export_archive"),
-                     ModificationId(uuidGen.newUuid),
-                     RudderEventActor,
-                     None
+                     ActiveTechniqueId("test_import_export_archive")
                    )
     } yield {
       ()

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalProperties.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalProperties.scala
@@ -45,10 +45,11 @@ import com.normation.GitVersion
 import com.normation.box.*
 import com.normation.errors.*
 import com.normation.eventlog.ModificationId
-import com.normation.rudder.domain.eventlog.*
 import com.normation.rudder.domain.properties.*
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio.ZioRuntime
 import zio.json.*
@@ -74,27 +75,27 @@ class CheckRudderGlobalProperties(
     .flatMap(list => ZIO.foreach(list)(_.as[GlobalPropertiesJson].toIO.map(_.toGlobalParam)))
 
   private def updateOne(modId: ModificationId, p: GlobalParameter): IOResult[Unit] = {
+    // system bootstrap check: no user context, act as Rudder with full access grant
+    given qc: QueryContext = QueryContext.systemQC
     for {
       saved <- roParamRepo.getGlobalParameter(p.name)
       _     <- saved match {
                  case None                                                      =>
                    BootstrapLogger.info(s"Creating missing global properties '${p.name}' with value: '${p.valueAsString}''") *>
-                   woParamRepo.saveParameter(
-                     p,
-                     modId,
-                     RudderEventActor,
-                     Some(s"Creating global system parameter '${p.name}' to its default value")
+                   woParamRepo.saveParameter(p)(using
+                     ChangeContext
+                       .newForRudder(Some(s"Creating global system parameter '${p.name}' to its default value"))
+                       .withModId(modId)
                    )
                  case Some(s) if p.value != s.value || p.provider != s.provider =>
                    val provider = p.provider.getOrElse(PropertyProvider.systemPropertyProvider).value
                    BootstrapLogger.info(
                      s"Resetting global properties '${p.name}' from $provider provider to value: ${p.valueAsString}"
                    ) *>
-                   woParamRepo.updateParameter(
-                     p,
-                     modId,
-                     RudderEventActor,
-                     Some(s"Resetting global system properties '${p.name}' to its default value")
+                   woParamRepo.updateParameter(p)(using
+                     ChangeContext
+                       .newForRudder(Some(s"Resetting global system properties '${p.name}' to its default value"))
+                       .withModId(modId)
                    )
                  case _                                                         => ZIO.unit
                }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateDirectiveWithSelectInputBroken.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateDirectiveWithSelectInputBroken.scala
@@ -41,12 +41,12 @@ import bootstrap.liftweb.BootstrapChecks
 import bootstrap.liftweb.BootstrapLogger
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.errors.*
-import com.normation.eventlog.ModificationId
-import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.policies.ActiveTechniqueId
 import com.normation.rudder.ncf.*
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.WoDirectiveRepository
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio.*
 import zio.*
@@ -66,7 +66,9 @@ class MigrateDirectiveWithSelectInputBroken(
   override val description = "Migrate directives with invalid parameters"
 
   def updateDirectivesWithSelectInputBroken: ZIO[Any, RudderError, Unit] = {
-    val modificationId = ModificationId(uuidGenerator.newUuid)
+    // this is a system migration, it operates on all tenants
+    given cc: ChangeContext = ChangeContext.newForRudder()
+    given qc: QueryContext  = QueryContext.systemQC
     for {
       res        <- techniqueReader.readTechniquesMetadataFile
       techniques  = res.techniques.filter(_.parameters.exists(_.constraints.exists(_.select.isDefined)))
@@ -99,12 +101,8 @@ class MigrateDirectiveWithSelectInputBroken(
                         }
                         saved               <- ZIO.foreach(updatedDirectives)(d => {
                                                  writeDirectives
-                                                   .saveDirective(
-                                                     atId,
-                                                     d,
-                                                     modificationId,
-                                                     RudderEventActor,
-                                                     Some(s"Updating invalid parameters in directive ${d.id.serialize}")
+                                                   .saveDirective(atId, d)(using
+                                                     cc.withMsg(s"Updating invalid parameters in directive ${d.id.serialize}")
                                                    )
                                                    .map(_ => Right(d.id))
                                                    .catchAll(err => Left((d.id, err)).succeed)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -68,7 +68,7 @@ import scala.util.matching.Regex
 import scala.xml.*
 
 class AsyncDeployment extends CometActor with CometListener with Loggable {
-  import AsyncDeployment.*
+  import com.normation.rudder.web.comet.AsyncDeployment.*
 
   private val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
   private val nodeFactRepo         = RudderConfig.nodeFactRepository
@@ -409,7 +409,8 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
     val groupsErrors: Map[NodeGroup, String] = failures.toList match {
       case Nil      => Map.empty
       case statuses =>
-        val groups = nodeGroupRepo.getAllByIds(statuses.map { case (id, _) => id }).runNow
+        // I'm not sure whose group it is. Maybe rudder?
+        val groups = nodeGroupRepo.getAllByIds(statuses.map { case (id, _) => id })(using QueryContext.todoQC).runNow
         groups.flatMap(g => failures.get(g.id).map(f => g -> f.getMessage)).toMap
     }
     groupsErrors.toList match {
@@ -462,7 +463,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
       val btnId = nodeBtnId(node)
       scriptLinkButton(btnId, link)
     }
-    val allNodes = nodeFactRepo.getAll()(using QueryContext.systemQC).runNow
+    val allNodes = nodeFactRepo.getAll()(using QueryContext.systemQC).runNow // systemQC because rudder action
     val nodesErrors:                   Map[MinimalNodeFactInterface, String] = nodeProperties.flatMap {
       case (_, _: SuccessNodePropertyHierarchy)     => None
       case (nodeId, f: FailedNodePropertyHierarchy) => allNodes.get(nodeId).map(_ -> f.getMessage)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -103,7 +103,7 @@ class DirectiveEditForm(
     displayTechniqueDetails: ActiveTechniqueId => JsCmd = { _ => Noop }
 ) extends SecureDispatchSnippet with Loggable {
 
-  import DirectiveEditForm.*
+  import com.normation.rudder.web.components.DirectiveEditForm.*
 
   val currentDirectiveSettingForm = new LocalSnippet[DirectiveEditForm]
 
@@ -133,9 +133,9 @@ class DirectiveEditForm(
 
   private val checkRights = CurrentUser.checkRights
 
-  val rules:        List[Rule]   = roRuleRepo.getAll(false).toBox.getOrElse(Seq()).toList
+  val rules:        List[Rule]   = roRuleRepo.getAll(false)(using snippetQC).toBox.getOrElse(Seq()).toList
   val rootCategory: RuleCategory = roRuleCategoryRepo
-    .getRootCategory()
+    .getRootCategory()(using snippetQC)
     .toBox
     .getOrElse(
       throw new RuntimeException("Error when retrieving the rule root category - it is most likelly a bug. Pleae report.")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -79,16 +79,19 @@ class NodeGroupCategoryForm(
   private val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
   private val checkRights                = CurrentUser.checkRights
 
-  val categories: Seq[NodeGroupCategory] = roGroupCategoryRepository.getAllNonSystemCategories().toBox match {
-    case eb: EmptyBox =>
-      val f = eb ?~! "Can not get Group root category"
-      logger.error(f.messageChain)
-      f.rootExceptionCause.foreach(ex => logger.error("Exception was:", ex))
-      Seq()
-    case Full(cats) => cats.filter(x => x.id != _nodeGroupCategory.id)
+  val categories: Seq[NodeGroupCategory] = {
+    roGroupCategoryRepository.getAllNonSystemCategories()(using snippetQC).toBox match {
+      case eb: EmptyBox =>
+        val f = eb ?~! "Can not get Group root category"
+        logger.error(f.messageChain)
+        f.rootExceptionCause.foreach(ex => logger.error("Exception was:", ex))
+        Seq()
+      case Full(cats) => cats.filter(x => x.id != _nodeGroupCategory.id)
+    }
   }
 
-  val parentCategory: Box[NodeGroupCategory] = roGroupCategoryRepository.getParentGroupCategory(nodeGroupCategory.id).toBox
+  val parentCategory: Box[NodeGroupCategory] =
+    roGroupCategoryRepository.getParentGroupCategory(nodeGroupCategory.id)(using snippetQC).toBox
 
   val parentCategoryId: String = parentCategory match {
     case Full(x) => x.id.value

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -332,7 +332,7 @@ class NodeGroupCategoryForm(
         _nodeGroupCategory.children,
         _nodeGroupCategory.items,
         _nodeGroupCategory.isSystem,
-        security = qc.accessGrant.toSecurityTag
+        security = qc.accessGrant.restrictToWrite.toSecurityTag
       )
 
       woGroupCategoryRepository

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -201,7 +201,7 @@ class NodeGroupForm(
     })
   }
 
-  private def showRelatedRulesTree(target: RuleTarget): NodeSeq = {
+  private def showRelatedRulesTree(target: RuleTarget)(using qc: QueryContext): NodeSeq = {
     val relatedRules                     = {
       dependencyService
         .targetDependencies(target)
@@ -211,7 +211,7 @@ class NodeGroupForm(
     }
     val (includingGroup, excludingGroup) = {
       ZIO
-        .foreach(relatedRules)(ruleRepository.get)
+        .foreach(relatedRules)(r => ruleRepository.get(r))
         .map(_.partition(r => RuleTarget.merge(r.targets).includes(target)))
         .map { case (included, excluded) => (included.map(_.id), excluded.map(_.id)) }
         .runNow

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.web.components
 
 import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.rule.category.*
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.model.JsTreeNode
@@ -76,7 +75,6 @@ class RuleCategoryTree(
   private val roRuleCategoryRepository = RudderConfig.roRuleCategoryRepository
   private val woRuleCategoryRepository = RudderConfig.woRuleCategoryRepository
   private val ruleCategoryService      = RudderConfig.ruleCategoryService
-  private val uuidGen                  = RudderConfig.stringUuidGenerator
   private var root                     = rootCategory
 
   private var selectedCategoryId = rootCategory.id
@@ -116,7 +114,7 @@ class RuleCategoryTree(
   }
 
   // Update selected category and select it in the tree (trigger its function)
-  def updateSelectedCategory(newSelection: RuleCategoryId): JsCmd = {
+  def updateSelectedCategory(newSelection: RuleCategoryId)(using qc: QueryContext): JsCmd = {
     selectedCategoryId = newSelection
     // Select the new node, boolean flag to true to respect select limitation
     JsRaw(s"""
@@ -128,7 +126,7 @@ class RuleCategoryTree(
   }
 
   // Perform category selection, filter in the dataTable and display the name of the category
-  def selectCategory(): JsCmd = {
+  def selectCategory()(using qc: QueryContext): JsCmd = {
     (for {
       rootCategory <- roRuleCategoryRepository.getRootCategory().toBox
       fqdn         <- ruleCategoryService.bothFqdn(rootCategory, selectedCategoryId, rootInCaps = true)
@@ -163,13 +161,7 @@ class RuleCategoryTree(
             category <- roRuleCategoryRepository.get(sourceCatId)
             result   <-
               woRuleCategoryRepository
-                .updateAndMove(
-                  category,
-                  destCatId,
-                  ModificationId(uuidGen.newUuid),
-                  qc.actor,
-                  reason = None
-                )
+                .updateAndMove(category, destCatId)(using qc.newCC())
                 .chainError(
                   s"Error while trying to move category with requested id '${sourceCatId.value}' to category id '${destCatId.value}'"
                 )
@@ -233,7 +225,7 @@ class RuleCategoryTree(
     StringEscapeUtils.escapeEcmaScript(id.value) + "Checkbox"
   }
 
-  private def categoryNode(category: RuleCategory): JsTreeNode = new JsTreeNode {
+  private def categoryNode(category: RuleCategory)(using qc: QueryContext): JsTreeNode = new JsTreeNode {
 
     override val attrs = ("data-jstree" -> """{ "type" : "category" }""") :: ("id", category.id.value) :: Nil
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
@@ -79,7 +79,7 @@ class RuleDisplayer(
       case Some(appManagement) =>
         Full(appManagement.rootCategory)
       case None                =>
-        roCategoryRepository.getRootCategory().toBox
+        CurrentUser.queryContext.withQCOr(Empty)(roCategoryRepository.getRootCategory().toBox)
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -39,9 +39,7 @@ package com.normation.rudder.web.components
 
 import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
-import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.logger.TimingDebugLogger
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
@@ -50,6 +48,7 @@ import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.reports.ChangesByRule
 import com.normation.rudder.services.reports.NodeChanges
+import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.services.ComputePolicyMode
@@ -96,9 +95,9 @@ class RuleGrid(
   import RuleGrid.*
 
   private val getFullNodeGroupLib      = () => (qc: QueryContext) ?=> RudderConfig.roNodeGroupRepository.getFullGroupLibrary()
-  private val getFullDirectiveLib      = () => RudderConfig.roDirectiveRepository.getFullDirectiveLibrary()
+  private val getFullDirectiveLib      = () => RudderConfig.roDirectiveRepository.getFullDirectiveLibrary()(using snippetQC)
   private val getRuleApplicationStatus = RudderConfig.ruleApplicationStatus.isApplied
-  private val getRootRuleCategory      = () => RudderConfig.roRuleCategoryRepository.getRootCategory()
+  private val getRootRuleCategory      = () => RudderConfig.roRuleCategoryRepository.getRootCategory()(using snippetQC)
 
   private val recentChanges          = RudderConfig.recentChangesService
   private val techniqueRepository    = RudderConfig.techniqueRepository
@@ -109,7 +108,6 @@ class RuleGrid(
   // used to error tempering
   private val roRuleRepository = RudderConfig.roRuleRepository
   private val woRuleRepository = RudderConfig.woRuleRepository
-  private val uuidGen          = RudderConfig.stringUuidGenerator
   private val nodeFactRepo     = RudderConfig.nodeFactRepository
 
   /////  local variables /////
@@ -547,12 +545,10 @@ class RuleGrid(
             // with the disable.
             // it's only a try, so it may fails, we won't try again
             (for {
-              r <- roRuleRepository.get(rule.id)
-              _ <- woRuleRepository.update(
-                     r.copy(isEnabledStatus = false),
-                     ModificationId(uuidGen.newUuid),
-                     RudderEventActor,
-                     Some("Rule automatically disabled because it contains error (bad target or bad directives)")
+              r <- roRuleRepository.get(rule.id)(using QueryContext.systemQC) // systemQC because it's a consistency repair
+              _ <- woRuleRepository.update(r.copy(isEnabledStatus = false))(using
+                     ChangeContext
+                       .newForRudder(Some("Rule automatically disabled because it contains error (bad target or bad directives)"))
                    )
             } yield {
               logger.warn(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -92,7 +92,7 @@ class SearchNodeComponent(
 
     groupPage: Boolean
 ) extends SecureDispatchSnippet with Loggable {
-  import SearchNodeComponent.*
+  import com.normation.rudder.web.components.SearchNodeComponent.*
 
   // our local copy of things we work on
   private var query   = _query.map(x => x.copy())
@@ -555,7 +555,7 @@ object SearchNodeComponent {
       c_oldVal: String,
       v_eltid:  String,
       v_old:    String
-  ): JsCmd = {
+  )(using qc: QueryContext): JsCmd = {
     // change input display
     val comp           = ditQueryData.criteriaMap.get(ot) match {
       case None    => StringComparator
@@ -606,7 +606,7 @@ object SearchNodeComponent {
     update
   }
 
-  def replaceAttributes(func: String => Any)(ajaxParam: String): JsCmd = {
+  def replaceAttributes(func: String => Any)(ajaxParam: String)(using qc: QueryContext): JsCmd = {
     parseAttrParam(ajaxParam) match {
       case None                                                             => Alert("Can't parse for attribute: " + ajaxParam)
       case Some((ot, a_eltid, a_oldVal, c_eltid, c_oldVal, v_eltid, v_old)) =>
@@ -627,7 +627,7 @@ object SearchNodeComponent {
     }
   }
 
-  def replaceComp(func: String => Any)(ajaxParam: String): JsCmd = {
+  def replaceComp(func: String => Any)(ajaxParam: String)(using qc: QueryContext): JsCmd = {
     parseCompParam(ajaxParam) match {
       case None                                             => Alert("Can't parse for comparator: " + ajaxParam)
       case Some((ot, a, c_eltid, c_oldVal, v_eltid, v_old)) =>
@@ -643,7 +643,7 @@ object SearchNodeComponent {
   }
 
   // expected "newObjectTypeValue,attributeSelectEltId,oldAttrValue,comparatorSelectEltId,oldCompValue,valueSelectEltId,oldValue
-  def ajaxAttr(lines: Buffer[CriterionLine], i: Int): GUIDJsExp = {
+  def ajaxAttr(lines: Buffer[CriterionLine], i: Int)(using qc: QueryContext): GUIDJsExp = {
     SHtml.ajaxCall( // we we change the attribute, we want to reset the value, see issue #1199
       JE.JsRaw(
         "this.value+',at_%s,'+%s+',ct_%s,'+ %s +',v_%s,'+%s"
@@ -653,7 +653,7 @@ object SearchNodeComponent {
     )
   }
   // expect "objectTypeValue,newAttrValue,comparatorSelectEltId,oldCompValue,valueSelectEltId
-  def ajaxComp(lines: Buffer[CriterionLine], i: Int): GUIDJsExp = {
+  def ajaxComp(lines: Buffer[CriterionLine], i: Int)(using qc: QueryContext): GUIDJsExp = {
     SHtml.ajaxCall( // we we change the attribute, we want to reset the value, see issue #1199
       JE.JsRaw(
         "%s+','+this.value+',ct_%s,'+ %s +',v_%s,'+%s"
@@ -663,7 +663,7 @@ object SearchNodeComponent {
     )
   }
   // expect "newCompValue,valueSelectEltId"
-  def ajaxVal(lines: Buffer[CriterionLine], i: Int):  GUIDJsExp = {
+  def ajaxVal(lines: Buffer[CriterionLine], i: Int):                          GUIDJsExp = {
     SHtml.ajaxCall(
       JE.JsRaw("this.value+',v_%s'".format(i)),
       s => After(TimeSpan(200), replaceValue(s))
@@ -719,7 +719,7 @@ object SearchNodeComponent {
     }
   }
 
-  def objectTypeSelect(ot: ObjectCriterion, lines: Buffer[CriterionLine], i: Int): NodeSeq = {
+  def objectTypeSelect(ot: ObjectCriterion, lines: Buffer[CriterionLine], i: Int)(using qc: QueryContext): NodeSeq = {
     SHtml.untrustedSelect(
       otOptions,
       Full(ot.objectType),
@@ -732,7 +732,9 @@ object SearchNodeComponent {
     )
   }
 
-  def attributeNameSelect(ot: ObjectCriterion, a: Criterion, lines: Buffer[CriterionLine], i: Int): NodeSeq = {
+  def attributeNameSelect(ot: ObjectCriterion, a: Criterion, lines: Buffer[CriterionLine], i: Int)(using
+      qc: QueryContext
+  ): NodeSeq = {
     SHtml.untrustedSelect(
       optionAttributesFor(ot.objectType),
       Full(a.name),
@@ -866,7 +868,7 @@ object SearchNodeComponent {
     }
   }
 
-  private def asForm(criterionType: CriterionType): AsForm = {
+  private def asForm(criterionType: CriterionType)(using qc: QueryContext): AsForm = {
     criterionType match {
       case NodeStateComparator  =>
         val nodeStates: List[(String, String)] = NodeState.labeledPairs.map { case (x, label) => (x.name, S.?(label)) }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
@@ -41,7 +41,6 @@ import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
 import com.normation.cfclerk.domain.Technique
 import com.normation.cfclerk.domain.TechniqueCategory
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.policies.*
@@ -108,7 +107,6 @@ class TechniqueEditForm(
   private val roActiveTechniqueRepository = RudderConfig.roDirectiveRepository
   private val rwActiveTechniqueRepository = RudderConfig.woDirectiveRepository
   private val checkSyncService            = RudderConfig.techniqueCheckSyncService
-  private val uuidGen                     = RudderConfig.stringUuidGenerator
   // transform Technique variable to human viewable HTML fields
   private val directiveEditorService      = RudderConfig.directiveEditorService
   private val dependencyService           = RudderConfig.dependencyAndDeletionService
@@ -118,7 +116,7 @@ class TechniqueEditForm(
   private var currentActiveTechnique: Box[ActiveTechnique] = Box(activeTechnique).or {
     for {
       tech          <- Box(technique)
-      optActiveTech <- roActiveTechniqueRepository.getActiveTechnique(tech.id.name).toBox
+      optActiveTech <- roActiveTechniqueRepository.getActiveTechnique(tech.id.name)(using snippetQC).toBox
       activeTech    <- optActiveTech
     } yield {
       activeTech
@@ -371,11 +369,13 @@ class TechniqueEditForm(
         onFailureRemovePopup()
       } else {
         JsRaw("hideBsModal('deleteActionDialog');") & { // JsRaw ok, const
-          val modId = ModificationId(uuidGen.newUuid)
+          given cc: ChangeContext = qc.newCC(crReasonsRemovePopup.map(_.get))
+
           (for {
-            deleted <- dependencyService.cascadeDeleteTechnique(id, modId, qc.actor, crReasonsRemovePopup.map(_.get))
+            deleted <-
+              dependencyService.cascadeDeleteTechnique(id)
             deploy  <- {
-              asyncDeploymentAgent ! AutomaticStartDeployment(modId, RudderEventActor)
+              asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, RudderEventActor)
               Full("Policy update request sent")
             }
           } yield {
@@ -538,10 +538,11 @@ class TechniqueEditForm(
    * of given root Active Technique library.
    * The template may not be present in the library.
    */
-  private def findUserBreadCrump(target: Technique): Option[List[ActiveTechniqueCategory]] = {
+  private def findUserBreadCrump(target: Technique)(using qc: QueryContext): Option[List[ActiveTechniqueCategory]] = {
     // find the potential WBUsreTechnique for given WBTechnique
     (for {
-      activeTechnique <- roActiveTechniqueRepository.getActiveTechnique(target.id.name).toBox.flatMap(Box(_))
+      activeTechnique <-
+        roActiveTechniqueRepository.getActiveTechnique(target.id.name).toBox.flatMap(Box(_))
       crump           <- roActiveTechniqueRepository.activeTechniqueBreadCrump(activeTechnique.id).toBox
     } yield {
       crump.reverse

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueTree.scala
@@ -119,7 +119,7 @@ class TechniqueTree(
       dep:             TechniqueDependencies,
       technique:       Technique,
       activeTechnique: ActiveTechnique
-  ): JsTreeNode = new JsTreeNode {
+  )(using qc: QueryContext): JsTreeNode = new JsTreeNode {
     override val attrs = ("data-jstree" -> """{ "type" : "category" }""") :: Nil
     val tooltipContent = s"<h3>${category.name}</h3>\n<div>${category.description}</div>"
     override def body: NodeSeq = {
@@ -137,7 +137,7 @@ class TechniqueTree(
       dep:             TechniqueDependencies,
       technique:       Technique,
       activeTechnique: ActiveTechnique
-  ): JsTreeNode = new JsTreeNode {
+  )(using qc: QueryContext): JsTreeNode = new JsTreeNode {
     val tooltipContent = s"<h3>${technique.name}</h3>\n<div>${technique.description}</div>"
     override def body: NodeSeq = {
       <a href="#"><span class="treeTechniqueName"  data-bs-toggle="tooltip" title={tooltipContent}>{technique.name}</span></a>
@@ -148,7 +148,7 @@ class TechniqueTree(
                                                                                       else Nil)
   }
 
-  private def directiveNode(dep: TechniqueDependencies, id: DirectiveUid): JsTreeNode = {
+  private def directiveNode(dep: TechniqueDependencies, id: DirectiveUid)(using qc: QueryContext): JsTreeNode = {
     val (directive, ruleIds) = dep.directives(id)
 
     new JsTreeNode {
@@ -163,7 +163,7 @@ class TechniqueTree(
     }
   }
 
-  private def ruleNode(id: RuleId): JsTreeNode = {
+  private def ruleNode(id: RuleId)(using qc: QueryContext): JsTreeNode = {
     ruleRepository.get(id).toBox match {
       case Full(rule) =>
         new JsTreeNode {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
@@ -149,7 +149,7 @@ class CreateActiveTechniqueCategoryPopup(
             children = Nil,
             items = Nil,
             isSystem = false,
-            security = qc.accessGrant.toSecurityTag
+            security = qc.accessGrant.restrictToWrite.toSecurityTag
           ),
           ActiveTechniqueCategoryId(categoryContainer.get)
         )(using qc.newCC(Some("user created a new category")))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
@@ -72,7 +72,7 @@ class CreateActiveTechniqueCategoryPopup(
   private val rwActiveTechniqueCategoryRepository = RudderConfig.woDirectiveRepository
   private val uuidGen                             = RudderConfig.stringUuidGenerator
 
-  private val categories = activeTechniqueCategoryRepository.getAllActiveTechniqueCategories().toBox
+  private val categories = activeTechniqueCategoryRepository.getAllActiveTechniqueCategories()(using snippetQC).toBox
 
   def secureDispatch: QueryContext ?=> PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => popupContent }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -259,7 +259,7 @@ class CreateCategoryOrGroupPopup(
             Nil,
             Nil,
             isSystem = false,
-            security = qc.accessGrant.toSecurityTag
+            security = qc.accessGrant.restrictToWrite.toSecurityTag
           ),
           NodeGroupCategoryId(piContainer.get)
         )(using
@@ -293,7 +293,7 @@ class CreateCategoryOrGroupPopup(
         isDynamic,
         srvList,
         _isEnabled = true,
-        security = qc.accessGrant.toSecurityTag
+        security = qc.accessGrant.restrictToWrite.toSecurityTag
       )
       woNodeGroupRepository
         .create(nodeGroup, NodeGroupCategoryId(piContainer.get))(using

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
@@ -200,7 +200,7 @@ class CreateCloneDirectivePopup(
           shortDescription = directiveShortDescription.get,
           _isEnabled = directive.isEnabled,
           policyMode = directive.policyMode,
-          security = qc.accessGrant.toSecurityTag
+          security = qc.accessGrant.restrictToWrite.toSecurityTag
         )
       }
       roDirectiveRepository

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
@@ -41,7 +41,6 @@ import bootstrap.liftweb.RudderConfig
 import com.normation.GitVersion
 import com.normation.box.*
 import com.normation.cfclerk.domain.TechniqueVersion
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.components.popup.CreateCloneDirectivePopup.*
@@ -212,11 +211,8 @@ class CreateCloneDirectivePopup(
           woDirectiveRepository
             .saveDirective(
               activeTechnique.id,
-              cloneDirective,
-              ModificationId(uuidGen.newUuid),
-              qc.actor,
-              reasons.map(_.get)
-            )
+              cloneDirective
+            )(using qc.newCC(reasons.map(_.get)))
             .toBox match {
             case Full(_) => {
               closePopup() & onSuccessCallback(cloneDirective)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -132,7 +132,7 @@ class CreateCloneGroupPopup(
                   Nil,
                   Nil,
                   isSystem = false,
-                  security = qc.accessGrant.toSecurityTag
+                  security = qc.accessGrant.restrictToWrite.toSecurityTag
                 ),
                 NodeGroupCategoryId(groupContainer.get)
               )(using
@@ -167,7 +167,7 @@ class CreateCloneGroupPopup(
               isDynamic,
               srvList,
               _isEnabled = true,
-              security = qc.accessGrant.toSecurityTag
+              security = qc.accessGrant.restrictToWrite.toSecurityTag
             )
 
             woNodeGroupRepository

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -38,10 +38,14 @@ class CreateCloneGroupPopup(
   private val uuidGen               = RudderConfig.stringUuidGenerator
   private val userPropertyService   = RudderConfig.userPropertyService
 
-  private val categories       = roNodeGroupRepository.getAllNonSystemCategories()
+  private val categories       = roNodeGroupRepository.getAllNonSystemCategories()(using snippetQC)
   // Fetch the parent category, if any
-  private val parentCategoryId =
-    nodeGroup.flatMap(x => roNodeGroupRepository.getNodeGroupCategory(x.id).toBox).map(_.id.value).getOrElse("")
+  private val parentCategoryId = {
+    nodeGroup
+      .flatMap(x => roNodeGroupRepository.getNodeGroupCategory(x.id)(using snippetQC).toBox)
+      .map(_.id.value)
+      .getOrElse("")
+  }
 
   var createContainer = false
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -158,7 +158,7 @@ class CreateOrUpdateGlobalParameterPopup(
                                parameterDescription.get,
                                None,
                                Visibility.default,
-                               security = qc.accessGrant.toSecurityTag
+                               security = qc.accessGrant.restrictToWrite.toSecurityTag
                              )
           diff            <- globalParamDiffFromAction(param)
           cr               = ChangeRequestService.createChangeRequestFromGlobalParameter(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -220,7 +220,7 @@ class CreateOrCloneRulePopup(
           shortDescription = ruleShortDescription.get,
           longDescription = clonedRule.map(_.longDescription).getOrElse(""),
           isEnabledStatus = !clonedRule.isDefined,
-          security = qc.accessGrant.toSecurityTag
+          security = qc.accessGrant.restrictToWrite.toSecurityTag
         )
       }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -40,7 +40,6 @@ package com.normation.rudder.web.components.popup
 import CreateOrCloneRulePopup.*
 import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
@@ -226,7 +225,7 @@ class CreateOrCloneRulePopup(
       }
 
       val createRule = {
-        woRuleRepository.create(rule, ModificationId(uuidGen.newUuid), qc.actor, reason.map(_.get)).toBox match {
+        woRuleRepository.create(rule)(using qc.newCC(reason.map(_.get))).toBox match {
           case Full(x)          =>
             onSuccessCallback(rule) & closePopup()
           case Empty            =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
@@ -68,17 +68,19 @@ class ExpectedPolicyPopup(
     htmlId_popup: String,
     nodeSrv:      Srv
 ) extends SecureDispatchSnippet with Loggable {
-  import ExpectedPolicyPopup.*
+  import com.normation.rudder.web.components.popup.ExpectedPolicyPopup.*
 
   private val ruleRepository  = RudderConfig.roRuleRepository
   private val dynGroupService = RudderConfig.dynGroupService
   private val checkDynGroup   = RudderConfig.pendingNodeCheckGroup
 
-  def secureDispatch: QueryContext ?=> PartialFunction[String, NodeSeq => NodeSeq] = { case "display" => { _ => display } }
+  override def secureDispatch: QueryContext ?=> PartialFunction[String, NodeSeq => NodeSeq] = {
+    case "display" => { _ => display }
+  }
 
   def display(using qc: QueryContext): NodeSeq = {
     // find the list of dyn groups on which that server would be and from that, the Rules
-    val rulesGrid: NodeSeq = getDependantRulesForNode match {
+    val rulesGrid: NodeSeq = getDependantRulesForNode() match {
       case Full(seq) =>
         val noDisplay = DisplayColumn.Force(display = false)
 
@@ -108,7 +110,7 @@ class ExpectedPolicyPopup(
     )(expectedTechnique)
   }
 
-  private val getDependantRulesForNode: Box[Seq[Rule]] = {
+  private def getDependantRulesForNode()(using qc: QueryContext): Box[Seq[Rule]] = {
     for {
       allDynGroups <- dynGroupService.getAllDynGroups()
       dynGroups    <- checkDynGroup

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -43,7 +43,6 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
 import com.normation.errors.PureResult
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.nodes.AddNodeGroupDiff
@@ -58,6 +57,7 @@ import com.normation.rudder.services.workflows.DGModAction
 import com.normation.rudder.services.workflows.DirectiveChangeRequest
 import com.normation.rudder.services.workflows.NodeGroupChangeRequest
 import com.normation.rudder.services.workflows.WorkflowService
+import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.components.DisplayColumn
@@ -211,7 +211,6 @@ class ModificationValidationPopup(
 
   private val userPropertyService   = RudderConfig.userPropertyService
   private val dependencyService     = RudderConfig.dependencyAndDeletionService
-  private val uuidGen               = RudderConfig.stringUuidGenerator
   private val techniqueRepo         = RudderConfig.techniqueRepository
   private val asyncDeploymentAgent  = RudderConfig.asyncDeploymentAgent
   private val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
@@ -654,13 +653,13 @@ class ModificationValidationPopup(
       activeTechniqueId: ActiveTechniqueId,
       why:               Option[String]
   )(using qc: QueryContext): JsCmd = {
-    val modId = ModificationId(uuidGen.newUuid)
-    woDirectiveRepository.saveDirective(activeTechniqueId, directive, modId, qc.actor, why).either.runNow match {
+    given cc: ChangeContext = qc.newCC(why)
+    woDirectiveRepository.saveDirective(activeTechniqueId, directive).either.runNow match {
       case Right(optChanges) =>
         optChanges match {
           case Some(diff) if diff.needDeployment =>
             // There is a modification diff that required deployment, launch a deployment.
-            asyncDeploymentAgent ! AutomaticStartDeployment(modId, RudderEventActor)
+            asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, RudderEventActor)
           case _                                 => // No change worthy of deployment, don't launch a deployment
         }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.web.components.popup
 
 import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.tenants.QueryContext
@@ -207,8 +206,7 @@ class RuleCategoryPopup(
   private def onSubmitDelete()(using qc: QueryContext): JsCmd = {
     targetCategory match {
       case Some(category) =>
-        val modId = new ModificationId(uuidGen.newUuid)
-        woRulecategoryRepository.delete(category.id, modId, qc.actor, None, checkEmpty = true).toBox match {
+        woRulecategoryRepository.delete(category.id, checkEmpty = true)(using qc.newCC()).toBox match {
           case Full(x) =>
             closePopup() &
             onSuccessCallback(x.value) &
@@ -242,8 +240,7 @@ class RuleCategoryPopup(
           )
 
           val parent = RuleCategoryId(categoryParent.get)
-          val modId  = new ModificationId(uuidGen.newUuid)
-          woRulecategoryRepository.create(newCategory, parent, modId, qc.actor, None).toBox
+          woRulecategoryRepository.create(newCategory, parent)(using qc.newCC()).toBox
         case Some(category) =>
           val updated = category.copy(
             name = categoryName.get,
@@ -254,8 +251,7 @@ class RuleCategoryPopup(
           if (updated == category && parentCategory.exists(_ == parent.value)) {
             Failure("There are no modifications to save")
           } else {
-            val modId = new ModificationId(uuidGen.newUuid)
-            woRulecategoryRepository.updateAndMove(updated, parent, modId, qc.actor, None).toBox
+            woRulecategoryRepository.updateAndMove(updated, parent)(using qc.newCC()).toBox
           }
       }) match {
         case Full(x)          => closePopup() & onSuccessCallback(x.id.value) & onSuccessCategory(x)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
@@ -236,7 +236,7 @@ class RuleCategoryPopup(
             categoryDescription.get,
             Nil,
             isSystem = false,
-            security = qc.accessGrant.toSecurityTag
+            security = qc.accessGrant.restrictToWrite.toSecurityTag
           )
 
           val parent = RuleCategoryId(categoryParent.get)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
@@ -47,6 +47,8 @@ import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyModeOverrides.*
 import com.normation.rudder.repository.FullActiveTechnique
 import com.normation.rudder.repository.FullActiveTechniqueCategory
+import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.SecurityTag
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.model.JsTreeNode
 import com.normation.rudder.web.snippet.WithNonce
@@ -118,6 +120,17 @@ object DisplayDirectiveTree extends Loggable {
 
   private val linkUtil = RudderConfig.linkUtil
 
+  private def tenantsBadge(security: Option[SecurityTag])(using qc: QueryContext): NodeSeq = {
+    qc.accessGrant.visibleSecurityTag(security) match {
+      case Some(SecurityTag.ByTenants(tenants)) if tenants.nonEmpty =>
+        val label = tenants.map(_.value).mkString(", ")
+        <span class="tenants-label" data-bs-toggle="tooltip" data-bs-placement="top" title={s"Tenants: ${label}"}>
+          <i class="fa fa-building"></i><b> {tenants.size}</b>
+        </span>
+      case _                                                        => NodeSeq.Empty
+    }
+  }
+
   /**
    * Display the directive tree, optionaly filtering out
    * some category or group by defining which one to
@@ -139,7 +152,7 @@ object DisplayDirectiveTree extends Loggable {
       keepCategory:     FullActiveTechniqueCategory => Boolean = _ => true,
       keepTechnique:    FullActiveTechnique => Boolean = _ => true,
       keepDirective:    Directive => Boolean = _ => true
-  ): NodeSeq = {
+  )(using qc: QueryContext): NodeSeq = {
 
     def displayCategory(
         category: FullActiveTechniqueCategory,
@@ -262,7 +275,7 @@ object DisplayDirectiveTree extends Loggable {
               """
             }
 
-            val className     = {
+            val className        = {
               val defaultClass    = "treeActiveTechniqueName"
               val disabledClass   = if (!activeTechnique.isEnabled) { "is-disabled" }
               else { "" }
@@ -270,15 +283,16 @@ object DisplayDirectiveTree extends Loggable {
               else { "" }
               s"${defaultClass} ${disabledClass} ${deprecatedClass}"
             }
-            val disabledBadge = if (!activeTechnique.isEnabled) { <span class="badge-disabled"></span> }
+            val disabledBadge    = if (!activeTechnique.isEnabled) { <span class="badge-disabled"></span> }
             else { NodeSeq.Empty }
+            val tenantsBadgeHtml = tenantsBadge(activeTechnique.security)
             <span class={
               className
             } data-bs-toggle="tooltip" data-bs-placement="top" title={
               tooltipContent
             }>{
               agentCompat.icon
-            }{technique.name}</span> ++ disabledBadge ++ btnCreateDirective
+            }{technique.name}</span> ++ disabledBadge ++ tenantsBadgeHtml ++ btnCreateDirective
           case None            =>
             <span class="error">The technique with id ''{activeTechnique.techniqueName}'' is missing from repository</span>
         }
@@ -495,7 +509,7 @@ object DisplayDirectiveTree extends Loggable {
               NodeSeq.Empty
             }
           }
-          </span> ++ { directiveTagsTooltip } ++
+          </span> ++ { directiveTagsTooltip } ++ { tenantsBadge(directive.security) } ++
           <div class="treeActions-container"> {actionBtns} {editButton} </div> ++
           WithNonce.scriptWithNonce(
             Script(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
@@ -45,6 +45,7 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.repository.*
+import com.normation.rudder.tenants.QueryContext
 import net.liftweb.common.*
 
 /**
@@ -59,7 +60,9 @@ class JsTreeUtilService(
 ) {
 
   // get the Active Technique category, log on error
-  def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId, logger: Logger): Option[ActiveTechniqueCategory] = {
+  def getActiveTechniqueCategory(id: ActiveTechniqueCategoryId, logger: Logger)(using
+      qc: QueryContext
+  ): Option[ActiveTechniqueCategory] = {
     directiveRepository.getActiveTechniqueCategory(id).toBox match {
       // remove sytem category
       case Full(Some(cat)) => if (cat.isSystem) None else Some(cat)
@@ -71,7 +74,9 @@ class JsTreeUtilService(
   }
 
   // get the Active Technique, log on error
-  def getActiveTechnique(id: ActiveTechniqueId, logger: Logger): Box[(ActiveTechnique, Option[Technique])] = {
+  def getActiveTechnique(id: ActiveTechniqueId, logger: Logger)(using
+      qc: QueryContext
+  ): Box[(ActiveTechnique, Option[Technique])] = {
     (for {
       activeTechnique <- directiveRepository.getActiveTechniqueByActiveTechnique(id).toBox.flatMap {
                            Box(_)
@@ -88,11 +93,13 @@ class JsTreeUtilService(
   }
 
   // get the Directive, log on error
-  def getPi(id: DirectiveUid, logger: Logger): Option[Directive] = directiveRepository.getDirective(id).toBox match {
-    case Full(directive) => directive
-    case e: EmptyBox =>
-      logger.error("Error while fetching node %s".format(id), e ?~! "Error message was:")
-      None
+  def getPi(id: DirectiveUid, logger: Logger)(using qc: QueryContext): Option[Directive] = {
+    directiveRepository.getDirective(id).toBox match {
+      case Full(directive) => directive
+      case e: EmptyBox =>
+        logger.error("Error while fetching node %s".format(id), e ?~! "Error message was:")
+        None
+    }
   }
 
   def getPtCategory(id: TechniqueCategoryId, logger: Logger): Option[TechniqueCategory] = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
@@ -46,6 +46,7 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.Reports
 import com.normation.rudder.repository.ReportsRepository
 import com.normation.rudder.repository.RoRuleRepository
+import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.*
 import com.normation.utils.DateFormaterService
@@ -77,7 +78,7 @@ class LogDisplayer(
     "logs-content"
   )
 
-  def ajaxRefresh(nodeId: NodeId, runDate: Option[DateTime], tableId: String): GUIDJsExp = {
+  def ajaxRefresh(nodeId: NodeId, runDate: Option[DateTime], tableId: String)(using qc: QueryContext): GUIDJsExp = {
     runDate match {
       case Some(runDate) =>
         SHtml.ajaxInvoke(() => {
@@ -91,7 +92,7 @@ class LogDisplayer(
     }
   }
 
-  def asyncDisplay(nodeId: NodeId, runDate: Option[DateTime], tableId: String): JsCmd = {
+  def asyncDisplay(nodeId: NodeId, runDate: Option[DateTime], tableId: String)(using qc: QueryContext): JsCmd = {
     val id      = JsNodeId(nodeId)
     val refresh = ajaxRefresh(nodeId, runDate, tableId)
     def getEventsInterval(jsonInterval: String): JsCmd = {
@@ -172,7 +173,7 @@ class LogDisplayer(
     """) // JsRaw ok, escaped
   }
 
-  def refreshData(nodeId: NodeId, reports: => Seq[Reports], tableId: String): JsCmd = {
+  def refreshData(nodeId: NodeId, reports: => Seq[Reports], tableId: String)(using qc: QueryContext): JsCmd = {
     def getDirectiveName(directiveId: DirectiveId): Box[String] = {
       configRepository
         .getDirective(directiveId)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -555,7 +555,9 @@ class ReportDisplayer(
   }
 
   // Handle show/hide logic of buttons, and rewrite button/container ids to avoid conflicts between tabs
-  private def displayRunLogs(nodeId: NodeId, runDate: Option[DateTime], tabId: String, tableId: String): NodeSeq = {
+  private def displayRunLogs(nodeId: NodeId, runDate: Option[DateTime], tabId: String, tableId: String)(using
+      qc: QueryContext
+  ): NodeSeq = {
     val btnId               = s"allLogButton-${tabId}"
     val logRunId            = s"logRun-${tabId}"
     val complianceLogGridId = s"complianceLogsGrid-${tabId}"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/TechniqueReloadingCallbacks.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/TechniqueReloadingCallbacks.scala
@@ -75,7 +75,7 @@ class SaveDirectivesOnTechniqueCallback(
   )(implicit cc: ChangeContext): Box[Unit] = {
 
     for {
-      techLib <- roDirectiveRepo.getFullDirectiveLibrary().toBox
+      techLib <- roDirectiveRepo.getFullDirectiveLibrary()(using cc.toQC).toBox
       updated <- bestEffort(techLib.allDirectives.values.toSeq) {
                    case (inActiveTechnique, directive) =>
                      techniqueIds.get(inActiveTechnique.techniqueName) match {
@@ -89,11 +89,11 @@ class SaveDirectivesOnTechniqueCallback(
                            newDirective = directive.copy(parameters = paramEditor.mapValueSeq)
                            saved       <- if (directive.isSystem) {
                                             woDirectiveRepo
-                                              .saveSystemDirective(inActiveTechnique.id, newDirective, cc.modId, cc.actor, cc.message)
+                                              .saveSystemDirective(inActiveTechnique.id, newDirective)
                                               .toBox
                                           } else {
                                             woDirectiveRepo
-                                              .saveDirective(inActiveTechnique.id, newDirective, cc.modId, cc.actor, cc.message)
+                                              .saveDirective(inActiveTechnique.id, newDirective)
                                               .toBox
                                           }
                          } yield {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -46,10 +46,7 @@ import com.normation.inventory.domain.PhysicalMachineType
 import com.normation.inventory.domain.VirtualMachineType
 import com.normation.inventory.domain.WindowsType
 import com.normation.inventory.ldap.core.TimingDebugLoggerPure
-import com.normation.ldap.sdk.BuildFilter.*
-import com.normation.ldap.sdk.FALSE
 import com.normation.plugins.SecureExtendableSnippet
-import com.normation.rudder.domain.RudderLDAPConstants.*
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.logger.ComplianceLogger
@@ -155,7 +152,7 @@ class HomePage extends SecureExtendableSnippet[HomePage] with StatefulSnippet wi
     )
   }
 
-  def details(html: NodeSeq):                                 NodeSeq = {
+  def details(html: NodeSeq):                              NodeSeq = {
     html
   }
   def pendingNodes(html: NodeSeq)(using qc: QueryContext): NodeSeq = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -122,12 +122,11 @@ object HomePageUtils {
 class HomePage extends SecureExtendableSnippet[HomePage] with StatefulSnippet with Loggable {
 
   private val nodeFactRepo     = RudderConfig.nodeFactRepository
-  private val ldap             = RudderConfig.roLDAPConnectionProvider
-  private val rudderDit        = RudderConfig.rudderDit
   private val reportingService = RudderConfig.reportingService
   private val roRuleRepo       = RudderConfig.roRuleRepository
   private val scoreService     = RudderConfig.rci.scoreService
   private val directiveRepo    = RudderConfig.roDirectiveRepository
+  private val groupRepo        = RudderConfig.roNodeGroupRepository
 
   def mainSecureDispatch: QueryContext ?=> Map[String, NodeSeq => NodeSeq] = {
 
@@ -159,7 +158,7 @@ class HomePage extends SecureExtendableSnippet[HomePage] with StatefulSnippet wi
   def details(html: NodeSeq):                                 NodeSeq = {
     html
   }
-  def pendingNodes(html: NodeSeq)(implicit qc: QueryContext): NodeSeq = {
+  def pendingNodes(html: NodeSeq)(using qc: QueryContext): NodeSeq = {
     displayCount(countPendingNodes, "pending nodes")
   }
 
@@ -167,23 +166,23 @@ class HomePage extends SecureExtendableSnippet[HomePage] with StatefulSnippet wi
     displayCount(Full(nodeCount), "accepted nodes")
   }
 
-  def rules(html: NodeSeq): NodeSeq = {
+  def rules(html: NodeSeq)(using qc: QueryContext): NodeSeq = {
     displayCount(countAllRules(), "rules")
   }
 
-  def directives(html: NodeSeq): NodeSeq = {
+  def directives(html: NodeSeq)(using qc: QueryContext): NodeSeq = {
     displayCount(countAllDirectives(), "directives")
   }
 
-  def groups(html: NodeSeq): NodeSeq = {
+  def groups(html: NodeSeq)(using qc: QueryContext): NodeSeq = {
     displayCount(countAllGroups(), "groups")
   }
 
-  def techniques(html: NodeSeq): NodeSeq = {
+  def techniques(html: NodeSeq)(using qc: QueryContext): NodeSeq = {
     displayCount(countAllTechniques(), "techniques")
   }
 
-  def getAllCompliance(allNodes: Map[NodeId, CoreNodeFact])(implicit qc: QueryContext): NodeSeq = {
+  def getAllCompliance(allNodes: Map[NodeId, CoreNodeFact])(using qc: QueryContext): NodeSeq = {
     // this needs to be outside of the zio for-comprehension context to see the right node facts
     val nodes = allNodes.filter(_._2.rudderSettings.state.isEnabled).keys.toSet
     (for {
@@ -416,21 +415,19 @@ class HomePage extends SecureExtendableSnippet[HomePage] with StatefulSnippet wi
     res
   }
 
-  private def countPendingNodes(implicit qc: QueryContext): Box[Int] = {
-    nodeFactRepo.getAll()(using qc, SelectNodeStatus.Pending).map(_.size)
-  }.toBox
+  private def countPendingNodes(using qc: QueryContext): Box[Int] = {
+    nodeFactRepo.getAll()(using qc, SelectNodeStatus.Pending).map(_.size).toBox
+  }
 
-  private def countAllRules(): Box[Int] = {
+  private def countAllRules()(using qc: QueryContext): Box[Int] = {
     roRuleRepo.getIds().map(_.size).toBox
   }
 
-  private def countAllDirectives(): Box[Int] = {
-    ldap.flatMap { con =>
-      con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, AND(IS(OC_DIRECTIVE), EQ(A_IS_SYSTEM, FALSE.toLDAPString)), "1.1")
-    }.map(x => x.size)
-  }.toBox
+  private def countAllDirectives()(using qc: QueryContext): Box[Int] = {
+    directiveRepo.getFullDirectiveLibrary().map(_.allDirectives.size).toBox
+  }
 
-  private def countAllTechniques(): Box[Int] = {
+  private def countAllTechniques()(using qc: QueryContext): Box[Int] = {
     // for techniques, we can't easily rely on LDAP attribute, because we can have a mix of isSystem/policyType.
     // So just use the repo.
     directiveRepo
@@ -439,13 +436,12 @@ class HomePage extends SecureExtendableSnippet[HomePage] with StatefulSnippet wi
         // here, we only want to count one technique whatever the number of versions, but only the ones enabled and of type "base"
         case (_, at) if at.policyTypes.isBase && at.isEnabled => Math.min(1, at.techniques.count(_._2.policyTypes.isBase))
       }.sum)
-  }.toBox
+      .toBox
+  }
 
-  private def countAllGroups(): Box[Int] = {
-    ldap
-      .flatMap(con => con.searchSub(rudderDit.GROUP.dn, OR(IS(OC_RUDDER_NODE_GROUP), IS(OC_SPECIAL_TARGET)), "1.1"))
-      .map(x => x.size)
-  }.toBox
+  private def countAllGroups()(using qc: QueryContext): Box[Int] = {
+    groupRepo.getAll().map(_.size).toBox
+  }
 
   private def displayCount(count: Box[Int], name: String) = {
     Text((count match {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -112,7 +112,7 @@ class TechniqueLibraryManagement extends SecureDispatchSnippet with Loggable {
   // current states for the page - they will be kept only for the duration
   // of one request and its followng Ajax requests
 
-  private val rootCategoryId = roActiveTechniqueRepository.getActiveTechniqueLibrary.map(_.id).toBox
+  private val rootCategoryId = roActiveTechniqueRepository.getActiveTechniqueLibrary(using snippetQC).map(_.id).toBox
 
   private val currentTechniqueDetails         = new LocalSnippet[TechniqueEditForm]
   private val currentTechniqueCategoryDetails = new LocalSnippet[TechniqueCategoryEditForm]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -46,7 +46,6 @@ import com.normation.cfclerk.domain.TechniqueGenerationMode.*
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.errors
-import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.domain.policies.ActiveTechniqueId
@@ -92,7 +91,7 @@ object JsonDirectiveRId {
 /**
  * Snippet for managing the System and Active Technique libraries.
  *
- * It allow to see what Techniques are available in the
+ * It allows to see what Techniques are available in the
  * system library, choose and configure which one to use in
  * the user private library.
  *
@@ -100,7 +99,9 @@ object JsonDirectiveRId {
  *
  */
 class DirectiveManagement extends SecureDispatchSnippet with Loggable {
-  import DirectiveManagement.*
+  import com.normation.rudder.web.snippet.configuration.DirectiveManagement.*
+
+  given qc: QueryContext = RudderConfig.userService.getCurrentQC
 
   private val techniqueRepository = RudderConfig.techniqueRepository
   private val getDirectiveLib     = () => RudderConfig.roDirectiveRepository.getFullDirectiveLibrary()
@@ -659,13 +660,12 @@ class DirectiveManagement extends SecureDispatchSnippet with Loggable {
                 "Delete",
                 () => {
                   RudderConfig.woDirectiveRepository
-                    .delete(
-                      directive.id.uid,
-                      ModificationId(RudderConfig.stringUuidGenerator.newUuid),
-                      qc.actor,
-                      Some(
-                        s"Deleting directive '${directive.name}' (${directive.id.debugString}) because its technique isn't available anymore"
-                      ).toBox
+                    .delete(directive.id.uid)(using
+                      qc.newCC(
+                        Some(
+                          s"Deleting directive '${directive.name}' (${directive.id.debugString}) because its technique isn't available anymore"
+                        )
+                      )
                     )
                     .toBox match {
                     case Full(diff) =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -721,7 +721,7 @@ class DirectiveManagement extends SecureDispatchSnippet with Loggable {
             "",
             5,
             _isEnabled = true,
-            security = qc.accessGrant.toSecurityTag
+            security = qc.accessGrant.restrictToWrite.toSecurityTag
           )
         }
         updateDirectiveSettingForm(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
@@ -46,6 +46,7 @@ import com.normation.rudder.services.workflows.GlobalParamChangeRequest
 import com.normation.rudder.services.workflows.GlobalParamModAction
 import com.normation.rudder.services.workflows.WorkflowService
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.SecurityTag
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.components.popup.CreateOrUpdateGlobalParameterPopup
 import com.normation.rudder.web.snippet.WithNonce
@@ -86,13 +87,24 @@ class ParameterManagement extends SecureDispatchSnippet with Loggable {
     }
   }
 
+  private def tenantsBadge(param: GlobalParameter)(implicit qc: QueryContext): NodeSeq = {
+    qc.accessGrant.visibleSecurityTag(param.security) match {
+      case Some(SecurityTag.ByTenants(tenants)) if tenants.nonEmpty =>
+        val label = tenants.map(_.value).mkString(", ")
+        <span class="tenants-label" data-bs-toggle="tooltip" data-bs-placement="top" title={s"Tenants: ${label}"}>
+          <i class="fa fa-building"></i><b> {tenants.size}</b>
+        </span>
+      case _                                                        => NodeSeq.Empty
+    }
+  }
+
   def displayGridParameters(params: Seq[GlobalParameter], gridName: String)(implicit qc: QueryContext): NodeSeq = {
     (
       "tbody *" #> ("tr" #> params.map { param =>
         val lineHtmlId = Helpers.nextFuncName
         ".parameterLine [jsuuid]" #> lineHtmlId &
         ".parameterLine [class]" #> Text("cursorPointer") &
-        ".name *" #> <b>{param.name}</b> &
+        ".name *" #> (<b>{param.name}</b> ++ tenantsBadge(param)) &
         ".value *" #> <pre class="json-beautify">{param.valueAsString}</pre> &
         ".description *" #> <span><ul class="ms-2"><li><b>Description:</b> {Text(param.description)}</li></ul></span> &
         ".description [id]" #> ("description-" + lineHtmlId) &

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -146,7 +146,7 @@ class SearchNodes extends SecureDispatchSnippet with StatefulSnippet with Loggab
               serverList = serverList.openOr(Seq[CoreNodeFact]()).map(_.id).toSet,
               _isEnabled = true,
               isSystem = false,
-              security = qc.accessGrant.toSecurityTag
+              security = qc.accessGrant.restrictToWrite.toSecurityTag
             )
           ),
           rootCategory = groupLibrary,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/net/liftweb/http/SecureDispatchSnippet.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/net/liftweb/http/SecureDispatchSnippet.scala
@@ -56,12 +56,12 @@ trait SecureDispatchSnippet extends DispatchSnippet {
     CurrentUser.queryContext.withQCOr(loggedInsecureDispatch)(secureDispatch)
   }
 
-  private def logInvaliAccess: Unit = ApplicationLoggerPure.Auth.logEffect.warn(
+  private def logInvalidAccess: Unit = ApplicationLoggerPure.Auth.logEffect.warn(
     s"Snippet '${this.getClass.getName}' can't be accessed in current security context (user is not authenticated)"
   )
 
   private def loggedInsecureDispatch: DispatchIt = {
-    logInvaliAccess
+    logInvalidAccess
     PartialFunction.empty
   }
 
@@ -69,7 +69,7 @@ trait SecureDispatchSnippet extends DispatchSnippet {
   // This need to be a val to avoid evaluation on ZIO runtime: https://github.com/Normation/rudder/pull/7188
   val snippetQC: QueryContext = {
     CurrentUser.queryContext.getOrElse {
-      logInvaliAccess
+      logInvalidAccess
       QueryContext.noneQC
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/net/liftweb/http/SecureDispatchSnippet.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/net/liftweb/http/SecureDispatchSnippet.scala
@@ -56,11 +56,22 @@ trait SecureDispatchSnippet extends DispatchSnippet {
     CurrentUser.queryContext.withQCOr(loggedInsecureDispatch)(secureDispatch)
   }
 
+  private def logInvaliAccess: Unit = ApplicationLoggerPure.Auth.logEffect.warn(
+    s"Snippet '${this.getClass.getName}' can't be accessed in current security context (user is not authenticated)"
+  )
+
   private def loggedInsecureDispatch: DispatchIt = {
-    ApplicationLoggerPure.Auth.logEffect.warn(
-      s"Snippet '${this.getClass.getName}' can't be accessed in current security context (user is not authenticated)"
-    )
+    logInvaliAccess
     PartialFunction.empty
+  }
+
+  // A method for having a query context available even during class instantiation
+  // This need to be a val to avoid evaluation on ZIO runtime: https://github.com/Normation/rudder/pull/7188
+  val snippetQC: QueryContext = {
+    CurrentUser.queryContext.getOrElse {
+      logInvaliAccess
+      QueryContext.noneQC
+    }
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
@@ -316,6 +316,24 @@ attributeTypes: ( 1.3.6.1.4.1.35061.2.1.355
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseExactMatch
   SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.356
+  NAME 'visibility'
+  DESC 'visibility of a property or parameter'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.357
+  NAME 'inheritMode'
+  DESC 'inherit mode of a property or parameter'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.358
+  NAME 'revision'
+  DESC 'revision of a versioned object'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 #######################################################
 ################  Object Classes ######################
 #######################################################
@@ -445,7 +463,7 @@ objectClasses: ( 1.3.6.1.4.1.35061.2.2.120
   SUP top
   STRUCTURAL
   MUST ( parameterName )
-  MAY ( parameterValue $ description $ propertyProvider $ securityTag) )
+  MAY ( parameterValue $ description $ propertyProvider $ securityTag $ visibility $ inheritMode $ revision) )
 #
 # Application properties
 #

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -52,6 +52,7 @@ import com.normation.rudder.UncheckedCustomRole
 import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.rest.AuthorizationApiMapping
 import com.normation.rudder.rest.RoleApiMapping
+import com.normation.rudder.tenants.TenantAccess
 import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.rudder.tenants.TenantId
 import com.normation.rudder.users.Argon2EncoderParams
@@ -337,14 +338,16 @@ class RudderUserDetailsTest extends ZIOSpecDefault {
         val userDetailList = getUserDetailList(tenantXML_1, "tenantXML_1")
 
         test("be able to define one tenants") {
-          assert(userDetailList.users("user_single").accessGrant)(equalTo(TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA")))))
+          assert(userDetailList.users("user_single").accessGrant)(
+            equalTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")))))
+          )
         }
 
         test("be able to define a list of tenants") {
           assert(userDetailList.users("user_multi").accessGrant)(
             equalTo(
               TenantAccessGrant.ByTenants(
-                Chunk(TenantId("zoneA"), TenantId("zoneB"))
+                Chunk(TenantAccess(TenantId("zoneA")), TenantAccess(TenantId("zoneB")))
               )
             )
           )
@@ -367,7 +370,9 @@ class RudderUserDetailsTest extends ZIOSpecDefault {
         }
 
         test("only have access to sane ascii identifier") {
-          assert(userDetailList.users("user_ascii").accessGrant)(equalTo(TenantAccessGrant.ByTenants(Chunk(TenantId("zoneA")))))
+          assert(userDetailList.users("user_ascii").accessGrant)(
+            equalTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")))))
+          )
         }
       }
     }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestCheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestCheckUsersFile.scala
@@ -102,7 +102,7 @@ class TestCheckUsersFile extends Specification {
   )(block: (() => Elem, CheckUsersFile) => A): A = {
 
     val (mockUserManagementTmpDir, mockUserManagement) = MockUserManagement(resourceFile = resourceFile)
-    val migration                                      = mockUserManagement.userService
+    val migration                                      = mockUserManagement.fileUserDetailListProvider
     val checkUsersFile                                 = new CheckUsersFile(migration)
 
     val elem = () => XmlSafe.load(migration.userFile.inputStream())

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalPropertiesTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalPropertiesTest.scala
@@ -39,6 +39,7 @@ package bootstrap.liftweb.checks.endconfig.consistency
 
 import com.normation.GitVersion
 import com.normation.rudder.MockGlobalParam
+import com.normation.rudder.MockTenants
 import com.normation.rudder.domain.properties.*
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
@@ -59,7 +60,7 @@ object CheckRudderGlobalPropertiesTest extends ZIOSpecDefault {
       test("it should check the global properties without errors") {
         for {
           counterRef <- Ref.make(0)
-          pRepo       = new MockGlobalParam().paramsRepo
+          pRepo       = new MockGlobalParam(new MockTenants()).paramsRepo
           uuidGen     = stubStringUuidGenerator
           underTest   = CheckRudderGlobalProperties(roParamRepo = pRepo, woParamRepo = pRepo, uuidGen = uuidGen)
           _           = underTest.checks()
@@ -69,7 +70,7 @@ object CheckRudderGlobalPropertiesTest extends ZIOSpecDefault {
       test("it should check the inconsistent global properties handling errors") {
         for {
           counterRef <- Ref.make(0)
-          pRepo       = new MockGlobalParam().paramsRepo
+          pRepo       = new MockGlobalParam(new MockTenants).paramsRepo
           uuidGen     = stubStringUuidGenerator
           underTest   = CheckRudderGlobalInconsistentProperties(roParamRepo = pRepo, woParamRepo = pRepo, uuidGen = uuidGen)
           _           = underTest.checks()

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateDirectiveWithSelectInputBroken.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateDirectiveWithSelectInputBroken.scala
@@ -42,17 +42,18 @@ import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.errors
 import com.normation.errors.IOResult
 import com.normation.errors.RudderError
-import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.Version
 import com.normation.rudder.MockDirectives
 import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockTechniques
-import com.normation.rudder.domain.eventlog
+import com.normation.rudder.MockTenants
 import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.hooks.CmdResult
 import com.normation.rudder.ncf.*
+import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio.*
 import org.junit.runner.*
@@ -66,7 +67,7 @@ class TestMigrateDirectiveWithSelectInputBroken extends Specification with Conte
   sequential
 
   // uses configuration repository from rudder-core tests resources
-  val mockDirectives = new MockDirectives(MockTechniques(new MockGitConfigRepo("")))
+  val mockDirectives = new MockDirectives(MockTechniques(new MockGitConfigRepo("")), new MockTenants())
 
   val editorTech      = EditorTechnique(
     BundleName("test-migrate-select"),
@@ -129,12 +130,14 @@ class TestMigrateDirectiveWithSelectInputBroken extends Specification with Conte
     security = None
   )
 
+  given cc: ChangeContext = ChangeContext.newForRudder()
+  given qc: QueryContext  = QueryContext.systemQC
   val atId = mockDirectives.directiveRepo
     .getActiveTechnique(TechniqueName("test-migrate-select"))
     .notOptional("should not empty")
     .runNow
     .id
-  mockDirectives.directiveRepo.saveDirective(atId, directive, ModificationId("..."), eventlog.RudderEventActor, None).runNow
+  mockDirectives.directiveRepo.saveDirective(atId, directive).runNow
 
   val migration = new MigrateDirectiveWithSelectInputBroken(
     techniqueReader,

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
@@ -41,6 +41,7 @@ import com.normation.rudder.MockGlobalParam
 import com.normation.rudder.MockNodeGroups
 import com.normation.rudder.MockNodes
 import com.normation.rudder.MockRules
+import com.normation.rudder.MockTenants
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.web.components.RuleGrid.*
@@ -55,9 +56,10 @@ import zio.json.*
 @RunWith(classOf[JUnitRunner])
 class RuleLineTest extends Specification {
 
-  val mockRules  = new MockRules()
-  val mockNodes  = new MockNodes
-  val mockGroups = new MockNodeGroups(mockNodes, new MockGlobalParam)
+  val mockTenants = new MockTenants
+  val mockRules   = new MockRules(mockTenants)
+  val mockNodes   = new MockNodes(mockTenants)
+  val mockGroups  = new MockNodeGroups(mockNodes, new MockGlobalParam(mockTenants), mockTenants)
 
   import com.normation.utils.SimpleStatus.*
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ComplianceLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ComplianceLineTest.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.MockCompliance
 import com.normation.rudder.MockDirectives
 import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockTechniques
+import com.normation.rudder.MockTenants
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyMode.Enforce
 import com.normation.rudder.domain.policies.PolicyModeOverrides
@@ -61,7 +62,8 @@ import zio.json.*
 @RunWith(classOf[JUnitRunner])
 class ComplianceLineTest extends Specification with JsonSpecMatcher {
 
-  val mockDirectives = new MockDirectives(MockTechniques(new MockGitConfigRepo("")))
+  val mockTenants    = new MockTenants()
+  val mockDirectives = new MockDirectives(MockTechniques(new MockGitConfigRepo("")), mockTenants)
   val mockCompliance = new MockCompliance(mockDirectives)
   implicit val qc: QueryContext                  = QueryContext.testQC
   val nodes:       MapView[NodeId, CoreNodeFact] = mockCompliance.nodeFactRepo.getAll().runNow


### PR DESCRIPTION
https://issues.rudder.io/issues/28945

:information_source: Disclaimer: the changes in that repo were done with the assist of claude code. Most of the systematic signature update (adding query/change context everywhere) were kept. Still, I reviewed each line, with a particular attention to the core filtering logic in ldap repos, the call at edge, and the serialization bits. Even with direction, claude was not good at:
- avoiding `systemQC`, it really likes thing that Just Compile - I think I only let legit one, but it will need care, 
- typical usage of serialization with zio-json, enumeratum, chimney. It might need a skill here
- boilerplate. It churn out methods and methods and methods for everything. Sometime it helps readability, sometimes it stinks javaisme. 

# Feats
(yes, feats, given how tedious it was)

- 1/ multi-tenants implemented for core configuration objects (directives and active techniques, rules, global properties, groups again)
- 2/ add a "read-only" kind of tenants so that user can see but not modify things, 
- 3/ API / UI kind of work (there will be likely a zillion things to adapt)

This is a big change, but most of it is just theading `given/using QueryContext/ChangeContext`.

Interesting parts are in package `com.normation.rudder.repository.TenantFiltering.scala` where is the actual filtering logic (usage of `TenantService` and `TenantCheckLogic`). 

The general design choice for LDAP respository is similar to what was done for `NodeFactRepository`, but softer:
- old LDAP repository are kept as they are. They become the persistance layer, 
- new `Ro/WoTenantXXX` repository are created. They have the tenant filtering logic and use the LDAP repo, or in memory mock for test, as a persistance layer. 

For snippet, I added a `snippetQC` in secure snippet that can be use for things out of `dispatch`. 

# Open questions / TODO

These questions are put here to give context, but they can/must be resolved in other PR. That PR is for infrastructure only (make everything works end to end, including API tests). 

## what is the core logic for tenant visibility and modification ? 

There is two parts here:  visibility when there is several tenants, and tenant update. 

## Visibility of object with several tenants

What is visibility we want when there is several tenant on an object ? The two options are: 
     - 1/ an user must have a super-set of all tenants applied (intersection == set of tenant on object). In that case, when an user create an object and set its tenants, removing tenant open up its visibility, 
     - 2/ an user must have at least one tenant (non empty intersection). In that case, adding tenant open up its visibility. 

It seems that the semantic (2) of "more tenants means more visibility" is the one expected by humans, but I fear it is unsound taken in a whole with nodes. So we need to do the math to know what is actually possible to remain consistent. 

## Entity's tenant update

It would be very nice to have tenants assigned at entity creation and then never change. The model would be easy to reason about. A change in tenant would mean a clone. 
But that would make migration and tenant evolution extremely complicated for users: 
- going from a non-tenant infra to a tenant one becomes a nightmare of directive and rule redefinition. Since it would be the kind of migration already painful, it becomes a show stopper, 
- assigning tenant during migration will be extremely error prone. So it needs to be amendable. 

But if tenant can be changed, it bears two more questions: 
- who can do it ? Admin or anybody ?
- if anybody can, then what tenant can be changed ? Typically, if an object has "A, B" tenant, and user has "A", can he remove B ? Make object open ? Etc. 

So we really need to do the math here, two, to keep a whole consistent behavior. 

## Check `open` security tag 

It doesn't seems to work when applied in directives and parent categories. Perhaps it's just a deserialisation problem, perhaps it's worse. 

## Auto set security tag value to ncf directive categorie

It seems that saving a technique when you have tenants correctly set its tenants, but it looks like the parent category (`ncf_techniques`) also get the tenants. We don't want to do that, we should not be allows to change tenant in that case. 