### PR TITLE
Fixes #29012: The reason why Trigger agent inventory and Trigger agent buttons are greyed out on windows agents is not explained in the webapp

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -442,7 +442,10 @@ class ReportDisplayer(
                           <div id={"triggerAgent" + defaultOrInventory} class="mb-3">
             <button id={
                             "triggerBtn" + defaultOrInventory
-                          } class="btn btn-primary btn-trigger" disabled="disabled" title="This action is not supported for Windows node">
+                          } class="btn btn-primary btn-trigger pe-auto" 
+                            data-bs-toggle="tooltip" 
+                            title="This action is not supported for Windows nodes" 
+                            disabled="disabled">
                               <span>Trigger agent {defaultOrInventory.toLowerCase()}</span>
                               &nbsp;
                               <i class="fa fa-play"></i>


### PR DESCRIPTION
https://issues.rudder.io/issues/29012

This PR aims to add a tooltip on the "Trigger agent" and "Trigger agent inventory" buttons for windows nodes which explain why the buttons are disabled

<img width="310" height="113" alt="image" src="https://github.com/user-attachments/assets/860b121b-5ada-4e1c-bf69-35c8f4239e95" />
