### PR TITLE
Fixes #28839: Rudder standard technique “Users” updates “last password changed” field in /etc/shadow daily even if no change was made

### DIFF
--- a/policies/lib/tree/30_generic_methods/user_password_hash.cf
+++ b/policies/lib/tree/30_generic_methods/user_password_hash.cf
@@ -66,7 +66,8 @@ bundle agent user_password_hash(login, password)
       "/etc/shadow"
                create => "false",
             edit_line => set_user_field("${login}", 3, "${epoch_days}"),
-        edit_defaults => ncf_empty_select("false");
+        edit_defaults => ncf_empty_select("false"),
+                   if => "${class_prefix}_repaired";
 
   methods:
     pass3.!user_exist_and_password_not_empty::


### PR DESCRIPTION
https://issues.rudder.io/issues/28839