### PR TITLE
Fixes #28984: Custom roles with underscore are not allowed but error is misleading 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/Authorizations.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/Authorizations.scala
@@ -234,7 +234,7 @@ object AuthorizationType {
    */
   // check if it's a valid right syntaxt, and if it's a special one word case or a (object, operation) one
   def checkSyntax(right: String): Option[Either[AuthorizationType.AnyRights.type, (String, String)]] = {
-    val regex = """(.*)_(.*)""".r
+    val regex = """(.*)_([^_]*)""".r
     right.toLowerCase() match {
       case "any"                 => Some(Left(AuthorizationType.AnyRights))
       case regex(obj, operation) => Some(Right((obj, operation)))
@@ -643,7 +643,7 @@ object RudderRoles {
     def checkExistingName(role: UncheckedCustomRole): Either[String, Unit] = {
       AuthorizationType.checkSyntax(role.name) match {
         case Some(_) =>
-          Left("'any' and patterns 'kind_[read,edit,write,all] are reserved that can't be used for a custom role")
+          Left("'any' and names with an '_' are reserved and can't be used for a custom role")
         case None    =>
           Right(())
       }

--- a/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
@@ -32,7 +32,7 @@
 -->
 
 <!--
-  The username is case-sensitive by default, if you want to change this behaviour, you can
+  The username is case-sensitive by default, if you want to change this behavior, you can
   change the parameter 'case-sensitivity' to 'false'
 
   The "authentication" tag should have a "hash" attribute, with these allowed values:
@@ -53,7 +53,7 @@
   If you configured the use of LDAP or Active Directory in rudder-web.properties file,
   you still need to specify here one user entry by user, with both the "password"
   field (which will be ignored - it can be left empty) and the "role" field
-  (where you define the actual authorisations of the user). The "hash" field of
+  (where you define the actual authorizations of the user). The "hash" field of
   "authentication" can be omitted.
 
   The "roles" tag must contain one or more of these values (comma separated), depending
@@ -70,15 +70,17 @@
 
   Example: "node_read" (can read nodes), "validator_all" (same as validator).
 
-  If the extended authorisations feature is enable, you can define custom roles. They are introduced by the `custom-roles`
-  tag, and they allow to define new role name for set of roles or authorisations.
+  BE CAREFUL: since "_" is used for combining built-in permission, it is forbidden in custom role names. 
+
+  If the extended authorizations feature is enable, you can define custom roles. They are introduced by the `custom-roles`
+  tag, and they allow to define new role name for set of roles or authorizations.
   A custom role is defined with the `<role>` tag with the attribute "name" (case-insensitive name of the role) and
   "roles" (same as for an user).
   Ex:
   <authentication>
     <custom-roles>
-      <role name="role_a0" permissions="node_read,node_write,configuration"/>
-      <role name="role_a1" permissions="ROLE_A0,inventory"/>
+      <role name="role-a0" permissions="node_read,node_write,configuration"/>
+      <role name="role-a1" permissions="ROLE_A0,inventory"/>
     </custom-roles>
   <authentication>
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -272,7 +272,9 @@ class RudderUserDetailsTest extends ZIOSpecDefault {
       }
 
       suite("We have reserved word for named custom role: authorization-like named are forbidden") {
-        val crs = List("any", "foo_all", "foo_read", "foo_write", "foo_edit").map(n => UncheckedCustomRole(n, Nil))
+        val crs = List("any", "foo_all", "foo_read", "foo_write", "foo_edit", "a_b_read", "a_b", "my_custom_role").map(n =>
+          UncheckedCustomRole(n, Nil)
+        )
         for {
           knownRoles <- RudderRoles.getAllRoles
           tests      <- ZIO.foreach(crs) { cr =>
@@ -282,7 +284,7 @@ class RudderUserDetailsTest extends ZIOSpecDefault {
                               val expected = List(
                                 (
                                   cr,
-                                  "'any' and patterns 'kind_[read,edit,write,all] are reserved that can't be used for a custom role"
+                                  "'any' and names with an '_' are reserved and can't be used for a custom role"
                                 )
                               )
                               test(s"'${cr.name}' can not be part of a named custom role")(
@@ -291,6 +293,26 @@ class RudderUserDetailsTest extends ZIOSpecDefault {
                             }
                         }
         } yield tests
+      }
+
+      suite("We correctly parse permissions") {
+        val crs = Chunk(
+          ("any", Some(Left(AuthorizationType.AnyRights))),
+          ("foo_all", Some(Right("foo", "all"))),
+          ("foo_read", Some(Right("foo", "read"))),
+          ("foo_write", Some(Right("foo", "write"))),
+          ("foo_edit", Some(Right("foo", "edit"))),
+          ("a_b_read", Some(Right("a_b", "read"))),
+          ("a_b", Some(Right("a", "b"))),                       // that will fail on "AuthorizationType.parseRight but here it's OK
+          ("my_custom_role", Some(Right("my_custom", "role"))), // same
+          ("my_custom_", Some(Right("my_custom", "")))          // same
+        )
+
+        crs.map { (right, res) =>
+          test(s"Parsing '${right}'")(
+            assert(AuthorizationType.checkSyntax(right))(equalTo(res))
+          )
+        }
       }
 
       suiteAll("In definition of tenants, we") {


### PR DESCRIPTION
https://issues.rudder.io/issues/28984