### PR TITLE
Fixes #26892: Add a contribution statement regarding GenAI

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,184 @@
+# Responsible use of AI agents and LLMs when contributing to Rudder
+
+This policy governs the use of AI coding agents and large language models (LLMs) when
+producing any contribution to the Rudder code base. It applies to all the Rudder source
+repositories
+
+It is a policy for **humans**. The companion agent-facing guidance (coding conventions an
+agent should follow) lives in `AGENTS.md` and in `.claude/skills/`.
+
+## Summary
+
+You may use AI agents as *assistants*. You may not let them author contributions you do
+not understand and stand behind. **A human is always responsible** — for every line
+contributed and for every review and the ongoing maintenance that follows. That
+responsibility is never delegable to a tool. You must **disclose** any such use *traceably*
+— the exact tool, model, and version, recorded in the git history so the contribution can
+be found and audited later — keep the agent **confined** (no access to secrets, no direct
+access to GitHub, nothing done in your name), and you remain fully accountable for what
+you propose.
+
+## Rules
+
+1. **No "vibe coding" on the Rudder code base (default rule).**
+   "Vibe coding" — generating code with an agent/LLM and proposing it without fully
+   reading, understanding, and validating it yourself — is *forbidden* by default for
+   contributions to Rudder. You must comprehend every line you submit as if you had
+   written it by hand, and be able to explain *what* it changes and *why*, in your own
+   words, in review — without going back to an agent to answer for you.
+
+2. **Agents are welcome as assistants.**
+   Using an AI agent or LLM to help you write, refactor, explore, explain, or test code
+   is fine. The tool assists; it does not author. The bar is the same as for any code:
+   you understand it, it meets our conventions, and it is correct.
+
+3. **Privacy, secrets, and confinement — keep the agent on a short leash.**
+   Most AI agents send their context to a third-party service, and many can run commands,
+   read your whole filesystem, and reach the network. Treat *what an agent can see and do*
+   as a first-class security and privacy concern, not an afterthought. Agent usage **must
+   be confined** so that it cannot, by construction:
+   - **Access secrets or sensitive data.** No credentials, API tokens, SSH/GPG private
+     keys, `.env` files, production or customer configuration, inventories, support data,
+     or any personal data in the agent's reach or context. Run agents in a sandbox scoped
+     to the source you're working on, with secrets excluded — never point one at a real
+     Rudder server, a production database, or a directory containing credentials.
+   - **Have direct access to GitHub (or any forge / CI / infrastructure).** Agents must
+     not push, open or merge pull requests, comment, approve, manage issues, cut releases,
+     or drive CI/CD on their own. They produce changes *locally*; a human reviews the diff
+     and performs every forge and infrastructure action themselves.
+   - **Act "in the name of" a human.** An agent must never operate under your identity,
+     tokens, or credentials, or otherwise speak or act as you — no posting, reviewing,
+     approving, or communicating that appears to come from you. Every outward,
+     attributable, or irreversible action (commit authorship, push, PR, review, merge,
+     release, chat) is taken by a person who owns it.
+
+   Independently of the IP question below, do **not** paste non-public Rudder source,
+   proprietary customer configurations, support tickets, or personal data into a
+   third-party hosted AI tool unless an agreement explicitly forbids training on, and
+   retaining, that content. When unsure whether something is safe to share with a tool,
+   assume it is not.
+
+4. **Disclose and trace every agent/LLM use — durably and precisely.**
+   *Any* — really any — use of an agent or LLM to produce content that goes into a Rudder
+   PR (code, docs, config, tests, scripts) must be disclosed. The point is *traceability*:
+   we must be able, at any later date, to find every contribution produced with a given
+   tool, model, or version (see "Why traceability matters" below). So the disclosure must
+   be **specific** and **durable**, recording for each AI-assisted change:
+   - the **agent / tool** name *and its version* (e.g. `Claude Code 2.0.1`, `Cursor 0.42`,
+     `GitHub Copilot`);
+   - the **model** identifier *including its version* (e.g. `claude-opus-4-8`, `gpt-5.1`)
+     — "some AI" or a bare vendor name is *not* a disclosure; if you don't know the exact
+     model/version, find out before you commit;
+   - briefly, *what* it assisted with, when not obvious from the diff.
+
+   Record this in **commit trailers** on the relevant commits. The git history is the
+   durable, queryable record — a PR description is not (it is not preserved in history and
+   is easily lost), so a PR note is welcome only *in addition* to the trailers. Example:
+
+   ```
+   Assisted-by: Claude Code 2.0.1 (model: claude-opus-4-8)
+   Assisted-by: GitHub Copilot (model: gpt-5.1)
+   ```
+
+   Keep trailers per-commit so the attribution stays attached to the exact changes the
+   tool touched (an agent used on only part of a PR must not be implied across the rest).
+   Authorship and DCO-style trailers (`Signed-off-by:`, `Co-authored-by:`) refer to
+   **humans only**; an AI tool is never listed as an author or co-author.
+
+5. **Write in your own words.**
+   PR descriptions, issue reports, and replies to review feedback must reflect *your*
+   understanding, not a raw LLM dump. A machine-generated PR body disconnected from the
+   actual diff will be treated as if no description had been provided. (LLM-assisted
+   translation for non-native English speakers is welcome — just say so.)
+
+6. **Keep contributions focused and clean.**
+   One logical change per PR. Agents tend to "helpfully" touch unrelated files
+   (reformatting, import reordering, adjacent refactors) — strip those out before
+   submitting. Split large changes into reviewable, logically ordered commits rather than
+   a single agent dump. Do not commit agent *session* artefacts (transient logs, scratch
+   configs); deliberate, reviewed additions under `.claude/skills/` are of course fine.
+
+7. **Test what you change.**
+   AI-assisted changes must build, pass the existing test suite, and ship tests for new
+   behaviour — written or reviewed with the same scrutiny as the production code. "The
+   agent says it added tests" is not enough; confirm the tests actually exercise the
+   intended behaviour and would fail without the change.
+
+8. **All code is reviewed by humans, and a human maintains it.**
+   Any code going into Rudder must be reviewed by human maintainers. AI assistance never
+   replaces human review, on either side of the PR. A maintainer's approval is a
+   *personal* attestation by a human and is not delegable to a tool. Responsibility does
+   not end at merge: a human owns the ongoing maintenance of the code (fixes, up-merges,
+   regressions), so don't contribute code that no human is prepared to maintain.
+
+9. **A human owns what you propose.**
+   Responsibility lies with the *human* contributor opening the PR. If you propose code,
+   you — a person — own it: its correctness, quality, security, and licensing, *whatever
+   means you used to produce it*. "The AI wrote it" is never an excuse, and the
+   responsibility can never be shifted to or shared with a tool. Given that Rudder manages
+   server configuration, patch management, and compliance, take particular care with the
+   things that have an outsized blast radius here: idempotency of techniques, backward
+   compatibility of the API and relay protocol, behaviour at scale on large inventories,
+   and security implications.
+
+10. **You must own the IP, and sign the CLA.**
+    You must own (or have the right to contribute) the intellectual property of all code
+    you propose to Rudder, and you must sign the
+    [CLA/CCLA](https://www.rudder.io/en/expand/contribute/) in any case (see also
+    `CONTRIBUTING.md`). Do not submit code whose provenance or license you cannot vouch
+    for — this includes AI-generated code you cannot account for. In particular:
+    - AI tools may reproduce *memorised snippets* from their training data, possibly under
+      a license incompatible with Rudder's, or near-verbatim copies of third-party code.
+      If a tool emits a block that looks copied (unusual specificity, foreign comments, a
+      stray license header), do not include it — rewrite or remove it.
+    - Do not paste *proprietary customer configurations, support tickets, or non-public
+      Rudder source* into third-party hosted AI tools unless the tool is covered by an
+      agreement that prohibits training on submitted content. This is a confidentiality
+      obligation, independent of the open-source IP question.
+    - Be aware of your tool vendor's terms: some assert rights over generated output that
+      are incompatible with redistribution under our license. If in doubt, ask before
+      submitting.
+
+11. **Maintainers may refuse any PR.**
+    Rudder maintainers are free to refuse any contribution, for any reason, including
+    concerns about undisclosed or irresponsible AI use, scope creep, un-reviewable size,
+    or a contributor who cannot explain their own diff.
+
+## Why traceability matters
+
+Disclosure is not box-ticking — it builds a *durable audit trail* we may need to act on
+years later, when a problem surfaces that is tied to a specific tool, model, or version.
+Recording the agent and model (with versions) per commit lets us, after the fact:
+
+- **Trace IP / licensing issues.** If a model is later found to reproduce code under an
+  incompatible license, we can locate every commit produced with that model/version and
+  assess or remediate the affected code.
+- **Respond to security / supply-chain concerns.** If a tool or model version is
+  implicated in introducing subtle defects, vulnerabilities, or a deliberate backdoor, we
+  can find and re-audit exactly the contributions it touched, instead of having to suspect
+  the whole code base.
+- **Investigate anything else, later.** Whatever the future concern — a model recall, a
+  vendor terms change, a quality regression linked to a tool — we can only review what we
+  can *find*. Untraceable AI contributions can't be reviewed in hindsight; that is why the
+  trail must live, precisely, in the git history.
+
+Treat the disclosure trail as a long-lived safety record: write it as if someone will
+query it in five years to answer "which of our code came from *that* tool/model/version?"
+
+## Why these rules
+
+Rudder is security and compliance software that our users trust to manage their
+infrastructure. Untraceable, unreviewed, or not-understood code is a risk to them and to
+the project. These rules keep contributions accountable, legally clean, and worthy of
+that trust — while still letting contributors benefit from good tooling.
+
+## This policy can change without notice
+
+The AI tooling landscape — the capabilities, the legal and licensing context, the
+security and privacy implications, the tools and models themselves — is extremely
+dynamic. Accordingly, **this policy may change at any time, without prior notice**, as we
+react to new developments. Always refer to the current version in the repository, and
+re-read it before relying on it; what was acceptable under a previous version is not
+guaranteed to remain so.
+
+See also: `CONTRIBUTING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,54 +1,62 @@
-= How to contribute to Rudder
+# How to contribute to Rudder
 
 Rudder is open to all kinds of contribution:
 
-* Bug reports and fixes
-* Documentation
-* Features ideas
-* New features
+- Bug reports and fixes
+- Documentation
+- Features ideas
+- New features
 
 If you want to contribute, the best way to start is to come and chat with us
-on https://chat.rudder.io[chat.rudder.io].
+on [chat.rudder.io](https://chat.rudder.io).
 
-NOTE: Large contributions on Rudder may require a https://www.rudder.io/en/expand/contribute/#panel-2422-8-0-1[CLA/CCLA].
+> [!NOTE]
+> Large contributions on Rudder may require a [CLA/CCLA](https://www.rudder.io/en/expand/contribute/#panel-2422-8-0-1).
 
-== Documentation contribution
+> [!IMPORTANT]
+> Using AI coding agents/LLMs to produce contributions is subject to our policy:
+> see [Responsible use of AI agents](AI_POLICY.md). In short: agents are OK as
+> assistants, no "vibe coding", any AI use must be disclosed in the PR, all code is
+> human-reviewed, and you own (and the CLA covers) everything you propose.
+
+## Documentation contribution
 
 Just click on the "Edit page" button, and open a pull request directly from Github's interface!
 
-== Development workflow
+## Development workflow
 
 We maintain several Rudder major/minor versions in separate branches.
 
-* `branches/rudder/6.2` is Rudder 6.2, from which 6.2 patch releases will be tagged
-* `branches/rudder/7.1` is Rudder 7.0, major 7, minor 0, from which 7.0 patch releases will be tagged
-* `branches/rudder/7.1` is Rudder 7.1, major 7, minor 1, from which 7.1 patch releases will be tagged
-* `branches/rudder/7.2` is Rudder 7.2, major 7, minor 2, from which 7.2 releases will be tagged
-* `master` is the next Rudder version, not branched yet
+- `branches/rudder/6.2` is Rudder 6.2, from which 6.2 patch releases will be tagged
+- `branches/rudder/7.0` is Rudder 7.0, major 7, minor 0, from which 7.0 patch releases will be tagged
+- `branches/rudder/7.1` is Rudder 7.1, major 7, minor 1, from which 7.1 patch releases will be tagged
+- `branches/rudder/7.2` is Rudder 7.2, major 7, minor 2, from which 7.2 releases will be tagged
+- `master` is the next Rudder version, not branched yet
 
-NOTE: Some tooling repositories only have a `master` branch.
+> [!NOTE]
+> Some tooling repositories only have a `master` branch.
 
 All bug fixes should be done in the oldest relevant branch (i.e.
 affected and still maintained).
-Version status is visible on https://docs.rudder.io/version.
-Don't hesitate to ask us on the https://chat.rudder.io[chat room] if you are unsure about which
+Version status is visible on <https://docs.rudder.io/version>.
+Don't hesitate to ask us on the [chat room](https://chat.rudder.io) if you are unsure about which
 branch you should work on.
 
 We have an internal CI platform running Jenkins, integrated to Github pull requests.
 CI configuration is mostly done trough `Jenkinsfile` files in the repositories.
 
-=== Issue tracker
+### Issue tracker
 
 We do not use Github's issue tracking but an external issue tracker hosted on
-https://issues.rudder.io.
+<https://issues.rudder.io>.
 
 Every change in one of the Rudder repositories must be linked to an issue in this
 tool, except for documentation fixes that can be contributed directly on
 Github.
 
-=== Development tooling (rudder-dev)
+### Development tooling (rudder-dev)
 
-==== Installation
+#### Installation
 
 To ease the use of a separate issue tracker and maintenance of several
 branches of Rudder, we have developed a dedicated tooling.
@@ -67,7 +75,7 @@ rudder-dev update
 
 (it will remind you to do so regularly).
 
-=== Setup
+### Setup
 
 At its first start, `rudder-dev` will create its configuration script in `~/.rudder-dev`.
 You need to edit it to provide your Github and bug tracker token:
@@ -81,7 +89,7 @@ github_token =
 redmine_token =
 ```
 
-=== Usage
+### Usage
 
 ```
 rudder-dev --help
@@ -89,45 +97,45 @@ rudder-dev --help
 
 For more information.
 
-== Development environments
+## Development environments
 
-=== Rudder test framework (rtf)
+### Rudder test framework (rtf)
 
 The `rtf` tool allows automated setup of multi-node environment using vagrant.
-Follow the docs in https://github.com/Normation/rudder-tests/[the rudder-tests repo]
+Follow the docs in [the rudder-tests repo](https://github.com/Normation/rudder-tests/)
 to install and configure it.
 
 It is also used for continuous integration and release testing.
 
-=== Scala
+### Scala
 
-Follow these link:contributing/webapp.md[instructions] to setup a development's environment with IntelliJ
+Follow these [instructions](contributing/webapp.md) to setup a development's environment with IntelliJ
 allowing you to test your changes.
 
-=== Rust
+### Rust
 
-Follow the link:contributing/rust.adoc[dedicated doc].
+Follow the [dedicated doc](contributing/rust.md).
 
-=== F#
+### F#
 
-Follow the link:contributing/fsharp.adoc[dedicated doc].
+Follow the [dedicated doc](contributing/fsharp.md).
 
-=== Shell
+### Shell
 
 Install and use `shellcheck`, it is used in our test script to lint shell scripts,
 and gives good advice during development.
 
-== Generate fake data
+## Generate fake data
 
 You may want to generate plenty of inventories to test Rudder, without the need
 of having a lot of VMs. The script `inventory-generation` in
-https://github.com/Normation/rudder-tools/tree/master/contrib/inventory-generation[rudder-tools]
+[rudder-tools](https://github.com/Normation/rudder-tools/tree/master/contrib/inventory-generation)
 creates the data for inventories creation and reports sending, and the way
 to create said inventories based on templates.
 Data are sufficiently differents to tests different cases (hostnames autoincrementing `RUDDERTEST<X>`,
 public/private keys autogenerated, software versions randomized, OS randomized, IP randomized).
 
-=== Usage
+### Usage
 
 To create data to generate 500 inventories
 
@@ -158,4 +166,3 @@ Purge the generated *data* (the generated inventories are not purged)
 ```
 inventory-generation -w
 ```
-

--- a/contributing/fsharp.md
+++ b/contributing/fsharp.md
@@ -1,8 +1,8 @@
-= F# dev environment
+# F# dev environment
 
-== General information
+## General information
 
-=== Compatibility
+### Compatibility
 
 While our F# code only runs on Windows for now, we strive to keep it compatible with Linux systems
 both for ease of development/testing and future abilities.
@@ -12,10 +12,10 @@ the broadest compatibility possible (especially for agent parts).
 
 Out builds should all target `netstandard2.0` target (with `<TargetFramework>netstandard2.0</TargetFramework>` in `fsproj` files).
 
-== Development environment
+## Development environment
 
 We work with the latest LTS .NET toolchain.
-Install the .NET toolchain by following the https://docs.microsoft.com/en-us/dotnet/core/install/[official docs].
+Install the .NET toolchain by following the [official docs](https://docs.microsoft.com/en-us/dotnet/core/install/).
 
 For example, on Fedora:
 
@@ -25,6 +25,6 @@ sudo dnf install dotnet
 
 Will install the latest version from the repositories.
 
-=== IDE/Editor
+### IDE/Editor
 
 VS Code with the **Ionide for F#** plugin is a good option.

--- a/contributing/webapp.md
+++ b/contributing/webapp.md
@@ -88,13 +88,14 @@ echo $PATH
 <span style="font-weight: bold;">Congrats!</span> Now you can exit IDEA and start it from the system menu. If a new menu entry is not shown, restart your login session.
 </div>
 
-### Install a jre
+### Install a jdk
 
-Install a recent jre, the latest LTS version should be fine.
+Install a recent JDK, the latest LTS version should be fine. Ensure that it's really a JDK, not only the 
+Java runtime (JRE). 
 
 > Note: avoid using `apt` to install an open jdk, the jdk packaged by ubuntu do not work (strange behaviors compiling rudder webapp). 
 
-> Suggestion: see `jdkman` for a handy open source java installer.
+> Suggestion: see `sdkman` for a handy open source java installer.
 
 Run `java -version` to validate
 
@@ -210,10 +211,8 @@ Depending on your needs, a relay and some agents can be added:
   "agent2": { "rudder-setup": "agent", "system" : "debian7" },
 ...
 ```
-> Note: for testing purpose a local development environment is needed: this implies that the `server` field must at least contain `"rudder-setup": "dev-server"`.\
-But if you only want to test Rudder without making any changes to the source code, replace `"rudder-setup": "dev-server"` by `"rudder-setup": "server"`
 
-> Note: you will not be able to access Rudder at this stage, you will need to setup and run Rudder through IntelliJ to be able to access it locally.
+> Note: you will not be able to access Rudder at this stage, you will need to set up and run Rudder through IntelliJ to be able to access it locally.
 
 When your file is ready, you will have to create and prepare the box by running :
 ```
@@ -236,7 +235,7 @@ You can find the port number back in the Vagrantfile.
 
 > For an eventual later use: this will not be necessary in this guide, but if you want to connect to the box, use (in `rudder-test` directory) :
 ```
-vagrant ssh <env's name>_server
+vagrant ssh <env-name>_server
 ```
 <div class="success">
 <span style="font-weight: bold;">Congrats!</span> You succeed to start your own test environment.
@@ -248,7 +247,7 @@ vagrant ssh <env's name>_server
 
 1. Connect to your vagrant box env, in `rudder-tests` directory :
 ```
-vagrant ssh <env's name>_server
+vagrant ssh <env-name>_server
 ```
 
 2. In vagrant box, find in `/opt/rudder/etc/openldap/slapd.conf` the two lines starting with `rootdn` and `rootpw` and keep them for the next section, those value are gonna be useful to configure the ldap connection.
@@ -304,6 +303,7 @@ mkdir -p /var/rudder/inventories/incoming \
     /var/rudder/inventories/accepted-nodes-updates \
     /var/rudder/inventories/received \
     /var/rudder/inventories/failed \
+    /var/rudder/configuration-repository/campaigns/ \
     /var/log/rudder/core \
     /var/log/rudder/compliance/ \
     /var/rudder/run/ 
@@ -334,7 +334,6 @@ git clone https://github.com/Normation/rudder-techniques.git
 ```
 2. Move technique's directory to `/var/rudder/configuration-repository/`
 ```
-sudo mkdir -p /var/rudder/configuration-repository/
 sudo cp -r rudder-techniques/techniques /var/rudder/configuration-repository/
 git init /var/rudder/configuration-repository/
 ```
@@ -463,25 +462,40 @@ and choose `/rudder/webapp/sources/rudder` or you can choose only the modules th
 Then select "Import Module from external model" and go for Maven
 ![Import all the Rudder's modules](select_modules.png)
 
+### Local configuration for rudder in dev mode
+
+In order to run rudder locally with jetty, you will need to create a `users.xml` file. This file contains the user credentials that can be used to be log into the webapp, as well as the user permissions of each user.
+You may put this file wherever you choose ; for instance, you can put it in `rudder-tests/dev/users.xml`.
+The configuration below will create an administrator user with username `admin` and password `admin`. Copy and paste this configuration into your `users.xml` file.
+
+```
+<authentication hash="argon2id" case-sensitivity="true">
+    <!-- this is a bcrypt password but you can use an argon2id password starting from 9.0 -->
+    <!-- user-name=admin, password=admin -->
+    <user name="admin" password="$2a$12$bW.RsmvUn8nCUsh2bfwAe.ZntUVVNBv0siVDoG94Q7rpQlO46wjiS" permissions="administrator" />
+</authentication>
+```
+
 ### Setup Run configuration
 
-In _Run -> Edit Configuration_ add a new configuration and choose Jetty Runner
-- Jetty Runner Folder : _downloaded jar of jetty-runner with version BELOW 11 from https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/
-(jetty 11 is not supported yet because of the lack of support for the servlet version used by rudder)_
+You will need version **11 or higher** of jetty-runner. Download the .jar here : https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/
+
+In IntelliJ, select _Run -> Edit Configuration -> add a new configuration_ and choose Jetty Runner
+- Jetty Runner Folder : path of the jetty-runner .jar
 - Module : <all modules>
 - Path : `/rudder`
 - WebApp Folder :
 ```
-<rudder's path directory>/webapp/sources/rudder/rudder-web/src/main/webapp
+<workspace>/rudder/webapp/sources/rudder/rudder-web/src/main/webapp
 ```
 - Classes Folder :
 ```
-<rudder's path directory>/webapp/sources/rudder/rudder-web/target/classes
+<workspace>/rudder/webapp/sources/rudder/rudder-web/target/classes
 ```
 - Runs on Port : 8080
 - VM Args :
 ```
--DrjrDisableannotation=true -Drun.mode=production -XX:MaxMetaspaceSize=360m -Xms256m -Xmx2048m -XX:-UseLoopPredicate -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -Drudder.configFile=/home/<user>/rudder-tests/dev/configuration.properties
+-DrjrDisableannotation=true -Drun.mode=production -XX:MaxMetaspaceSize=360m -Xms256m -Xmx2048m -XX:-UseLoopPredicate -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -Drudder.configFile=<workspace>/rudder-tests/dev/configuration.properties -Drudder.authFile=<workspace>/rudder-tests/dev/users.xml
 ```
 > Note: `-Drun.mode` values : `production`, `development`
 
@@ -506,8 +520,8 @@ In IntelliJ : _File -> Project Structure -> Project settings_
 
 - Make sure that the Project java SDK is at least at version 8, same for Project language level
 ![SDK Setting](SDK_setup.png)
-- In `Modules` make sure that every your modules have a Language level at 8 at least
-- For every modules mark src/main/Scala as Sources
+- In `Modules`, make sure that the language level of each module is set to 8 or above
+- For every module, mark src/main/Scala as `Source Folder`
 ![Example of project's structure sources setup](project_structure.png)
 - Setup display format file manager
 ![Recommended options to display files in project tree](settings_filer.png)
@@ -534,26 +548,27 @@ Inside `rudder/webapp/sources/`.
 
 > Note: It can take several minutes to download all necessary dependencies.
 
+### Set up the build script
+The webapp module contains a script to build the project, located at `src/main/build.sh`.
+Running this script requires npm, as well as some node dependencies.
+
+Follow the official instructions to [install nodejs](https://nodejs.org/en/download) on your system.
+
+Then, run the ``src/main/build.sh` script, the first time it will initialize dependencies in the rudder-web module itself.
+
 ### Setup File Watchers (Highly recommended)
 The purpose of the File Watcher is to automatically apply actions on defined file types
 when they are modified. In Rudder we use it to move generate frontend file (css, html, elm)
 to the right directory when they are modify.
 In Files -> Settings -> tools -> File Watchers
-Add 3 new Watcher : for CSS, HTML and Elm file with these configurations (change `file type` according to the watcher) :
+Add 3 new Watchers : for CSS, HTML and Elm file with these configurations (change `file type` according to the watcher) :
 
 The `Program` field value is the same for these 3 watchers
 
 ![File watcher setting](file_watcher2.png)
 
-Otherwise at every modification you will need to run the `src/main/build.sh` script in the module.
+Otherwise, you will need to run the `src/main/build.sh` script manually after each modification.
 
-Also, the requirement of the `src/main/build.sh` is to have installed node dependencies.
-
-So, inside `rudder/webapp/sources/rudder/rudder-web/src/main/`, run :
-
-```bash
-npm install
-```
 
 ## Setup technique editor
 
@@ -571,14 +586,22 @@ ls -lsh /usr/share/ | grep ncf
 
 Setup apache configuration:
 
-* Install apache (httpd or apache2)
+* Install apache (httpd or apache2 depending on your system)
 
-* Run the following commands (done on Fedora with httpd, path/service are different on deb systems) 
+* Run the following commands
 
+Commands for fedora (with httpd) :
 ```
 cp <path/to/rudder/repo>/contributing/rudder.conf /etc/httpd/conf.d/
 sed -i "s#<pathToncfRepo>#<path/to/ncf/repo>#" /etc/httpd/conf.d/rudder.conf
 service httpd restart
+```
+
+Commands for deb systems (with apache2) :
+```
+cp <path/to/rudder/repo>/contributing/rudder.conf /etc/apache2/conf-available/
+sed -i "s#<pathToncfRepo>#<path/to/ncf/repo>#" /etc/apache2/conf-available/rudder.conf
+service apache2 restart
 ```
 
 ## Running Rudder
@@ -588,25 +611,6 @@ You can now compile and run Rudder in IntelliJ !
 You can access the application by running it from IntelliJ. The url is:
 ##### http://localhost/rudder
 > Warning : make sure your development's environment is running before running Rudder. `./rtf platform setup <env's name>` in rudder-test directory. Otherwise you will get errors in IntelliJ's console.
-
-#### Local configuration for rudder in dev mode
-
-> Note: Some features will not work in this development environment 
-> - plugins
-> - agents (compliance and policy generation)
-
-user configuration > 
-
-> Note: the first time you run rudder locally with jetty, you will need to setup a user in the local user configuration.
-
-```
-<authentication hash="argon2id" case-sensitivity="true">
-    <!-- this is a bcrypt password but you can use an argon2id password starting from 9.0 -->
-    <!-- user-name=admin, password=admin -->
-    <user name="admin" password="$2a$12$bW.RsmvUn8nCUsh2bfwAe.ZntUVVNBv0siVDoG94Q7rpQlO46wjiS" permissions="administrator" />
-</authentication>
-
-```
 
 
 Let's code ! :rocket:
@@ -635,14 +639,15 @@ The war generated is named `rudder-web-8.3.5-SNAPSHOT.war` in this example.
 Copy the war in the vbox server
 ```
 cd <workspace>/rudder-tests
-vagrant upload <workspace>/rudder/webapp/sources/rudder/rudder-web/target/rudder-web-8.3.5-SNAPSHOT.war
+vagrant upload <workspace>/rudder/webapp/sources/rudder/rudder-web/target/rudder-web-8.3.5-SNAPSHOT.war <env-name>_server
 ```
 
 Connect to the vbox and put the war in the share directory and restart the service `rudder-jetty`
 ```
-vagrant ssh myvmtest_server
+vagrant ssh <env-name>_server
 sudo su
 mv rudder-web-8.3.5-SNAPSHOT.war /opt/rudder/share/webapps/
+cd /opt/rudder/share/webapps/
 mv rudder.war rudder.war.save
 mv rudder-web-8.3.5-SNAPSHOT.war rudder.war
 systemctl restart rudder-jetty
@@ -686,14 +691,111 @@ curl -k https://localhost:<port>/rudder/api/latest/systemUpdate/targets \
         -d '[]'
 ```
 
-#### Documentations
+#### Documentation
 If you want to learn how to use Rudder and its web interface, consult the documentation here : https://docs.rudder.io/reference/5.0/usage/web_interface.html :shipit:
 
-#### Contribution
-If you want to submit your code, please feel to contribute by following the [code submit process](https://github.com/Normation/rudder/blob/master/CONTRIBUTING.adoc), we would be happy to review your code and see new contributors join the boat! :heart:
+#### Contributions
+If you want to submit your code, please feel to contribute by following the [code submit process](https://github.com/Normation/rudder/blob/master/CONTRIBUTING.md), we would be happy to review your code and see new contributors join the boat! :heart:
 
 #### Bug reports
 If you detect any bugs in the application please feel free to report it by signing up here if you don't have already an account: https://issues.rudder.io/ :bug:
 
 #### Community
-If you want to discuss about Rudder and get some helps, you can join our Gitter : https://gitter.im/normation/rudder :speech_balloon:
+If you want to discuss Rudder or ask for help, you can join our Gitter : https://gitter.im/normation/rudder :speech_balloon:
+
+
+## Hotswap agent setup (Recommended)
+
+Setting up Hotswap agent allows code changes to be instantly reloaded in the webapp, without stopping and re-running it. The setup process is described below.
+
+* Download a _JBR with JCEF_  version of [JetBrainsRuntime](https://github.com/JetBrains/JetBrainsRuntime). Choose a Java version that is supported by Rudder (e.g. 17 or 21).
+* Untar the archive : `tar -xzvf jbr_jcef-x.y.z.os.version.tar.gz`
+* In IntelliJ, select _File -> Project Structure -> SDKs_. Click on the `+` button to add a new SDK, and choose the root `jbr_jcef` directory.
+* In _Project Structure_, go to the _Project_ tab. In the SDK field, choose the `jbr_jcef` sdk.
+* In _Run -> Edit Configurations_ , select your existing jetty configuration. Add the following VM arguments : 
+
+```
+-XX:+AllowEnhancedClassRedefinition 
+-XX:HotswapAgent=fatjar
+```
+
+* Download the [hotswap-agent .jar](https://github.com/HotswapProjects/HotswapAgent/releases/download/1.4.2-SNAPSHOT/hotswap-agent-1.4.2-SNAPSHOT.jar) 
+* Run the following commands to link it to the sdk :
+```
+cd jbr_jcef-21.0.3-linux-x64-b458.1/lib
+mkdir hotswap
+cd hotswap
+ln -s ../../hotswap-agent-1.4.2-SNAPSHOT.jar ./hotswap-agent.jar
+```
+* Download the [hotswap-agent.properties file](https://github.com/HotswapProjects/HotswapAgent/raw/master/hotswap-agent-core/src/main/resources/hotswap-agent.properties) in your `rudder/webapp/sources/rudder/rudder-web/src/main/resources` directory.
+* Edit the parameters in the `hotswap-agent.properties` file :
+```
+autoHotswap=true
+disabledPlugins=Spring,AnonymousClassPatch,Hibernate,HibernateJakarta,Hibernate3,Hibernate3JPA,SpringBoot,Jersey1,Jersey2,Tomcat,ZK,Logback,MyFaces,Mojarra,Omnifaces,ELResolver,WildFlyELResolver,OsgiEquinox,Owb,OwbJakarta,WebObjects,Weld,WeldJakarta,JBossModules,ResteasyRegistry,Deltaspike,GlassFish,Weblogic,Vaadin,Wicket,CxfJAXRS,FreeMarker,Undertow,MyBatis,IBatis,Thymeleaf,Velocity
+
+LOGGER=info
+LOGGER.org.hotswap.agent.plugin.spring=warning
+```
+
+* Re-run jetty.
+
+You're all set ! From now on, you only need to click _Build -> Rebuild project_ (or only a specific module) in order to reload your changes while the webapp is running.
+
+## Plugin installation (Optional)
+
+You may wish to test a plugin in the Rudder webapp in development mode. The plugin installation process is described below.
+
+### Download and build
+
+Clone the `rudder-plugins` repo into your workspace.
+Make sure your local clones of `rudder` and `rudder-plugins` are on the same branch, e.g. `branches/rudder/9.0`.
+
+Build the `plugins-common` module :
+```
+<workspace>/rudder-plugins$ make generate-all-pom
+<workspace>/rudder-plugins$ cd plugins-common
+<workspace>/rudder-plugins/plugins-common$ make
+```
+
+Each plugin has a dedicated directory. Build the plugin(s) you want to import :
+```
+<workspace>/rudder-plugins/$ cd <plugin-name>
+<workspace>/rudder-plugins/<plugin-name>$ make
+```
+
+> _NOTE :_ The plugin must be built prior to importing it in IntelliJ. The `make` step generates the `pom.xml` file of the module.
+
+### Import the plugin module in intelliJ
+
+In IntelliJ, Select _File -> Project structure -> Modules_. Click on the `+` button and select `Import module`.
+In the text field, paste the path of the `pom.xml` file at the root of the plugin's module, i.e. `<workspace>/rudder-plugins/<plugin-name>/pom.xml`, and click _OK_.
+You should now see the module `plugin-name` appear in the _Project_ tab, alongside the `rudder` module.
+
+### Testing
+
+In the Maven tab of IntelliJ, click _Reload all Maven projects_, and restart the webapp.
+You should now be able to use the plugin in your local Rudder instance.
+
+### Notes
+
+This process is mostly identical in case you want to import a private plugin. In that case, you will need to clone the private plugins repo and follow the installation instructions, as well as build the `plugins-common-private` module.
+Some plugins may require additional installation steps in order to work properly (e.g. the `security-benchmarks` plugin), in which case these steps should be documented in the root directory of the plugin's source code.
+
+## rudder and rudderc installation (Optional)
+
+While browsing the webapp, you may notice some error notifications. This is normal, since the Rudder software is supposed to be installed in your server VM, rather than your host machine.
+In order to reduce the amount of redundant error notifications and error logs in IntelliJ, you may want to copy some files from your server VM.
+Most error notifications are due to the absence of the `/opt/rudder/bin/rudder` and `/opt/rudder/bin/rudderc` binaries.
+
+Get the private SSH key path and hostname of your `<env-name>_server` VM with :
+```
+<workspace>/rudder-tests$ vagrant ssh-config
+```
+
+Copy the `rudder` and `rudderc` binaries (replace `<private/key/path>` and `<hostname>` with the values from the previous command) :
+```
+<workspace>/rudder-tests$ scp -i <private/key/path> -P 2222 vagrant@<hostname>:/opt/rudder/bin/rudder /opt/rudder/bin/rudder
+<workspace>/rudder-tests$ scp -i <private/key/path> -P 2222 vagrant@<hostname>:/opt/rudder/bin/rudderc /opt/rudder/bin/rudderc
+```
+
+You can copy other files from your server VM as needed.


### PR DESCRIPTION
https://issues.rudder.io/issues/26892

Contribution assissted by Claude Code Opus 3.8, based on [Jellyfin LLM/AI policy](https://jellyfin.org/docs/general/contributing/llm-policies/),
the [OpenInfra Foundation AI-generated content policy](https://openinfra.org/legal/ai-policy/),
and the [Linux Foundation generative AI guidance](https://www.linuxfoundation.org/legal/generative-ai).

Main ideas: 
- code agent as assistant are ok, not as full author,
- there must be a human behind: that human is responsible for code quality, tests, etc, and like any code contribution, don't displace the burden on maintainers
- disclose and trace what you used, 
- be careful, agent are fool, contain and don't let them loose with anything looking like a secret and actual direct capacity of nuisance. 

I'm not sure at all: 
- about the wording/form used,  :white_check_mark: 
- how we want to disclose. The current method/wording will likely clash with our internal tooling: => :white_check_mark: : we will adapt

Also: normalizing contributing/CONTRIBUTING to markdown. I backported the 9.2 versions to avoid divergence (that's why there is changes).

