### PR TITLE
Fixes #29034: Correct CurrentUser initialisation problem

### DIFF
--- a/adr/webapp/28452-avoid-currentuser-for-querycontext-in-lift-snippets.md
+++ b/adr/webapp/28452-avoid-currentuser-for-querycontext-in-lift-snippets.md
@@ -3,7 +3,7 @@
 * Status: accepted
 * Deciders: CAN, PIO, FAR
 * Date: 2025-03-01
-
+* Updated for details about root cause explanation: 2026-06-10
 
 ## Context
 
@@ -11,12 +11,16 @@ The webapp makes use of Liftweb [snippets](https://exploring.liftweb.net/master/
 Several snippets require that the user is authenticated, and use that information for display.
 
 For that purpose, the authenticated user is provided into a `CurrentUser` global and static variable.
-But this has known limitations, such that :
-* the variable can only be set for each HTTP request, due to all the servlets and spring-security plumbings,
-* a variable lookup would sometimes return no user, even if there is actually an authenticated user (when used with the `ZIO` framework in latest versions, see [the corresponding issue](https://issues.rudder.io/issues/26605)).
+But this has a known limitation:
+* the variable is set for each HTTP request in a thread local due to the way spring-security filter works,
+* a variable lookup would return no user if there is a thread context switch, which happens when ZIO runs its effects.
 
 Because of that inconvenience, there are security and auditability issues, such that the current user and their tenants are not known.
 The object `QueryContext` holds the currently authenticated user and their tenants for that purpose, and is not known in that case.
+
+Example problematic cases are described in https://issues.rudder.io/issues/29034#note-2. 
+The specific case to avoid is calling `f(x)(using CurrenUser.queryContext.getOrElse(...)).runNow` or any ZIO runtime evaluation method
+taking a by-value argument leading to `CurrentUser.queryContext` getting resolved in the ZIO thread pool context. 
 
 ## Decision
 
@@ -37,6 +41,23 @@ trait SecureDispatchSnippet extends DispatchSnippet {
   }
 }
 ```
+
+For snippet `val` instantiated by snipped constructor (for example for stateful snippets) via a `f(x)(using qc:QueryContext)` function, 
+the call to `CurrentUser.queryContext` MUST be done in another expression than the one passed to `runNow`: 
+
+```scala 3
+given qc: QueryContext = CurrentUser.queryContext.getOrElse(throw new RuntimeException())
+//...
+private val x = f(x)
+```
+Or with an explicit call:
+```scala 3
+val qc: QueryContext = CurrentUser.queryContext.getOrElse(throw new RuntimeException())
+// ...
+private val x = f(x)(using qc)
+```
+
+
 
 This will :
 * enforce that extending snippets are provided with a `QueryContext`,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -89,14 +89,16 @@ class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailLi
   override def doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain): Unit = {
     val session = request.getSession(false)
     if (session != null) { // else do nothing : not logged in
-      val auth = SecurityContextHolder.getContext.getAuthentication
+      val context = SecurityContextHolder.getContext
+      val auth    = context.getAuthentication
       if (auth != null) { // else not logged in
         val userDetails = auth.getPrincipal
         userDetails match { // we should only do session invalidation in specific cases : status is disabled/deleted, user is unknown
           case user: RudderUserDetail =>
             val username = user.getUsername
             implicit val userDetail: RudderUserDetail = user
-            (userCache.get
+            // we need to NOT put doFilter into ZIO effect, so we exec immediately, see https://issues.rudder.io/issues/29034
+            userCache.get
               .map(_.get(username))
               .flatMap {
                 case checkUser(reason) =>
@@ -131,12 +133,13 @@ class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailLi
                       }
                     )
                 case _                 =>
-                  // here, we absolutely need nonBlocking, else the with a blocking IO, we yield a new thread and
-                  // at least in ZIO 2.1.12, the thread local context is lost.
-                  IOResult.nonBlocking(filterChain.doFilter(request, response))
-
-              })
-              .runNow
+                  ZIO.unit
+              }
+              .either
+              .runNow match {
+              case Left(err) => throw new RuntimeException(err.fullMsg)
+              case Right(()) => filterChain.doFilter(request, response)
+            }
           case _ => ()
         }
       } else {


### PR DESCRIPTION
https://issues.rudder.io/issues/29034

The description of the problem is available here: https://issues.rudder.io/issues/29034#note-2

I didn't see any occurence of `f(...)(using CurrentUser.queryContext).[toBox, runNow, etc]` so we should be safe on that part. 

I tested the other case by first changing the `doFilter` on an other thread pool with a `IOResult.attempt`, and yes, the security context is lost; and it remains with the filter on the same thread. So that should makes everything work up to the lift `RequestVar` in all cases. 

I didn't see any other things on that path that are boxed into a ZIO effect after authentication filter (which we know works). I looked at anything defined in `web.xml` plus other filters. 

I've also update the corresponding ADR to make the root cause clear and better explain what is forbidden. 
The decision doesn't change, so I don't think it needs another ADR. 
