### PR TITLE
Fixes #29003: The display of logs related to variable override conflicts is not very user-friendly.

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
@@ -174,8 +174,7 @@ object PropertyHierarchyError {
     override def message: String = {
       conflicts.toList.map {
         case (k, hierarchies) =>
-          val error = conflictMessage(k, hierarchies)
-          s"In hierarchy with ${hierarchies.map(_.id).mkString(", ").mkString("{", "|", "}")} :\n${error}"
+          s"${conflictMessage(k, hierarchies)}"
       }.mkString("\n")
     }
 
@@ -218,17 +217,19 @@ object PropertyHierarchyError {
               case None         => n.name
               case Some(parent) => s"${n.name} <- ${inheritanceName(parent)} "
             }
-          case _ => ""
+          case _ => s"${p.id} (${p.name})"
         }
       }
 
       val faulty = conflicts.map(inheritanceName)
-
-      s"Error when trying to find overrides for group property '${prop.name}'. " +
-      s"Several groups which are not in an inheritance relation define it. You will need to define " +
-      s"a new group with all these groups as parent and choose the order on which you want to do " +
-      s"the override by hand. Faulty groups:\n ${faulty.mkString("\n ")}"
-
+      val error  = s"When trying to find overrides for group property '${prop.name}'"
+      val cause  = s"Several faulty groups are not in a proper inheritance relation, faulty groups are : ${faulty.mkString(",")}"
+      val fix    =
+        "Define a new parent group for all these faulty groups and then manually define the order in which the overrides should be applied"
+      s"""ERROR: ${error}
+          CAUSE: ${cause}
+          FIX: ${fix}
+          """.stripMargin
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29003

Fix error message and re-word a little

Initially the log was 
```
2026-06-04 00:06:36+0200 ERROR policy.generation.manager - Error when updating policy, reason was: Unexpected: Generation ended but some nodes were in errors: Error while building target configuration node for node '395c0024-93bd-42de-8b72-b7f530eb25e3' which is one of the target of rules. Ignoring it for the rest of the process <- Property resolution failed for node 395c0024-93bd-42de-8b72-b7f530eb25e3 with error : In hierarchy with {f|c|f|b|5|a|4|0|-|a|f|8|3|-|4|8|a|7|-|a|7|2|9|-|9|5|b|d|5|8|6|5|2|8|d|3|,| |6|2|d|f|b|8|b|8|-|c|1|c|d|-|4|5|0|3|-|a|e|9|9|-|2|4|5|7|6|5|3|a|8|6|b|1} :
Error when trying to find overrides for group property 'SITE'. Several groups which are not in an inheritance relation define it. You will need to define a new group with all these groups as parent and choose the order on which you want to do the override by hand. Faulty groups: ; Error while building target configuration node for node '9034b531-f242-4a51-b8a8-95d7e6bc0ac0' which is one of the target of rules. Ignoring it for the rest of the process <- Property resolution failed for node 9034b531-f242-4a51-b8a8-95d7e6bc0ac0 with error :
```
Now it is :
```
2026-06-11 16:13:27+0200 ERROR policy.generation.manager - [pool-2-thread-3] (Logger line:274) - Policy update error for process '597' at 2026-06-11 14:13:27: Unexpected: Generation ended but some nodes were in errors: Error while building target configuration node for node '1ae5af0a-eaea-46a5-91ec-74e86596549a' which is one of the target of rules. Ignoring it for the rest of the process <- Property resolution failed for node 1ae5af0a-eaea-46a5-91ec-74e86596549a with error : ERROR: When trying to find overrides for group property 'myprop'
          CAUSE: Several faulty groups are not in a proper inheritance relation, faulty groups are : e34cd408-8173-42a2-9258-145403efb6a2 (second),9e40f05c-f9e9-404c-9262-2260ee4cfbb8 (first)
          FIX: Define a new parent group for all these faulty groups and then manually define the order in which the overrides should be applied
```