### PR TITLE
Fixes #29072: Add a claude skill for scala in rudder

### DIFF
--- a/.claude/skills/rudder-scala/000-coding-philosophy.md
+++ b/.claude/skills/rudder-scala/000-coding-philosophy.md
@@ -1,0 +1,203 @@
+# 000 — Coding philosophy
+
+The spirit behind every other topic in this skill.
+
+## Functional programming, pragmatically
+
+- **Immutable data.** Model with `case class`/`sealed trait`. No `var`, no in-place
+  mutation of collections in new domain/service code. To "change" a value, produce a
+  new one (see [`403`](403-quicklens-updates.md)); for *shared* state use `Ref`/
+  `Semaphore` (see [`300`](300-effects-zio-ioresult.md)).
+  - **Performance exception (allowed):** `var` and mutable collections are fine in
+    new performance-sensitive code **provided the mutation is purely internal to a
+    well-defined scope and the API stays functional** — e.g. a method that takes a
+    `Chunk`, builds its result with a local mutable array, and returns a `Chunk`. The
+    mutation must not escape that scope.
+  - **`var` as a class property is highly discouraged.** New uses must be clearly
+    justified (benchmark, memory-footprint computation, …) — not a default.
+  - **Legacy:** the Lift UI layer (`rudder-web/.../snippet`, `web/model`, `web/comet`)
+    uses `var` heavily; don't add to it and don't rewrite it on sight. Some
+    perf-critical core classes (e.g. `ComplianceLevel`) also hold mutable state — see
+    the rules above before following suit. Everywhere else, no `var`.
+- **Effects as values.** Anything that mutates state, does I/O, talks to the network,
+  filesystem, LDAP, DB, clock, randomness… is an *effect* and must be reified as
+  `IOResult` (see [`300`](300-effects-zio-ioresult.md)). Pure computation that can
+  fail uses `PureResult[A] = Either[RudderError, A]`.
+- **Total functions where you can.** Prefer returning `Option`/`Either`/`IOResult`
+  over throwing. Throwing is reserved for truly exceptional, unrecoverable situations
+  and is then caught at the boundary (`IOResult.attempt`).
+- **No `return`.** `return` is **forbidden**. A function is an expression that evaluates
+  to its value; use `if`/`match`/combinators so the last expression *is* the result.
+  Early-`return` control flow is a smell — model it with `Option`/`Either`/`IOResult`
+  and the matching combinators instead.
+- **No `null`, and check it only at the edge — explicitly.** We don't use `null` in our
+  own code — model absence with `Option`. The *only* place to guard against `null` is the
+  **system edge**, where untrusted/Java code can hand one in (a Java API return, a
+  deserialized value). Handle it there **once**, and the rest of the code then assumes
+  non-null by construction (this is parse-don't-validate for nullability, see
+  [`201`](201-parse-dont-validate.md)). Don't sprinkle null checks through the domain.
+
+  Make the null handling **visible in the code** — typically a `match` on `null` — so a
+  future reader sees that this `null` case was deliberately handled, and that the
+  resulting `Option` exists *because of nullability at the boundary*, not because it is a
+  business-model optional value. A bare `Option(javaCall())` hides that intent.
+
+  ```scala
+  // clear: the null was handled here, and that is WHY this is an Option
+  val name: Option[String] = javaApi.getName() match {
+    case null => None
+    case s    => Some(s)
+  }
+
+  // avoid: reader can't tell a null-guard from a genuine domain optional
+  val name = Option(javaApi.getName())
+  ```
+
+  Match the type to the *meaning* of the missing value:
+  - a **genuine domain optional** ("this value may legitimately be absent") → `Option`,
+    modelled as such for that reason;
+  - an **unexpected `null` that is an error** (the boundary promised a value and broke
+    its contract) → don't swallow it into a `None`; fail with `PureResult`/`IOResult`
+    (e.g. an `Inconsistency`/`Unexpected`, see [`301`](301-error-model.md)). `Option`
+    is reserved for *absence of a value*, not for *error*.
+
+  ```scala
+  // null here is a contract violation, not an optional → it's an error
+  javaApi.getRequiredId() match {
+    case null => Inconsistency("provider returned a null id").fail   // IOResult
+    case id   => id.succeed
+  }
+  ```
+
+## Don't lie in your code (WYSIWYG signatures)
+
+A signature should tell the whole truth — what it needs and what can happen — with no
+hidden surprises. Make contracts **WYSIWYG**:
+
+- **Structure inputs.** Take the precise type, not a stand-in. `getUser(id: UserId)`,
+  not `getUser(id: String)` (see [`001`](001-scala3-idioms.md)).
+- **Enumerate outputs.** All expected outcomes live in the result type — `Option` for
+  "maybe absent", an ADT for several cases — not hidden behind exceptions.
+- **No hidden constraints, dependencies, or side effects.** If it does I/O or can fail,
+  say so in the type: `IOResult[...]` / `PureResult[...]` (see [`300`](300-effects-zio-ioresult.md)).
+- **Total functions.** Prefer functions defined for every value of their input types;
+  push partiality into the types (parsed inputs, `Option`/`Either` outputs).
+
+The Rudder idiom is "longer but naively explicit", e.g.
+`getUserFromDB(id: UserId): IOResult[Option[User]]` — a reader sees exactly what's
+required and what may happen. Errors and absence are then a deliberate, typed part of
+the contract, not a trap (see [`301`](301-error-model.md)).
+
+## Less code is better code
+
+- Optimize for **fewer lines and fewer moving parts**, not for cleverness or for
+  "completing the pattern". A 5-line solution that a teammate understands at a glance
+  beats a 50-line "architecturally pure" one.
+- Before adding a class, a layer, or an abstraction, ask whether the code is simpler
+  without it. We are *attached but not integrist* about DDD/hexagonal
+  (see [`101`](101-architecture-ddd-hexagonal.md)).
+- Delete more than you add. This applies to code and to dependencies
+  (see [`700`](700-dependencies-ecosystem.md)).
+
+## Duplication: the rule of three
+
+- **Duplicating once is fine** — and is *preferred* over prematurely adding a
+  parameter, an abstraction, or a shared helper. Concrete and simple first.
+- A **second** occurrence is useful, not alarming: it reveals which parts actually vary
+  (the "free axes") versus what is truly common. You usually can't see the right
+  abstraction until you've seen it twice.
+- At the **third** occurrence, stop and consolidate the logic into a single point. Now
+  the abstraction is informed by real cases instead of guessed up front.
+- Corollary: don't build a generic/parameterized solution for a single (or imagined)
+  use. Over-engineering to avoid duplication is worse than the duplication.
+
+## No type-level acrobatics
+
+- Scala 3 is very powerful. We **use** that power — but we want it to come from
+  **third-party libraries** that have already paid the complexity cost: `zio` for
+  effects, `chimney` for transformations, `quicklens` for updates, `zio-json` for
+  (de)serialization.
+- Avoid hand-rolled type-class hierarchies, heavy `implicit`/`given` resolution
+  puzzles, match types, or macro tricks in business code. If you find yourself
+  fighting the type system, step back and pick the boring solution.
+- A `given` that just wires a library's derivation (e.g. `derives JsonCodec`) is
+  fine and encouraged; a `given` that encodes clever business logic is a smell.
+
+## Comments explain *why*, not *how*
+
+- Write **short, descriptive** comments that capture the **why** — intent, rationale,
+  trade-offs — or a genuinely **noticeable point** (a subtlety, an invariant, a gotcha,
+  a non-obvious edge case, a link to context).
+- **Don't** comment the **how**: a comment that just rephrases what the code already
+  says in English is noise. The code is the source of truth for *how*; keep it readable
+  enough to not need narration.
+- Prefer making the code self-explanatory (good names, small functions) over adding a
+  comment. Reach for a comment when the reasoning can't live in the code itself.
+
+```scala
+// system object must ALWAYS be ENABLED, otherwise policy generation skips it (RUDDER-1234)
+def isEnabled: Boolean = _isEnabled || policyTypes.isSystem
+
+// BAD — restates the code:
+// return true if enabled or if it is a system type
+def isEnabled: Boolean = _isEnabled || policyTypes.isSystem
+```
+
+## Unit testing is mandatory — and a design tool
+
+- **Tests are not optional.** Code lands with tests (see [`900`](900-testing.md) for the
+  how). Untested code is treated as unfinished.
+- **Tests shape the architecture.** Testability is a design signal: if something is
+  hard to test in isolation, it's usually a smell — too coupled to persistence/user
+  input/infrastructure, or one unit doing too many things with too many concepts. Make
+  it testable by *fixing the design* (pure logic behind a trait, effects pushed out —
+  see [`101`](101-architecture-ddd-hexagonal.md)), not by reaching for heavyweight test
+  machinery. More reasons tests earn their keep:
+  - **A test materializes the goal.** Writing the expected input → output makes the
+    problem concrete; it often clarifies *what* you're actually solving before (and
+    while) you solve it.
+  - **A test documents intent.** It's executable documentation for other devs: it shows
+    how the code is meant to be used and what behaviour is expected — and, unlike prose,
+    it can't silently drift out of date.
+  - **Tests tighten the feedback loop.** A fast, local check beats redeploying and
+    clicking through the UI. A quicker feedback loop is always good for DX and for
+    converging efficiently toward a solution.
+  - **Tests are a regression ledger.** Over time the suite becomes a record of every
+    edge case and bug we've fixed — encoding "don't reintroduce this" so old defects
+    stay dead. When you fix a bug, add the test that would have caught it.
+- **We don't do TDD** (in the hyped, test-first-always sense). Write tests alongside the
+  code, driven by the design — not as a ritual that dictates it.
+- **100% coverage is a non-goal.** Don't chase a number. Concentrate effort where it
+  pays:
+  - **business logic** — the rules, computations, parsing, invariants;
+  - **"broader unit tests"** — exercise a slice of logic end-to-end, but with
+    *controllable* inputs and **no** real I/O, so they stay **fast, deterministic, and
+    fully automated**. These catch integration mistakes between units without the cost
+    and flakiness of touching real systems.
+- Skip tests that only assert the framework/compiler (trivial getters, pure data
+  shuffling with no logic).
+
+## Migration mindset
+
+- The codebase spans 15+ years. **Don't** mass-rewrite legacy on sight.
+- **Do** apply current conventions to every file you create or substantially edit,
+  and nudge neighbouring code toward them when it's cheap and safe.
+- Joda-Time, Lift `Box`, and `.runNow` at call sites are *legacy we are leaving* —
+  prefer `java.time`, `IOResult`, and pushing effects outward instead
+  (see [`500`](500-datetime-java-time.md), [`302`](302-bridging-toio-runnow.md)).
+
+### Concurrent branches & up-merge
+
+We maintain several release branches at once (e.g. `branches/rudder/8.3`,
+`branches/rudder/9.1`, `branches/rudder/9.2`) and **up-merge** bug fixes from the oldest
+maintained branch up to the current one. A fix touching code that has diverged between
+branches creates merge conflicts, so:
+
+- **Be mindful of up-merge cost.** When fixing a bug on an old branch, prefer changes
+  that will merge cleanly forward — keep the diff focused, and avoid gratuitously
+  reshaping surrounding code that has already moved on in newer branches.
+- **But clean code wins.** This constraint *tempers* how much unrelated churn we add;
+  it does **not** justify writing worse code. We will **not** introduce convoluted
+  bridging/compat shims, pick worse names, or duplicate logic just to dodge a merge
+  conflict. Resolve the conflict at merge time instead.
+- Net: minimize incidental diff, never compromise the quality of the change itself.

--- a/.claude/skills/rudder-scala/001-scala3-idioms.md
+++ b/.claude/skills/rudder-scala/001-scala3-idioms.md
@@ -1,0 +1,177 @@
+# 001 — Scala 3 idioms
+
+How we write idiomatic Scala 3 so business code stays small and import-light.
+
+## Logic lives in companion objects and extensions, not in the data
+
+A business `case class` should be *dumb* (ideally zero methods). Put parsing,
+serialization, conversion and helpers in the **companion object** or in `extension`
+methods. This keeps the data type clean and aligns with Scala 3 practice.
+
+Real example — `TenantAccess` (a tenant id + a permission) is a dumb 2-field case
+class; its companion holds the `parse`, `serialize` and codec
+(`rudder-core/.../tenants/Tenants.scala`):
+
+```scala
+final case class TenantAccess(id: TenantId, grant: TenantPermission)
+
+object TenantAccess {
+  def apply(id: TenantId): TenantAccess = TenantAccess(id, TenantPermission.ReadWrite)
+
+  // "tenantId:permission", permission optional (absent => ReadWrite)
+  def parse(s: String): Option[TenantAccess] = {
+    val (rawId, optToken) = s.split(":", 2) match {
+      case Array(id)       => (id, None)
+      case Array(id, perm) => (id, Some(perm))
+      case _               => (s, None)
+    }
+    for {
+      id    <- TenantId.parse(rawId)
+      grant <- TenantPermission.parseToken(optToken)
+    } yield TenantAccess(id, grant)
+  }
+
+  extension (t: TenantAccess) {
+    def serialize: String =
+      if (t.grant == TenantPermission.ReadWrite) t.id.value else s"${t.id.value}:${t.grant.entryName}"
+  }
+
+  given JsonCodec[TenantAccess] =
+    JsonCodec.string.transformOrFail(s => parse(s).toRight(s"Invalid tenant access: '$s'"), _.serialize)
+}
+```
+
+Use a multi-field `case class` like this when the concept genuinely *is* several
+values. When a concept is a **single** underlying value, prefer an `opaque type`
+instead (see below).
+
+## Minimize implicit imports
+
+We want the **general case to need no `import` for implicits/givens**. Achieve that
+by defining `given`/`implicit val` instances in the **companion object** of the type
+they target — they're then found by implicit scope without an import. Reserve
+explicit imports for genuinely cross-cutting helpers.
+
+## Import syntax: no grouped `{a, b, c}`
+
+Never group several names from one package on a single line with braces. Use **one
+import per line**, and when you take **strictly more than two** names from the same
+package, use a **star import** instead.
+
+```scala
+// NO — grouped braces
+import com.normation.errors.{IOResult, PureResult, RudderError}
+
+// yes — 1 or 2 names: one import per line
+import com.normation.errors.IOResult
+import com.normation.errors.PureResult
+
+// yes — 3+ names from the same package: star import
+import com.normation.errors.*
+```
+
+scalafmt (`rewrite.imports.expand`) already **expands grouped braces to one-per-line**,
+so it enforces the "no `{a, b, c}`" half automatically. Choosing a **star import once you
+have 3+** names is *our* convention on top — scalafmt won't create it for you, but it
+leaves a `.*` import as-is. So: write the star yourself when it's 3 or more (see
+[`800`](800-build-and-formatting.md)).
+
+## `extension` methods
+
+Use `extension` to add behaviour to a type without polluting the type itself, e.g.
+the `AcceptationDateTime` opaque type (`rudder-core/.../policies/ActiveTechnique.scala`):
+
+```scala
+opaque type AcceptationDateTime = Map[TechniqueVersion, Instant]
+object AcceptationDateTime {
+  extension (self: AcceptationDateTime) {
+    def withNewVersions(vs: Map[TechniqueVersion, Instant]): AcceptationDateTime = self ++ vs
+    def versions: Map[TechniqueVersion, Instant] = self
+  }
+  def empty: AcceptationDateTime = Map()
+}
+```
+
+## Type-directed development: no stringly-typed code
+
+We let **types describe the domain**. A new concept gets a new type — we do **not**
+thread bare `String`/`Int`/`Boolean`/`Map[String, String]` around to stand for domain
+notions. This makes signatures self-documenting, prevents mixing up a `NodeId` with a
+`RuleId`, and lets "parse, don't validate" ([`201`](201-parse-dont-validate.md)) anchor
+invariants on the type.
+
+- Modelling a new thing? Define a type for it (and put its `parse`/`serialize`/codec in
+  the companion).
+- A parameter that is "an id", "a name", "a token", "a path"… is a *type*, not a
+  `String`. If you're about to write `def f(x: String, y: String)`, stop and name them.
+
+### Choosing the wrapper: `opaque type` > value class > raw
+
+For a concept backed by a **single** underlying value, in order of preference:
+
+1. **`opaque type`** — the preferred form for **new** wrappers. A true zero-cost
+   newtype (no runtime allocation) that still presents a typed API and keeps invariants
+   true. Expose construction/behaviour via the companion + `extension` (as
+   `AcceptationDateTime` above).
+   ```scala
+   opaque type TenantId = String
+   object TenantId {
+     def parse(s: String): Option[TenantId] = Option.when(s.nonEmpty && s.forall(_.isLetterOrDigit))(s)
+     extension (t: TenantId) def value: String = t
+   }
+   ```
+2. **Value class** — `case class X(value: T) extends AnyVal`. The older, still-common
+   form (e.g. `PluginId`, `Licensee`, `SoftwareId`). Fine to leave in place and to
+   match in existing files, but for new single-value wrappers prefer an `opaque type`
+   — e.g. `PluginId` (just a `String` with a regex invariant) would today be better as
+   an `opaque type`.
+3. **Raw `String`/`Int`** — never, for a domain concept.
+
+For a concept that is genuinely **two or more** values, use a `case class`
+(e.g. `TenantAccess` above) — not an `opaque type` over a tuple.
+
+## ADTs: `sealed trait` + `case object`/`case class`
+
+Model closed sets of cases with `sealed trait` + `case object`/`case class`. Keep the
+cases dumb; put logic in the companion (e.g. `PluginInstallStatus.from(...)` decides the
+status from inputs in one place).
+
+We do **not** use the native Scala 3 `enum` keyword. When you need an enumeration with
+a name/value, lookup-by-name, or `values`, use **enumeratum** (see
+[`401`](401-json-zio-json.md#enums)) — it's the project standard.
+
+## Collections: prefer `Chunk`
+
+Prefer zio's **`Chunk`** (and `NonEmptyChunk`) for sequences — it's a more
+memory-compact, array-backed structure. `List` is historical and fine for small or
+recursively-built data; `cats.data.NonEmptyList` is used where a non-empty list is
+required (e.g. accumulated errors, see [`301`](301-error-model.md)). Match the
+surrounding code when editing.
+
+## `given`/`using` over `implicit`
+
+Use Scala 3 `given`/`using` for **new** code — even when the surrounding class still
+uses `implicit`. Don't mirror the old style for consistency's sake.
+
+Moreover, when you touch a file, **rewrite the `implicit`s you see into `given`/`using`
+whenever the change is strictly equivalent** (a plain `implicit val`/`implicit def`/
+`using`-parameter with no behavioural difference). Leave `implicit` in place only when
+the rewrite isn't a no-op — e.g. `implicit class` extension wrappers (use an
+[`extension`](#extension-methods) instead, which is a different shape, not a mechanical
+swap) or implicit conversions, where semantics or resolution could shift. Keep such
+rewrites within the [up-merge](000-coding-philosophy.md#concurrent-branches--up-merge)
+budget: don't churn an entire legacy file just to convert implicits.
+
+## Style reminders
+
+- Don't add `copy` helpers; use [quicklens](403-quicklens-updates.md) for updates.
+- Don't write companion methods that merely re-expose a field — let the case class
+  field stand on its own.
+- No `var` in new code (see the immutability carve-out in
+  [`000`](000-coding-philosophy.md) for the legacy Lift / perf-local exceptions).
+- **Parameterless `def`s keep their `()`.** Declare and call a no-argument *method* with
+  empty parens — `def reload(): IOResult[Unit]` / `repo.reload()` — so it is visibly a
+  method, not a `val`. Reserve no-parens access (`def value: String`) for the
+  field-like, side-effect-free accessor case (e.g. on an `extension`/wrapper). The `()`
+  signals "this is a computation/effect", and lets a `val` later replace a pure
+  parameterless `def` without churning call sites.

--- a/.claude/skills/rudder-scala/100-package-layout.md
+++ b/.claude/skills/rudder-scala/100-package-layout.md
@@ -1,0 +1,58 @@
+# 100 — Package & directory layout
+
+Organize packages by **bounded context first**, then by the aspects of that context —
+*not* by technical layer.
+
+## The rule
+
+A bounded context (`score`, `campaigns`, `tenants`, `properties`, `facts/nodes`, …) is
+a top-level package, and everything about that context lives under it: its domain
+types, its repositories, its services, its serialization, etc.
+
+Real example — `rudder-core/.../com/normation/rudder/score/`:
+
+```
+com/normation/rudder/score/
+├── Score.scala                 // domain types
+├── ComplianceScore.scala
+├── SystemUpdateScore.scala
+├── ScoreRepository.scala       // persistence port (200)
+├── GlobalScoreRepository.scala
+└── ScoreService.scala          // domain service (100 §Services)
+```
+
+Domain, repository and service for *score* sit together because they form one cohesive
+topic — you read and change them as a unit.
+
+## The legacy layout (don't extend it)
+
+Older code is organized by **technical layer** at the top level, with per-concept
+sub-packages underneath:
+
+```
+com/normation/rudder/
+├── domain/...        // ~76 files: types for every concept
+├── repository/...    // ~37 files: repositories for every concept
+└── services/...      // ~83 files: services for every concept
+```
+
+This scatters one concept across three (or more) distant trees. It was acceptable when
+Rudder was small and a whole **sub-project** *was* the bounded context (e.g.
+`ldap-inventory`, the `rudder` projects) — but at today's size it hurts cohesion and
+discoverability.
+
+## What to do
+
+- **New context → new top-level package** under `com.normation.rudder.<context>`, with
+  its domain/repository/service aspects inside it (the `score` shape).
+- **New code in an existing context** → put it in that context's package, even if a
+  technical-layer home also exists. Prefer adding to `…/properties/` over `…/services/`.
+- **Don't** add new files under the legacy `domain/` `repository/` `services/` trees,
+  and **don't** mass-migrate existing ones on sight — moving files is costly to
+  [up-merge](000-coding-philosophy.md#concurrent-branches--up-merge). Migrate a concept
+  when you're already substantially reworking it.
+- Module boundaries (`rudder-core`, `rudder-rest`, `rudder-web`, `ldap-inventory`, …)
+  still matter and are orthogonal to this: within a module, lay out by context.
+
+See [`101`](101-architecture-ddd-hexagonal.md) for bounded contexts and services,
+[`200`](200-persistence-repositories.md) for repositories.

--- a/.claude/skills/rudder-scala/101-architecture-ddd-hexagonal.md
+++ b/.claude/skills/rudder-scala/101-architecture-ddd-hexagonal.md
@@ -1,0 +1,107 @@
+# 101 — Architecture: pragmatic DDD & hexagonal
+
+We are **attached but not integrist** about Domain-Driven Design and hexagonal
+architecture. We use them to get *clear responsibilities and loose coupling*, not to
+generate ceremony.
+
+## The aspiration: pure, isolation-testable domain logic
+
+The goal everything else serves: **business logic that is pure and can be tested in
+isolation**, with **invariants we can identify and enforce**.
+
+- **Pure.** Domain logic is a function of its inputs — no I/O, no hidden state, no
+  clock/randomness baked in. Effects are pushed to the edges (repositories, services'
+  boundaries) so the core is just data → data (see [`300`](300-effects-zio-ioresult.md)).
+- **Testable in isolation.** Such logic needs no database, no LDAP, no HTTP, no
+  mocking framework to test — you call it with values and assert on values. If a piece
+  of logic can't be tested without standing up infrastructure, that's the design
+  telling you it's too coupled or too big — split it (this is the testability-as-design
+  signal from [`000`](000-coding-philosophy.md#unit-testing-is-mandatory--and-a-design-tool)).
+- **Invariants you can enforce.** Make illegal states unrepresentable: encode rules in
+  types (parsed wrappers, ADTs — see [`001`](001-scala3-idioms.md),
+  [`201`](201-parse-dont-validate.md)) so the compiler upholds them, and check the rest
+  in one well-identified place (a `parse`, a smart constructor, a domain function)
+  rather than scattering ad-hoc checks. An invariant that lives in pure code is one you
+  can actually test.
+
+This is the *target*; legacy code won't all look like this, but new design should bend
+toward it.
+
+## What we keep from DDD / hexagonal
+
+- **Bounded contexts.** Code is organized around business domains (nodes, rules,
+  directives, campaigns, plugins, compliance/reports, properties, …). Each context
+  owns its domain types and its repositories, **colocated in one package per context**
+  — see [`100`](100-package-layout.md) for the directory layout.
+- **Domain at the center.** Pure domain types and logic don't depend on
+  infrastructure. Infrastructure (LDAP, git, DB, HTTP) depends on the domain via
+  traits (ports), not the other way around.
+- **Ports & adapters.** A repository *trait* is a port; its `*Impl` (LDAP, git, in
+  memory…) is an adapter. Business code talks to the trait only
+  (see [`102`](102-traits-and-dependency-injection.md), [`200`](200-persistence-repositories.md)).
+- **Boundaries parse input.** Anything coming from outside is parsed into typed
+  domain objects before the domain touches it (see [`201`](201-parse-dont-validate.md)).
+
+## What we deliberately relax
+
+- **Naming conventions.** We do *not* religiously use DDD vocabulary
+  (Aggregate, ValueObject, Entity, Factory…) in type names. Clear, plain names win.
+- **No mandatory layering ceremony.** We don't create a separate "application
+  service", "domain service", "DTO", and "mapper" for every operation. If a single
+  function in a repository is enough, that's the design.
+- **Pattern completeness is not a goal.** Implement the *part* of the pattern that
+  buys clarity or decoupling; skip the rest. Fewer, simpler types beat a textbook
+  hexagon.
+
+## Decision guide
+
+- New concept that other code reasons about → a domain `case class`/ADT in the
+  relevant bounded context.
+- Need to read/write that concept somewhere → a **repository trait** + impl
+  ([`200`](200-persistence-repositories.md)).
+- Crossing a boundary (API, file, LDAP, CLI) → parse into domain types on the way in,
+  serialize on the way out ([`201`](201-parse-dont-validate.md),
+  [`401`](401-json-zio-json.md)).
+- Mapping between two internal representations → chimney
+  ([`402`](402-chimney-transformers.md)), not hand-written field copying.
+
+## Services
+
+"**Service**" is a naming convention with a precise meaning here: a **stateless**,
+**single-instance** class that holds **domain logic** in the usual DDD sense — behaviour
+that doesn't naturally belong to a single entity/value object (it orchestrates several
+of them, or implements a domain operation/policy). It is *not* a catch-all for "any
+class".
+
+- **Stateless.** A service holds no mutable state of its own; it operates on its inputs
+  and its (injected) collaborators. State lives in repositories
+  ([`200`](200-persistence-repositories.md)) or, when truly needed, in `Ref`/`Semaphore`
+  cells ([`300`](300-effects-zio-ioresult.md)).
+- **Single instance.** There is exactly one, created as a `lazy val` in `RudderConfig`
+  and wired by constructor ([`102`](102-traits-and-dependency-injection.md)) — not
+  instantiated ad hoc at call sites.
+- **Trait + impl.** Like everything else, a service is a **trait** (the API) with an
+  implementation; effectful methods return `IOResult` ([`300`](300-effects-zio-ioresult.md)).
+- **Naming.** The type is suffixed `Service` (`NodePropertiesService`,
+  `WorkflowLevelService`, …); impls follow the usual `*Impl`/`Default*` forms.
+
+```scala
+trait NodePropertiesService {
+  def updateAll(): IOResult[Unit]
+  // ... domain operations over node properties
+}
+
+// in RudderConfig:
+lazy val nodePropertiesService = new NodePropertiesServiceImpl(propertiesRepository, ...)
+```
+
+Use a service when logic spans multiple entities/repositories or expresses a domain
+rule with no obvious home; don't create one just to wrap a single repository call (call
+the repository) or to host pure helpers on one type (put those in its companion /
+`extension`, see [`001`](001-scala3-idioms.md)).
+
+## Coupling test
+
+Before adding a dependency between two modules/contexts, ask: *does the domain need
+this, or only an adapter?* Keep the arrows pointing inward. If a domain type starts
+importing infrastructure, that's the signal to introduce (or use) a port.

--- a/.claude/skills/rudder-scala/102-traits-and-dependency-injection.md
+++ b/.claude/skills/rudder-scala/102-traits-and-dependency-injection.md
@@ -1,0 +1,57 @@
+# 102 — Traits & dependency injection
+
+## Program to interfaces (traits)
+
+Every service and repository has a **trait** defining its API — *even when there is a
+single implementation*. Business code depends on the trait; the concrete `*Impl` is
+an implementation detail.
+
+```scala
+trait PropertiesRepository {
+  def getAllGroupProps(): IOResult[Map[NodeGroupId, ResolvedNodePropertyHierarchy]]
+  def getNodeProps(nodeId: NodeId)(implicit qc: QueryContext): IOResult[Option[ResolvedNodePropertyHierarchy]]
+  def saveNodeProps(props: Map[NodeId, ResolvedNodePropertyHierarchy]): IOResult[Unit]
+  def deleteNode(nodeId: NodeId): IOResult[Unit]
+}
+```
+(`rudder-core/.../properties/PropertiesRepository.scala`)
+
+Trait method signatures are the contract: they return `IOResult[...]` for anything
+effectful (see [`300`](300-effects-zio-ioresult.md)), take typed domain inputs
+(see [`201`](201-parse-dont-validate.md)), and may carry context like
+`(implicit qc: QueryContext)` for security scoping (see [`600`](600-security-in-depth.md)).
+
+## Dependency injection is constructor-only
+
+**Do not** use ZIO's environment (`ZLayer`, `R` in `ZIO[R, E, A]`) for DI. Our `R` is
+always `Any`. Wiring is done by **constructor parameters**, and the whole object graph
+is assembled in one place: `RudderConfig`
+(`rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala`).
+
+`RudderConfig` is, in its own words:
+
+> "This is not a cake-pattern, just a plain object with load of lazy vals."
+
+```scala
+lazy val pluginSystemService  = new PluginsServiceImpl(...)
+lazy val rudderPackageService = new RudderPackageCmdService(RUDDER_PACKAGE_CMD)
+lazy val workflowLevelService = new DefaultWorkflowLevel(...)
+```
+
+Each component takes its collaborators (as traits) in its constructor and is
+instantiated once as a `lazy val`. Dependencies flow in; nothing reaches out to a
+global registry or service locator.
+
+## Rules of thumb
+
+- A new service/repository = **trait** (the port) + **`*Impl` class** (the adapter)
+  whose constructor takes the traits it needs.
+- Wire the new impl as a `lazy val` in `RudderConfig`, passing the already-declared
+  collaborators.
+- **No** `ZLayer`/`ZIO` environment, **no** cake pattern, **no** runtime DI framework.
+  (A single module, `SettingsApi`, passes a service via `ZIO` env + `provideLayer`
+  instead of by constructor — that's a known exception to avoid copying, not the
+  pattern.)
+- Keep constructors honest: if a class needs a collaborator, take it as a parameter —
+  don't reach for a singleton.
+- Test doubles are just alternative trait implementations passed to the constructor.

--- a/.claude/skills/rudder-scala/103-rest-api-and-endpoints.md
+++ b/.claude/skills/rudder-scala/103-rest-api-and-endpoints.md
@@ -1,0 +1,91 @@
+# 103 — REST API & endpoints
+
+REST endpoints are **declared declaratively** as data, separately from their handlers.
+Every endpoint carries its HTTP method, path, API version, and — critically — the
+**authorization** it requires. This is security-in-depth at the API edge
+(see [`600`](600-security-in-depth.md)).
+
+## Endpoint definitions (the schema)
+
+Endpoints are enumerated as enumeratum `EndpointSchema` enums (see
+[`401`](401-json-zio-json.md#enums) for enumeratum). Example
+(`rudder-rest/.../EndpointsDefinition.scala`):
+
+```scala
+sealed trait CampaignApi extends EnumEntry with EndpointSchema with GeneralApi with SortIndex
+object CampaignApi extends Enum[CampaignApi] with ApiModuleProvider[CampaignApi] {
+
+  case object GetCampaigns extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get all campaigns"
+    val (action, path) = GET / "campaigns"
+    val dataContainer: Some[String]            = Some("campaigns")
+    val authz:         List[AuthorizationType] = AuthorizationType.Configuration.Read :: Nil
+  }
+  case object SaveCampaign extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
+    val (action, path) = POST / "campaigns"
+    val authz:         List[AuthorizationType] = AuthorizationType.Configuration.Write :: Nil
+    // ...
+  }
+}
+```
+
+Each endpoint declares:
+
+- **method + path** via the DSL: `GET / "campaigns" / "events" / "{id}"`.
+- **API version** it appears in: `StartsAtVersionN` (versioning is explicit, never
+  silent).
+- **`authz: List[AuthorizationType]`** — the permission(s) required. *Every* endpoint
+  must declare this; a read endpoint gets `...Read`, a mutating one `...Write`. This is
+  the single source of truth the framework enforces — do not rely on the handler to
+  re-check by hand.
+- a `description` (feeds API docs) and `dataContainer` (the JSON field results sit in).
+
+## Handlers (the lift adapter)
+
+Handlers live under `rudder-rest/.../rest/lift/` and implement `process(...)` /
+`process0(...)`, which receive the parsed `ApiVersion`, `ApiPath`, request, params and
+the `AuthzToken`. The body works in `IOResult` and is rendered with the
+`.toLiftResponse*` boundary (a `.toBox`-style run, see [`302`](302-bridging-toio-runnow.md)):
+
+```scala
+def process(version: ApiVersion, path: ApiPath, resources: String, req: Req,
+            params: DefaultParams, authz: AuthzToken): LiftResponse = {
+  campaignEventRepository
+    .get(CampaignEventId(resources))                 // IOResult[...]
+    .toLiftResponseOne(params, schema, _ => Some(resources))
+}
+```
+
+- `.toLiftResponseOne(...)` / `.toLiftResponseList(...)` turn an `IOResult[A]` into the
+  HTTP response, mapping `RudderError` to the proper status/body. Keep the *whole*
+  handler in `IOResult` and convert once, at the end.
+- Parse path/query/body into typed values first (**parse, don't validate**,
+  [`201`](201-parse-dont-validate.md)); never thread raw strings into the service.
+- The response JSON is a **contract**: lock it with a test, and once the business model
+  needs to diverge from it, serialize a DTO (chimney) rather than the domain object —
+  see [`404`](404-serialization-contracts.md).
+
+## Plugin APIs & dynamic status (ADR 28612)
+
+Whether a plugin's API is currently enabled (license/status) is checked **centrally by
+the framework**, not by hand in each endpoint. Source of truth: ADR
+[`28612-dynamic-checking-of-plugin-status-in-menu-and-api`](../../../adr/webapp/28612-dynamic-checking-of-plugin-status-in-menu-and-api.md).
+
+- A plugin's API provider extends `PluginLiftApiModuleProvider[API]` and takes the
+  status as a context parameter: `class MyApiImpl(...)(using status: PluginStatus)`. The
+  `given PluginStatus = pluginStatusService` is provided in the plugin's `Conf` object
+  (and `AlwaysEnabledPluginStatus` in tests).
+- `ApiModule.isEnabled` defaults correctly; only `override def isEnabled = true` locally
+  for an endpoint that must always work. Core (non-plugin) endpoints are always enabled.
+- Menu entries use `testMenuAccess(<authz>)` (not the bare `TestAccess`) so they
+  appear/disappear with the plugin status.
+- Don't re-implement plugin-status checks ad hoc in handlers or menus.
+
+## Rules
+
+- Add an endpoint → add a `case object` to the relevant `*Api` schema with method,
+  path, `StartsAtVersion*`, `description`, `dataContainer`, **and `authz`**.
+- New internal-only endpoints go under `rest/internal/`; public ones under `rest/lift/`.
+- Handler returns `IOResult`, converted with `.toLiftResponse*` — no bare `.runNow`.
+- Don't bypass the schema/authz mechanism with ad-hoc permission checks.

--- a/.claude/skills/rudder-scala/104-bootstrap-and-migrations.md
+++ b/.claude/skills/rudder-scala/104-bootstrap-and-migrations.md
@@ -1,0 +1,104 @@
+# 104 — Bootstrap checks & self-managed migrations
+
+Rudder manages its **own** integrity: schema and data migrations, consistency checks,
+and one-time initialisations run **inside the application at startup**, not from external
+scripts. The mechanism is the `BootstrapChecks` pipeline under
+`rudder-web/.../bootstrap/liftweb/checks/`.
+
+## The `BootstrapChecks` interface
+
+A check is a small class implementing `bootstrap.liftweb.BootstrapChecks`
+(`bootstrap/liftweb/BootstrapChecks.scala`):
+
+```scala
+trait BootstrapChecks {
+  def description: String
+  def checks(): Unit   // executed during boot — be careful with the time it takes
+}
+```
+
+Checks are grouped into ordered sequences (`SequentialImmediateBootStrapChecks`, or
+`OnceBootstrapChecks` for the very earliest) that log and time each step and `catchAll`
+so one failure doesn't abort the whole sequence. Log through `BootstrapLogger`
+(`bootchecks`, with `.Early.DB` / `.Early.LDAP` children — see [`303`](303-logging.md)).
+
+## Two phases — pick the right one
+
+### `earlyconfig/` — during `RudderConfig` instantiation, before services
+
+Packages `checks.earlyconfig.db` and `checks.earlyconfig.ldap`. These run **as soon as
+the DB/LDAP connection exists and before the repositories/services are built**, because
+those services may depend on the changes. Wired in `RudderConfig` as immediate sequences
+(e.g. `earlyDbChecks` / `earlyLdapChecks`, run with `.checks()` right there).
+
+Use early checks for: **evolving database schemas and data layout**, LDAP layout, and
+consistency that later components rely on (create/alter tables, enforce a schema,
+add columns, drop obsolete tables…).
+
+### `endconfig/` — after services/repositories are instantiated
+
+Packages `checks.endconfig.{action,consistency,migration,onetimeinit}`. Collected into
+`allBootstrapChecks` in `RudderConfig` and run from `RudderConfig.init()` via
+`allBootstrapChecks.checks()` — deliberately **outside** Lift's `boot()` (which is
+wrapped in a try/catch that would swallow failures).
+
+Use end checks for: **converging data**, triggering the start of things, one-time
+initialisations (default templates, instance UUID, technique-library reload…), and
+migrations that need the domain services to already exist.
+
+### Services that must start after the webapp boots
+
+A long-lived service that should start once the webapp is up (not a check) is started in
+`bootstrap/liftweb/Boot.scala#boot`, not in the checks pipeline.
+
+## Self-managed, convergent migrations
+
+We do **not** ship external migration scripts — the app migrates itself on startup. That
+puts two requirements on every migration:
+
+- **Convergent, idempotent, restartable.** A check may run on every boot and may be
+  interrupted; it must be safe to re-run. Use `CREATE TABLE IF NOT EXISTS`,
+  `ADD COLUMN IF NOT EXISTS`, guard on current state, and design so an interrupted
+  migration simply resumes next boot.
+- **Minimise blocking / transaction time.** Boot must not hang on a long migration.
+  **Prefer async**: do the heavy work on a forked daemon fiber so boot continues, e.g.
+  (`checks/earlyconfig/db/CreateTableNodeFacts.scala`):
+
+  ```scala
+  override def checks(): Unit = {
+    val prog = for { _ <- createTableStatement } yield ()
+    // run async so it does not block boot
+    prog
+      .catchAll(err => BootstrapLogger.Early.DB.error(s"... ${err.fullMsg}"))
+      .forkDaemon
+      .runNow
+  }
+  ```
+
+  This is one of the **sanctioned `.runNow`** boundaries (see
+  [`302`](302-bridging-toio-runnow.md)): the `checks()` method is a `Unit` boot hook, so
+  it forks the effect and returns. The forked migration is "convergent and asynchronous:
+  it does not block boot, and can be interrupted and restarted afterward."
+
+## The hard balance
+
+Async is the default, but **when correctness depends on the migration finishing before
+the data is used, it must be synchronous** (blocking) — e.g. a schema change a service
+needs the moment it starts. Split the work: do the *minimal* integrity-critical part
+synchronously (and early), and fork the bulk (back-filling rows, rewriting large tables)
+to run in the background. Document, per migration, what is sync and why.
+
+## Adding a migration/check
+
+1. Write a class extending `BootstrapChecks` in the right package
+   (`earlyconfig.db`/`.ldap` if services depend on it; `endconfig.*` otherwise), with a
+   clear `description` and an idempotent body.
+2. Decide sync vs async (default async via `.forkDaemon`); keep the synchronous portion
+   minimal.
+3. Wire it into the matching sequence in `RudderConfig` (`earlyDbChecks`,
+   `earlyLdapChecks`, or `allBootstrapChecks`); a separate long-running service starts in
+   `Boot.scala#boot`.
+4. Log via `BootstrapLogger`, and `catchAll` so a failure is logged, not fatal (unless it
+   genuinely must abort startup).
+5. Test it (incl. the "runs twice" / "interrupted then resumed" cases) — see
+   [`900`](900-testing.md); persistence specifics in [`200`](200-persistence-repositories.md).

--- a/.claude/skills/rudder-scala/200-persistence-repositories.md
+++ b/.claude/skills/rudder-scala/200-persistence-repositories.md
@@ -1,0 +1,70 @@
+# 200 — Persistence: repositories
+
+**Every piece of persisted data goes through a repository**, which is the *single
+point of change* for that data. Nothing else reads or writes the underlying store
+(LDAP, git, DB, files) directly.
+
+## Shape of a repository
+
+- A **trait** (the port) declares the API in domain terms, returning `IOResult[...]`
+  for every operation (all persistence is effectful — see [`300`](300-effects-zio-ioresult.md)).
+- One or more **`*Impl`** adapters implement it against a concrete store.
+- It is wired by constructor in `RudderConfig` (see [`102`](102-traits-and-dependency-injection.md)).
+
+```scala
+trait PropertiesRepository {
+  def getNodeProps(nodeId: NodeId)(implicit qc: QueryContext): IOResult[Option[ResolvedNodePropertyHierarchy]]
+  def saveNodeProps(props: Map[NodeId, ResolvedNodePropertyHierarchy]): IOResult[Unit]
+  def deleteNode(nodeId: NodeId): IOResult[Unit]
+}
+```
+
+## API speaks the domain, not the storage
+
+- Inputs and outputs are **typed domain objects**, never raw rows/JSON/LDAP entries.
+- Parsing storage → domain and serializing domain → storage happens *inside* the impl.
+  Callers never see the wire/storage format.
+- Security context (e.g. `QueryContext` carrying tenant scoping) is part of the
+  signature where access must be restricted (see [`600`](600-security-in-depth.md)).
+
+## Split read and write at the interface (`Ro*` / `Wo*`)
+
+Separate **read-only** and **write-only** operations into distinct traits, prefixed
+`Ro`/`Wo` — e.g. `RoNodeGroupRepository` (reads) and `WoNodeGroupRepository` (writes).
+
+- **Why:** it's design hygiene. Splitting forces you to think about the *real scope of
+  access* a caller needs, and lets you hand a component read-only capability without
+  also granting writes (defense in depth, see [`600`](600-security-in-depth.md)).
+- **The more complex / sensitive the data, the more this matters.** For a trivial
+  store a single trait is fine; for a central aggregate, split it.
+- This is *not* full CQRS. There's no separate read/write model or eventual
+  consistency. The **same `*Impl`** typically implements both traits (and the write
+  impl usually needs read access anyway).
+
+```scala
+trait RoNodeGroupRepository { def get(id: NodeGroupId): IOResult[Option[NodeGroup]]; /* ... */ }
+trait WoNodeGroupRepository { def update(g: NodeGroup): IOResult[Unit];             /* ... */ }
+class NodeGroupRepositoryImpl(...) extends RoNodeGroupRepository with WoNodeGroupRepository { ... }
+```
+
+## Optional dedicated persistence layer
+
+A repository may directly contain its storage logic. When the complexity warrants it,
+it can instead delegate to a **dedicated persistence/storage layer** — e.g.
+`NodeFactRepository` is backed by a separate `NodeFactStorage`
+(`rudder-core/.../facts/nodes/`). This split is **optional**: introduce it only when
+the storage concerns are genuinely complex enough to earn the extra indirection.
+Default to the simpler single-trait repository.
+
+## Do / don't
+
+- **Do** funnel all reads/writes of a given dataset through its one repository.
+- **Do** return `IOResult[Option[A]]` for "maybe absent", `IOResult[A]` for
+  "must exist or fail", `IOResult[Unit]` for writes.
+- **Don't** scatter store access across services. If two places touch the same data
+  directly, one of them should be calling the repository instead.
+- **Don't** leak storage types (LDAP entries, SQL rows, JSON) out of the impl.
+
+Schema and data **migrations** are not done here ad hoc — the app migrates itself at
+startup through the bootstrap-checks pipeline (self-managed integrity, async where
+possible). See [`104`](104-bootstrap-and-migrations.md).

--- a/.claude/skills/rudder-scala/201-parse-dont-validate.md
+++ b/.claude/skills/rudder-scala/201-parse-dont-validate.md
@@ -1,0 +1,46 @@
+# 201 — Parse, don't validate
+
+Any value crossing an I/O boundary (HTTP API, CLI args, config files, git content,
+LDAP, DB) is **parsed into a typed domain object at the boundary**. The domain then
+works only with values that are *correct by construction* — we never pass an unchecked
+`String` inward and re-check it later.
+
+## The pattern
+
+A `parse` function turns raw input into either a typed value or an error message, and
+lives in the companion of the target type:
+
+```scala
+case class PluginId(value: String) extends AnyVal
+object PluginId {
+  private val pluginIdRegex = """^(\p{Alnum}[\p{Alnum}-_]*)$""".r
+  def parse(s: String): Either[String, PluginId] = s match {
+    case pluginIdRegex(_) => Right(PluginId(s))
+    case _                => Left(s"Invalid plugin ID: '$s'. ...")
+  }
+}
+```
+
+For values that round-trip (parse ⇆ serialize), pair `parse` with a `serialize`:
+
+```scala
+case class CampaignId(value: String, rev: Revision = GitVersion.DEFAULT_REV) {
+  def serialize: String = ...
+}
+object CampaignId {
+  def parse(s: String): Either[String, CampaignId] = GitVersion.parseUidRev(s).map { case (id, rev) => CampaignId(id, rev) }
+  implicit val codec: JsonCodec[CampaignId] = JsonCodec.string.transformOrFail(CampaignId.parse, _.serialize)
+}
+```
+
+## Consequences
+
+- **Make illegal states unrepresentable.** Prefer a wrapper type with a private/
+  guarded constructor + `parse` over a bare primitive that "should" be valid.
+- **Parsing returns errors, it doesn't throw.** Use `Either[String, A]` (string =
+  message) or `PureResult[A]`/`IOResult[A]` (`RudderError`) — see
+  [`301`](301-error-model.md). zio-json codecs use `mapOrFail`/`transformOrFail` so a
+  bad payload becomes a decode error, not a half-built object.
+- **Parse once, at the edge.** Deep in the domain, assume validity — don't re-validate.
+- **Errors are accumulated** when parsing collections of inputs, so the user sees all
+  problems at once (`Accumulated`, see [`301`](301-error-model.md)).

--- a/.claude/skills/rudder-scala/300-effects-zio-ioresult.md
+++ b/.claude/skills/rudder-scala/300-effects-zio-ioresult.md
@@ -1,0 +1,142 @@
+# 300 — Effects: ZIO & `IOResult`
+
+We use **ZIO** as our effect handler — but only for *effects*, never for DI or service
+wiring (that is constructor-based, see [`102`](102-traits-and-dependency-injection.md)).
+
+## The two result types
+
+Defined in `com.normation.errors` (`utils/.../ZioCommons.scala`):
+
+```scala
+type PureResult[A] = Either[RudderError, A]      // pure, may fail, fully evaluated
+type IOResult[A]   = ZIO[Any, RudderError, A]    // effectful, may fail, must be run
+```
+
+- The environment `R` is **always `Any`** — we do not use ZIO's environment for DI.
+- The error channel `E` is **always `RudderError`** (see [`301`](301-error-model.md)).
+- `IOResult` is the one and only name for this type — always use it.
+
+### When to use which — prefer the least powerful
+
+**Always reach for the least powerful abstraction that does the job.** `IOResult` can do
+*anything* (I/O, mutation, concurrency, fail in any way) — that power is exactly why it
+is the *wrong* default: a `PureResult` signature *promises* the caller there are no side
+effects, is trivially testable, and composes without a runtime. Don't reach for
+`IOResult` just because it's available.
+
+- **Plain value / `Option`** — for total or near-total pure helpers (no failure to
+  report). Most code.
+- **`PureResult[A]`** — pure computation that can fail (parsing, validation,
+  business-rule checks) with **no** side effect. Prefer this whenever the logic is pure,
+  even if its caller is effectful — keep the pure core pure and lift only at the call
+  site (see [`101`](101-architecture-ddd-hexagonal.md), [`302`](302-bridging-toio-runnow.md)).
+- **`IOResult[A]`** — *only* when there is actually an effect: I/O (LDAP, git, DB,
+  files, network), mutation, clock, randomness, logging side-effects, or calling
+  effectful code. If genuinely in doubt whether something is effectful, it is — but
+  first check whether you can keep the piece pure.
+
+Rule of thumb: a function that merely *transforms data* should be `A => PureResult[B]`
+(or `A => B`), not `A => IOResult[B]`. If you typed it `IOResult` out of habit, narrow
+it.
+
+## Importing effectful code into `IOResult`
+
+Wrap side-effecting calls — never let an exception escape:
+
+```scala
+// blocking by default (LDAP/DB/file/network):
+IOResult.attempt("explain what failed")( javaApi.doThing() )      // => IO[SystemError, A]
+// CPU-bound, non-blocking:
+IOResult.nonBlocking("explain what failed")( pureButThrowing() )
+// when the body itself returns an IOResult and may throw while building it:
+IOResult.attemptZIO("explain what failed")( buildEffect() )
+```
+
+Always pass a meaningful error message; it becomes the `SystemError` shown to
+operators.
+
+### Thread pools: why `attempt` blocks by default
+
+The ZIO runtime has **two thread pools**:
+
+- a **CPU-bound** pool — a *fixed* number of threads (≈ number of available CPUs) for
+  non-blocking, compute work;
+- a **blocking** pool — for effects that may wait on I/O indefinitely; it grows a new
+  thread per fiber that runs such an effect.
+
+Putting a blocking effect on the CPU pool starves it and can **deadlock** the app.
+Because Rudder has a lot of I/O code and a lot of `.runNow` entry points (see
+[`302`](302-bridging-toio-runnow.md)), we deliberately make `IOResult.attempt` **blocking
+by default** (`ZIO.attemptBlocking` — see its implementation in `ZioCommons.scala`). This
+is *slightly wasteful* (a no-I/O effect may still land on the blocking pool), but it is
+the safe choice that avoids deadlocks. ZIO 2.1 dropped its automatic blocking detection
+in favour of a heuristic that didn't work for us, so we set blocking back explicitly.
+
+So choose the importer by the work:
+
+- `IOResult.attempt(...)` — **default**, for anything that may block (LDAP, DB/doobie,
+  files, network, most Java APIs). When unsure, use this.
+- `IOResult.nonBlocking(...)` — only for genuinely CPU-bound, non-blocking work that
+  throws.
+
+### Caveat: ZIO threads and `ThreadLocal` (Spring Security)
+
+Because effects run on ZIO's own managed threads (and fibers can move between threads),
+**Java frameworks that carry context in a `ThreadLocal` don't see it inside a ZIO
+effect**. The concrete case is **Spring Security**, whose `SecurityContextHolder` is
+thread-local: code executed inside a ZIO effect can *lose the authenticated principal*.
+This caused a real bug (lost Spring authentication when running in a ZIO context),
+addressed in PR #7188 and the background to ADR
+[`28452-avoid-currentuser-for-querycontext-in-lift-snippets`](../../../adr/webapp/28452-avoid-currentuser-for-querycontext-in-lift-snippets.md)
+(see [`600`](600-security-in-depth.md)). When bridging ZIO with thread-local-based code,
+capture the needed context *before* entering the effect and pass it explicitly — don't
+rely on it being readable from inside.
+
+## Composing
+
+Use normal ZIO combinators: `map`, `flatMap`/for-comprehension, `foreach`,
+`foreachPar`, `ZIO.foreach`, `catchAll`, `mapError`, `chainError` (see
+[`301`](301-error-model.md)). Prefer `ZIO.foreach`/`accumulate*` over manual folds.
+
+```scala
+for {
+  raw   <- repo.getRaw(id)                 // IOResult[Raw]
+  value <- parse(raw).toIO                 // PureResult -> IOResult
+  _     <- repo.save(value)                // IOResult[Unit]
+} yield value
+```
+
+## Mutable state & concurrency
+
+Never use `var` / `synchronized` / mutable collections for shared state. Use ZIO's
+concurrency primitives:
+
+- **`Ref`** for in-memory state / caches — atomic `get`/`update`/`modify`:
+  ```scala
+  for {
+    cache <- Ref.make(Map.empty[NodeId, NodeConfigurationHash])
+    _     <- cache.update(_ + (id -> hash))
+    all   <- cache.get
+  } yield all
+  ```
+- **`Semaphore`** to bound concurrency / serialize a critical section:
+  `semaphore.withPermits(1) { effect }`.
+- A long-lived cache held in a field may initialise its `Ref` once at construction with
+  `Ref.make(...).runNow` — this is one of the few **sanctioned `.runNow`** uses
+  (creating the cell, not running business logic); see
+  [`302`](302-bridging-toio-runnow.md). Example:
+  `rudder-core/.../nodeconfig/NodeConfigurationCacheRepository.scala`.
+
+## Don't
+
+- Don't run the effect (`.runNow`) deep inside business logic — keep it as a value and
+  push the run to the edge (see [`302`](302-bridging-toio-runnow.md)).
+- Don't use `ZLayer`/`ZIO[R, …]` with a non-`Any` `R` for wiring services. (The only
+  non-`Any` `R` we accept is `Scope` for resources. One module — `rudder-rest/.../lift/
+  SettingsApi.scala` — threads a service through the env with `provideLayer`; treat it
+  as a **dispreferred legacy exception**, not a template. Pass collaborators by
+  constructor instead, see [`102`](102-traits-and-dependency-injection.md).)
+- Don't reach for extra ZIO modules — scope is `zio` core + `zio-json` only
+  (see [`700`](700-dependencies-ecosystem.md)).
+- Don't swallow errors with `.orDie`/`catchAll(_ => unit)` unless it is genuinely
+  unrecoverable and logged.

--- a/.claude/skills/rudder-scala/301-error-model.md
+++ b/.claude/skills/rudder-scala/301-error-model.md
@@ -1,0 +1,153 @@
+# 301 — Error model: `RudderError`
+
+All failures flow through one error channel: **`RudderError`**. This lets modules
+compose seamlessly (`IOResult`/`PureResult` both fail with `RudderError`). Each
+*module* still defines its own domain error subtype for meaningful semantics.
+
+> Foundational rationale: the talk **"Systematic error management in application"**
+> (DevoxxFR 2021, F. Armand). It is the design source for this topic; the key points are
+> summarized below.
+
+## Nominal cases, errors, defects
+
+Every interaction a piece of code models is one of three things. Classifying them
+correctly is the whole game — **you, the developer, decide which is which, and it
+depends on the (sub)system** (the same condition can be an error in one bounded context
+and a defect in another).
+
+- **Nominal case** — an *expected* outcome. Crucially this is **not only the happy
+  path**: "the game can be won *or* lost" are both nominal. Model the full set of
+  expected outcomes in the **success type**, as an enumeration/ADT — not as errors.
+  - e.g. `getUser` returning `Option[User]`: "no user for that id" is nominal, encoded
+    in the type, not signalled as an error.
+- **Error** — an *expected non-nominal* case (the environment or a rule failed in a way
+  you anticipated). Reflected in the **error channel** as a `RudderError`. It is a
+  **signal** for someone to act on (see "Errors are a signal" below).
+- **Defect** — an *out-of-model*, unexpected case: by definition the app is now in an
+  unknown state. **Not** reflected in types. The only sound response is to **stop as
+  cleanly as possible** — never to pretend it's an error and continue.
+
+Picking the boundary is "choosing your horizon": nothing beyond it is part of your
+model, and if it leaks in, the system is inconsistent. Example from Rudder: a JVM
+`SecurityException` is an **expected error** inside the JS engine
+(`execScript(js): IOResult[String]`, user-supplied scripts) — and a **defect**
+everywhere else, by our deliberate choice.
+
+### Handling defects: crash, don't catch
+
+- Don't wrap out-of-model `Throwable`s into the error channel to "keep going".
+  `IOResult.attempt` is for **recoverable** exceptions (DB/FS/network) → `SystemError`.
+  It is **not** for fatal `Error`s like `OutOfMemoryError`: those are defects that must
+  kill the app (a global `Thread.setDefaultUncaughtExceptionHandler` logs and cleans up
+  before exit).
+- For a ZIO defect that genuinely can't be handled, fail fast (`.orDie`) rather than
+  inventing a bogus nominal/error value.
+
+## The base trait (`utils/.../ZioCommons.scala`, `object errors`)
+
+```scala
+trait RudderError {
+  def msg: String                                   // what went wrong
+  def fullMsg: String = getClass.getSimpleName + ": " + msg
+}
+```
+
+## Built-in errors
+
+- `SystemError(msg, cause: Throwable)` — produced by `IOResult.attempt`; wraps a thrown
+  exception with a readable, trimmed stack (only `com.normation` frames).
+- `Unexpected(msg)` — "I wasn't expecting that value".
+- `Inconsistency(msg)` — a business-logic inconsistency. `Either[String, _].toIO`
+  becomes an `Inconsistency`.
+- `Chained(hint, cause)` — adds context while preserving the underlying error.
+- `Accumulated(NonEmptyList[E])` — many errors at once (e.g. validating a collection);
+  has `.deduplicate`.
+- `SecurityError` (trait) — a failure caused by a security concern; prints as
+  `SecurityError: …` (see [`600`](600-security-in-depth.md)).
+
+## One common super-trait — on purpose
+
+We use a **single** `RudderError` super-trait for the whole app rather than separate,
+unrelated error hierarchies per sub-system. This is a deliberate choice:
+
+- it lets the compiler **automatically categorize** results — no boilerplate
+  transformers to map between error types at every call;
+- shared tooling (`Chained`, `SystemError`, `notOptional`, `chainError`, `accumulate`)
+  works on *all* errors, written once;
+- in practice `Chained` is enough for trans-system cases, and the rare specific need is
+  a cheap ad-hoc combinator.
+
+So: **don't introduce a parallel error hierarchy with no common supertype.** Define
+domain subtypes *of* `RudderError`. (If Rudder were split into separately-compiled
+services, a shared error lib would be the equivalent.)
+
+## Define a domain error per module
+
+A bounded context defines its own subtype(s) so callers can pattern-match meaningfully:
+
+```scala
+sealed trait CampaignError extends RudderError
+object CampaignError {
+  final case class NotFound(id: CampaignId) extends CampaignError { def msg = s"Campaign '${id.value}' not found" }
+  final case class Invalid(msg: String)     extends CampaignError
+}
+```
+
+Keep it small and specific; don't invent a subtype for every line. Reuse
+`Inconsistency`/`Unexpected` for one-off generic cases.
+
+## Errors are a signal — give agency
+
+An error's only purpose is to be **acted on** by whoever has to deal with the problem
+(possibly you, at 3am). So a message must be **unambiguous and actionable**, and you
+should write it for a specific audience. An application always has **three kinds of
+users — don't forget any**:
+
+- **end users** — can influence *inputs*. Help them with precise parameter types and
+  messages that say what to give instead (overlaps with parse-don't-validate, `201`).
+- **ops** — concerned with the environment and system interactions. This is typically
+  what surfaces in the error channel (`SystemError`, connection/FS issues): give them
+  enough to fix the environment.
+- **developers** — make the model's hypotheses and limits. On a *defect*, dump enough
+  context (stack, state) to fix the model.
+
+When an error crosses a sub-system boundary, **translate it** so it stays relevant to
+its new audience — add context with `chainError` (each layer contributes a hint) rather
+than leaking a raw lower-level cause unexplained.
+
+## Adding context: `chainError`
+
+Wrap an error with a hint as it bubbles up, instead of constructing strings by hand:
+
+```scala
+repo.load(id).chainError(s"Error while loading rule '${id.value}'")   // on ZIO and on Either
+```
+
+This yields a `Chained` whose `fullMsg` reads `hint; cause was: <cause.fullMsg>`.
+
+## Accumulating errors
+
+When processing many items and you want *all* failures, not the first, use the
+accumulation helpers in `object errors`:
+
+```scala
+items.accumulate(parseOne)        // Iterable[A] => IOResult[List[B]], errors -> Accumulated
+results.accumulate                // Iterable[PureResult[A]] => PureResult[List[A]]
+```
+
+This is how "parse, don't validate" surfaces every problem at once
+(see [`201`](201-parse-dont-validate.md)).
+
+## Guidance
+
+- **Fail with a value, don't throw.** Throwing is only for the inside of
+  `IOResult.attempt`, which converts a *recoverable* exception to `SystemError`.
+- **Classify deliberately:** expected outcome → success type (enumeration); expected
+  failure → `RudderError`; out-of-model → defect, crash cleanly.
+- Give every error a **clear, actionable `msg`** aimed at whoever must react
+  (user / ops / dev). Operators read `fullMsg`.
+- Add context with `chainError` rather than rebuilding messages.
+- Don't over-model: a couple of domain subtypes per context is plenty.
+- **Keep good error handling on the path of least resistance.** If it isn't easy and
+  boilerplate-free, it won't be done consistently — that's why the combinators in
+  `object errors` exist; prefer them (and add small ones) over ad-hoc handling.

--- a/.claude/skills/rudder-scala/302-bridging-toio-runnow.md
+++ b/.claude/skills/rudder-scala/302-bridging-toio-runnow.md
@@ -1,0 +1,77 @@
+# 302 — Bridging legacy code: `.toIO`, `.toBox`, `.runNow`
+
+Rudder has **no single effect entry point**. Effects are run in many places,
+especially where ZIO code meets historical, non-effect-managed code (Lift web layer,
+Java callers). We bridge with thin wrappers and we **minimize `.runNow`**.
+
+All of these live in `com.normation.errors` / `com.normation.box` / `com.normation.zio`
+(`utils/.../ZioCommons.scala`).
+
+## Into the effect world — `.toIO` (preferred direction)
+
+Lift a non-ZIO result into `IOResult` so it composes with the rest:
+
+```scala
+pureResult.toIO            // PureResult[A]        => IOResult[A]
+either.toIO                // Either[String, A]    => IOResult[A]  (Left -> Inconsistency)
+option.notOptional("msg")  // Option[A]            => IOResult[A]  (None -> Inconsistency)
+box.toIO                   // lift.common.Box[A]   => IOResult[A]  (legacy Lift Box)
+chimneyResult.toIO         // chimney partial.Result[A] => IOResult[A]
+```
+
+Use `.toIO` to *stay* in `IOResult` as long as possible — that's how we keep effect
+management consistent.
+
+**Lift late, stay at the least powerful level.** `.toIO` is a one-way step *up* in
+power: a `PureResult` keeps its "no side effects" promise, an `IOResult` doesn't. So
+keep pure logic as `PureResult` (or plain values) and call `.toIO` only at the point you
+actually need to compose with an effect — don't widen a whole pipeline to `IOResult`
+just because one step at the end is effectful (see
+[`300`](300-effects-zio-ioresult.md#when-to-use-which--prefer-the-least-powerful)).
+
+When you lift across a **sub-system boundary**, add context with `chainError` so the
+error stays meaningful to its new audience instead of leaking a raw lower-level cause
+(each layer contributes a hint — see [`301`](301-error-model.md)):
+
+```scala
+parseConfig(raw).toIO.chainError(s"Error reading settings for node '${id.value}'")
+```
+
+## Out to legacy — `.toBox` (Lift) and Java interop
+
+When you must hand a result to legacy Lift code that expects a `Box`:
+
+```scala
+ioResult.toBox             // IOResult[A]   => Box[A]    (runs the effect!)
+pureResult.toBox           // PureResult[A] => Box[A]
+either.toBox               // Either[String, A] => Box[A]
+```
+
+`ioResult.toBox` *runs the effect* under the hood (`ZioRuntime.runNow`) and maps
+`RudderError` to a Lift `Failure` (preserving `Chained`/`SystemError` structure). Use
+it at the Lift boundary, not inside business logic.
+
+## Running effects — `.runNow` (minimize!)
+
+```scala
+ioResult.runNow                         // A           (throws fiber failure on error)
+ioResult.runNowLogError(logger)         // Unit        (logs RudderError, discards result)
+ioResult.runOrDie(err => new Exc(...))  // A           (throws your exception on error)
+```
+
+**Every `.runNow` breaks the global consistency of effect management.** Treat each one
+as a small debt:
+
+- It belongs at a **true boundary** — a Lift snippet/REST handler edge, a Java-called
+  shim, app bootstrap — never in the middle of a service.
+- When you find yourself wanting `.runNow` mid-logic, the fix is almost always to
+  return `IOResult` and let the caller compose; push the run further out.
+- Prefer `.toBox`/`.runNowLogError` at Lift edges over a bare `.runNow` so errors are
+  turned into something the UI/log can use rather than thrown.
+- When touching legacy code, **reduce** the number of `.runNow` if you reasonably can;
+  don't add new ones casually.
+
+## Resources
+
+For acquire/release use `IOManaged` / `ZIO.acquireRelease` (in `com.normation.box`),
+not manual try/finally.

--- a/.claude/skills/rudder-scala/303-logging.md
+++ b/.claude/skills/rudder-scala/303-logging.md
@@ -1,0 +1,52 @@
+# 303 — Logging
+
+Logging is an effect: in new code it stays inside `IOResult`/`UIO` rather than being a
+hidden side effect. We log through ZIO-aware loggers and are **migrating away from the
+Lift `extends Logger`** style.
+
+## Use a named pure logger derived from `NamedZioLogger`
+
+`com.normation.NamedZioLogger` (`utils/.../ZioCommons.scala`) is the effectful logger:
+its `trace/debug/info/warn/error` return `UIO[Unit]`, so log calls compose inside an
+`IOResult` for-comprehension and never throw into the app error channel.
+
+Create one **named** logger object per area, by convention suffixed `Pure`:
+
+```scala
+object ComplianceDebugLoggerPure extends NamedZioLogger {
+  def loggerName: String = "explain_compliance"
+}
+
+// usage, inside an effect:
+for {
+  _   <- ComplianceDebugLoggerPure.debug(s"Computing compliance for ${id.value}")
+  res <- compute(id)
+  _   <- ComplianceDebugLoggerPure.info(s"done: ${res.size} entries")
+} yield res
+```
+
+- `def loggerName` (use `def`/`lazy val`, **not** `val` — a `val` triggers
+  `UninitializedFieldError`).
+- `NamedZioLogger("some.name")` gives an ad-hoc instance when a dedicated object is
+  overkill.
+- Named loggers live together under `com.normation.rudder.domain.logger` (e.g.
+  `ApplicationLogger`, `PolicyGenerationLogger`); add new ones there.
+
+## Don't break the effect for logging
+
+- Log errors **without** propagating them to the app error channel — `NamedZioLogger`
+  already isolates logging failures (`logAndForgetResult`). Don't `catchAll` real
+  business errors just to log.
+- Need to log around a value you must keep? Use `ZIO.tap`/`tapError`:
+  ```scala
+  repo.load(id)
+    .tapError(err => LoggerPure.error(s"load failed: ${err.fullMsg}"))
+  ```
+
+## Legacy: Lift `extends Logger`
+
+Older code uses `object X extends net.liftweb.common.Logger` (eager, non-effectful).
+**Don't add new ones.** When you touch such code, prefer introducing a `*Pure`
+`NamedZioLogger` and routing new log calls through it. A legacy `Logger` and its `Pure`
+counterpart can coexist on the same logical name during migration (see
+`DebugComplianceLogger.scala`).

--- a/.claude/skills/rudder-scala/400-domain-case-classes.md
+++ b/.claude/skills/rudder-scala/400-domain-case-classes.md
@@ -1,0 +1,72 @@
+# 400 — Domain case classes
+
+Business objects are **plain, dumb `case class`es** — ideally with *no* methods. All
+logic (parsing, serialization, conversion, derived views) goes in the **companion
+object** or in `extension` methods (see [`001`](001-scala3-idioms.md)).
+
+## Shape
+
+```scala
+final case class Plugin(
+    id:            PluginId,
+    name:          String,
+    description:   String,
+    version:       Option[String],
+    status:        PluginInstallStatus,
+    pluginVersion: Version,
+    errors:        List[PluginError],
+    license:       Option[PluginLicense]
+)
+```
+(`rudder-core/.../plugins/PluginData.scala`)
+
+- `final case class` for domain entities/value objects.
+- Use precise field types, not primitives: `PluginId` not `String`, `Version` not
+  `String`, `Option[...]` for genuinely optional data.
+- Prefer `final case class` and immutability everywhere; no `var`.
+
+## Wrap identifiers and scalars
+
+Don't pass bare `String`/`Int` for domain concepts. Wrap them:
+
+```scala
+final case class Licensee(value: String)   extends AnyVal   // existing common form
+opaque type NodeName = String                               // modern newtype, zero overhead
+```
+
+This makes signatures self-documenting and prevents mixing up a `RuleId` with a
+`DirectiveId`. See [`001`](001-scala3-idioms.md) for value-class vs opaque-type choice.
+
+## ADTs for closed sets
+
+```scala
+sealed trait PluginInstallStatus
+object PluginInstallStatus {
+  case object Enabled     extends PluginInstallStatus
+  case object Disabled    extends PluginInstallStatus
+  case object Uninstalled extends PluginInstallStatus
+
+  // decision logic lives in the companion, not on the cases
+  def from(pluginType: PluginType, installed: Boolean, enabled: Boolean, reason: StatusDisabledReason): PluginInstallStatus = ...
+}
+```
+
+When you need name/value, lookup, or `values`, use **enumeratum** (the project
+standard — *not* the native Scala 3 `enum` keyword); see
+[`401`](401-json-zio-json.md#enums). Keep the cases dumb.
+
+## Where the logic goes
+
+| Concern | Where |
+|---|---|
+| Build/validate from raw input | `def parse` in companion ([`201`](201-parse-dont-validate.md)) |
+| JSON in/out | codecs in companion ([`401`](401-json-zio-json.md)) |
+| Map to another representation | chimney `Transformer` ([`402`](402-chimney-transformers.md)) |
+| Produce a modified copy | quicklens ([`403`](403-quicklens-updates.md)) |
+| Derived/display helpers | `def` in companion or `extension`, kept minimal |
+
+## Don't
+
+- Don't put I/O, repository calls, or effectful logic on the case class.
+- Don't add convenience methods that just re-expose fields.
+- Don't accept `String` where a parsed domain type belongs.

--- a/.claude/skills/rudder-scala/401-json-zio-json.md
+++ b/.claude/skills/rudder-scala/401-json-zio-json.md
@@ -1,0 +1,115 @@
+# 401 — JSON with zio-json
+
+zio-json is our **only** JSON library (see [`700`](700-dependencies-ecosystem.md)).
+lift-json is removed — don't reintroduce it (source of truth: ADR
+[`18879-main-json-library-zio-json`](../../../adr/webapp/18879-main-json-library-zio-json.md)).
+Define codecs so callers need **no implicit import** — put them in the type's companion
+(see [`001`](001-scala3-idioms.md)).
+
+## Derive when you can, write a codec when you must
+
+For a **plain case class** whose members all have codecs, prefer Scala 3 derivation:
+
+```scala
+final case class CampaignInfo(
+    id:          CampaignId,
+    name:        String,
+    status:      CampaignStatus,
+    schedule:    CampaignSchedule
+) derives JsonCodec
+```
+
+Derivation finds member codecs from implicit scope, so each member type must itself
+provide a codec in its companion — which is exactly the pattern below.
+
+In practice, **most types define their codec manually** rather than via `derives` —
+that's expected, not a smell. Wrapper/identifier types and anything parsed need
+`mapOrFail`/`transformOrFail` (see [`201`](201-parse-dont-validate.md)) and *cannot* be
+derived; types needing a discriminator, custom field names, or a specific wire format
+also use explicit codecs. So: reach for `derives JsonCodec` on simple aggregates, and
+write an explicit `implicit val`/`given` codec (in the companion) whenever the wire
+format isn't a trivial 1:1 of the fields.
+
+## Wrapper types: map a primitive codec
+
+For value/opaque wrappers, build on a primitive codec — don't hand-write a parser:
+
+```scala
+object PluginId {
+  implicit val decoder: JsonDecoder[PluginId] = JsonDecoder[String].mapOrFail(parse)        // parse: String => Either[String, PluginId]
+  implicit val encoder: JsonEncoder[PluginId] = JsonEncoder[String].contramap(_.value)
+}
+```
+
+When you have a `parse`/`serialize` pair, one line gives a round-trip codec:
+
+```scala
+implicit val codec: JsonCodec[CampaignId] = JsonCodec.string.transformOrFail(CampaignId.parse, _.serialize)
+```
+
+`mapOrFail`/`transformOrFail` keep us honest about **parse-don't-validate**
+([`201`](201-parse-dont-validate.md)): a bad payload becomes a decode error.
+
+## Sealed hierarchies: discriminators
+
+For ADTs serialized as tagged objects, use a discriminator field:
+
+```scala
+@jsonDiscriminator("value")
+sealed trait CampaignStatus { def value: CampaignStatusValue }
+```
+
+## Map keys & custom scalars
+
+Use `JsonFieldEncoder`/`JsonFieldDecoder` for map keys, and `.contramap`/`.mapOrFail`
+on string codecs for custom scalars (see the `AcceptationDateTime` codec in
+`rudder-core/.../policies/ActiveTechnique.scala`, which also shows encoding `Instant`).
+
+## Guidance
+
+- **Put codecs in the companion object** of the type so no import is needed at use site.
+- Prefer `derives JsonCodec`; drop to manual `mapOrFail`/`contramap` only for wrappers
+  and special formats.
+- `given`/`implicit val` both appear in the codebase; prefer `given`
+  (new code must use `given`).
+- Don't reach for circe/jackson/play-json — zio-json only.
+
+## Enums {#enums}
+
+We use **enumeratum** for enumerations (name/value, lookup-by-name, `values`) — we do
+**not** use the native Scala 3 `enum` keyword. The pattern is a `sealed` base extending
+`EnumEntry` + a companion extending `Enum[...]`, with each case giving its
+**`entryName`** explicitly (`rudder-core/.../campaigns/DataTypes.scala`):
+
+```scala
+import enumeratum.*
+
+sealed abstract class CampaignSortOrder(override val entryName: String) extends EnumEntry
+object CampaignSortOrder extends Enum[CampaignSortOrder] {
+  case object StartDate extends CampaignSortOrder("startDate")
+  case object EndDate   extends CampaignSortOrder("endDate")
+
+  // accept extra/legacy input spellings without changing the canonical entryName
+  override def extraNamesToValuesMap: Map[String, CampaignSortOrder] =
+    Map("start" -> StartDate, "end" -> EndDate)
+
+  override def values: IndexedSeq[CampaignSortOrder] = findValues
+}
+```
+
+**Always set `entryName` explicitly** (the `(override val entryName: String)` arg).
+`entryName` is the *serialized* token, so pinning it decouples the wire/persisted form
+from the Scala identifier: you can rename `case object StartDate`, move it, or refactor
+the type freely without changing what users and stored files see. Relying on the default
+(derived from the object name) would silently break that contract on any rename — see
+[`404`](404-serialization-contracts.md). Use `extraNamesToValuesMap` to keep accepting
+older input spellings.
+
+For JSON, derive the codec from the enumeratum integration rather than hand-writing it:
+
+```scala
+import zio.json.enumeratum.*
+implicit val codec: JsonCodec[CampaignStatusValue] = ... // via zio-json enumeratum support
+```
+
+For sealed hierarchies serialized as tagged objects, use `@jsonDiscriminator` (above).

--- a/.claude/skills/rudder-scala/402-chimney-transformers.md
+++ b/.claude/skills/rudder-scala/402-chimney-transformers.md
@@ -1,0 +1,56 @@
+# 402 — Mapping with chimney
+
+When converting between two representations of the same data (domain ⇆ API DTO,
+domain ⇆ storage, wrapper ⇆ underlying), use **chimney** instead of hand-written
+field-by-field copying. Less boilerplate, and the compiler checks completeness.
+
+The main use is mapping a business object to/from a **DTO** so the serialized contract
+can evolve independently of the domain model — see [`404`](404-serialization-contracts.md).
+
+## Inline transformation
+
+```scala
+import io.scalaland.chimney.dsl.*
+
+val dto: PluginDto = plugin.into[PluginDto]
+  .withFieldComputed(_.statusLabel, _.status.toString)
+  .transform
+```
+
+Use `transformInto[T]` for the trivial 1:1 case, `.into[T]....transform` when a few
+fields need help (`withFieldConst`, `withFieldComputed`, `withFieldRenamed`).
+
+## Reusable `Transformer` instances
+
+Define a `Transformer` in the companion so it's found without imports and reused
+(including by nested derivations and by [zio-json](401-json-zio-json.md) where useful):
+
+```scala
+object PluginId {
+  implicit val transformer: Transformer[PluginId, String] = Transformer.derive[PluginId, String]
+}
+object MaxNodes {
+  implicit val transformer: Transformer[MaxNodes, Option[Int]] = _.value
+}
+```
+(`rudder-core/.../plugins/PluginData.scala`)
+
+## Fallible transformations
+
+When a mapping can fail, use chimney's partial transformers and bridge the result into
+our effect types with the helper from `com.normation.errors`:
+
+```scala
+result.toIO            // chimney partial.Result[A] => IOResult[A]
+result.toPureResult    // => PureResult[A]
+```
+(see [`302`](302-bridging-toio-runnow.md)). This keeps failures on the `RudderError`
+channel ([`301`](301-error-model.md)).
+
+## Guidance
+
+- Reach for chimney whenever you'd otherwise write repetitive `X(a = src.a, b = src.b, …)`.
+- Put shared `Transformer`s in companions; keep one-off mappings inline at the call site.
+- Don't smuggle business logic into transformers — they map shapes, not enforce rules.
+  Validation belongs in `parse` ([`201`](201-parse-dont-validate.md)).
+- chimney is an approved dependency; don't add a second mapping library.

--- a/.claude/skills/rudder-scala/403-quicklens-updates.md
+++ b/.claude/skills/rudder-scala/403-quicklens-updates.md
@@ -1,0 +1,46 @@
+# 403 — Updating immutable data with quicklens
+
+To produce a modified copy of a case class — especially a **nested** one — use
+softwaremill **quicklens**, not `.copy`.
+
+```scala
+import com.softwaremill.quicklens.*
+
+val updated = obj.modify(_.field).setTo(newValue)
+
+// nested, no copy-of-copy-of-copy:
+val updated = rule.modify(_.info.status.value).setTo(Enabled)
+
+// multiple fields, chain:
+val updated = plugin
+  .modify(_.name).setTo(newName)
+  .modify(_.status).setTo(Disabled)
+```
+
+## Why
+
+- Reads far better than nested `.copy`, especially for deep updates
+  (`a.copy(b = a.b.copy(c = a.b.c.copy(...)))` → one `.modify` chain).
+- It's already a dependency (declared in `webapp/sources/pom.xml`, compile dep of
+  rudder-core). Existing example:
+  `rudder-core/.../facts/nodes/NodeFactStorage.scala`.
+
+## Handy combinators
+
+```scala
+xs.modify(_.each.field).setTo(v)                 // every element of a collection
+opt.modify(_.each.field).using(f)                // Option / collection, transform
+m.modify(_.at("key").field).setTo(v)             // Map value at key
+obj.modify(_.field).using(old => f(old))         // compute from old value
+```
+
+## Guidance
+
+- **Default to quicklens** for updates to new/changed code.
+- `.copy` is acceptable only for trivial single-field, single-level updates in code
+  already written that way — but prefer `.modify(_.x).setTo(v)` even there for
+  consistency.
+- For *building* a different type from this one, that's a mapping job → use
+  [chimney](402-chimney-transformers.md), not quicklens.
+
+(This is a standing team preference — see the `prefer-quicklens-over-copy` memory.)

--- a/.claude/skills/rudder-scala/404-serialization-contracts.md
+++ b/.claude/skills/rudder-scala/404-serialization-contracts.md
@@ -1,0 +1,65 @@
+# 404 — Serialization contracts & DTOs
+
+Anything we serialize **for someone outside the code** — REST API responses/requests,
+persisted files, DB JSON, anything a user's scripts, monitoring, or another system reads
+— is a **contract**. The internal business model is not.
+
+These two have opposite lifecycles, and keeping them separate is the point:
+
+| | Business model | Serialized contract |
+|---|---|---|
+| Who depends on it | our code | users, ops, other systems, stored data |
+| Change policy | **change freely & often** to model the domain accurately/efficiently | **never change unintentionally**; backward-compatible, bridged if needed |
+| Lifecycle | fast, dev-driven | slow, spans several minor versions |
+
+This is the macro "pure core / stable adapter" boundary (see
+[`101`](101-architecture-ddd-hexagonal.md) and the DevoxxFR error-management talk
+referenced in [`SKILL.md`](SKILL.md)): the core sub-system iterates rapidly; the API
+sub-system keeps promises. The bigger the promise, the stricter the contract.
+
+## Keep it simple first, split when it pays (the rule)
+
+Don't build a translation layer before you need it. The progression:
+
+1. **No DTO at first.** If the serialized shape happens to match the business object
+   exactly, serialize the business object directly (codec in its companion,
+   [`401`](401-json-zio-json.md)). Don't add a parallel type "just in case".
+2. **But pin the output in tests immediately.** Even with no DTO, the user-facing
+   serialization is a contract: assert the exact JSON in REST API tests (and
+   file/persistence tests) with the JSON matcher (`beEqualToJson`, see
+   [`900`](900-testing.md)). These tests are the **guardrail** that makes an accidental
+   format change fail loudly.
+3. **Introduce a DTO when the business model needs to evolve** (which happens often).
+   Add a dedicated serialization type — `XxxDto`/`JsonXxx`/`RestXxx` — and map
+   **to/from** the business object with **chimney** ([`402`](402-chimney-transformers.md)).
+   The business object is now free to change; the DTO absorbs it.
+4. **Then evolve the contract on its own path.** Changes to the DTO are deliberate and
+   backward-compatible: add optional fields, keep old ones, bridge/migrate, version at
+   the REST layer (`StartsAtVersion*`, see [`103`](103-rest-api-and-endpoints.md)).
+   A breaking change is a versioned, intentional act — never a side effect of a core
+   refactor.
+
+So the trigger to add a DTO is **"the business model wants to move but the wire form
+must not"** — not dogma. Until then, the directly-serialized object plus its locked-down
+test is the simpler, preferred design.
+
+## Stable serialized tokens
+
+Within either form, individual serialized tokens are part of the contract too — choose
+them explicitly so refactors can't shift them:
+
+- **Enum `entryName`** — set it explicitly so renaming a `case object` doesn't change
+  the wire value (see [`401`](401-json-zio-json.md#enums)).
+- **Field names / discriminators** — when the JSON field must differ from the Scala
+  name, pin it (custom codec / `@jsonDiscriminator`), don't let it ride on the
+  identifier.
+- Accept old input spellings (e.g. enumeratum `extraNamesToValuesMap`) when you need to
+  broaden inputs without breaking the canonical output.
+
+## Checklist
+
+- Is this data read by anyone outside our code (API, file, DB JSON)? → it's a contract.
+- Is its exact serialized form asserted in a test? → if not, add it.
+- Am I about to change a business object that is serialized directly? → if the wire form
+  must stay, introduce a DTO + chimney mapping first, then change the core.
+- Am I changing a DTO/contract on purpose? → is it backward-compatible / versioned?

--- a/.claude/skills/rudder-scala/500-datetime-java-time.md
+++ b/.claude/skills/rudder-scala/500-datetime-java-time.md
@@ -1,0 +1,82 @@
+# 500 — Date & time: `java.time`
+
+We are **migrating off Joda-Time** (`org.joda.time`), which is no longer maintained.
+New and changed code uses the **`java.time`** standard library and its Scala-friendly
+wrapper.
+
+> Source of truth: ADR [`28515-use-java-time`](../../../adr/webapp/28515-use-java-time.md)
+> and ADR [`27084-date-format-timezone`](../../../adr/webapp/27084-date-format-timezone.md).
+> Read them when in doubt.
+
+## Choosing the type (per ADR 28515)
+
+- **Default to `Instant`** — a UTC timestamp, naturally offset-free. Use it for "a
+  moment in time" almost everywhere (it dominates the codebase). It's also what our
+  storage bindings expect.
+- **`LocalDateTime`** only when you must compute in **days/months or larger** (calendar
+  math, DST awareness) — `Instant` has no calendar concept.
+- **Avoid `ZonedDateTime`/`OffsetDateTime`.** When a timezone genuinely matters, keep it
+  as a **separate field/context** alongside an `Instant`, rather than carrying a zoned
+  type around. (`ZonedDateTime` survives in some places like `PluginLicense`, but it's
+  not the pattern to reach for.)
+- Zones/offsets → `java.time.ZoneId` / `ZoneOffset` when needed.
+
+## Don't introduce Joda
+
+- **Don't** add new `org.joda.time.*` usages.
+- When you touch code that uses Joda, prefer migrating the touched part to `java.time`
+  if it's safe and contained.
+
+## Conversion / formatting helpers
+
+`com.normation.utils.DateFormaterService` (`utils/.../DateFormaterService.scala`) is the
+central place for date handling and the Joda⇄java.time bridge used during migration:
+
+```scala
+import com.normation.utils.DateFormaterService.*
+
+// joda -> java.time (transitional)
+jodaDateTime.toJavaInstant
+jodaDateTime.toZonedDateTime
+jodaDateTime.toOffsetDateTime
+// java.time -> joda (only where legacy APIs still require it)
+instant.toJodaDateTime
+offsetDateTime.toJodaDateTime
+// display
+DateFormaterService.getDisplayDate(zonedDateTime)
+```
+
+Use these extensions instead of re-deriving conversions inline.
+
+## ZIO clock
+
+For "now" inside an effect, get it from the ZIO clock rather than calling
+`Instant.now()` directly, so time stays testable/effectful:
+
+```scala
+import com.normation.zio.currentOffsetDateTimeUTC   // UIO[OffsetDateTime]
+```
+
+(see `com.normation.zio` in `ZioCommons.scala`).
+
+## Serialization & display: explicit timezone, UTC (per ADR 27084)
+
+Every serialized date carries an **explicit timezone**, and the format is
+**RFC 3339-compatible**:
+
+- **REST API** — parse strictly RFC 3339 on input; output in **UTC with the `Z`
+  offset**. Use the ISO formatters via `DateFormaterService` (built on
+  `DateTimeFormatter.ISO_INSTANT` / `ISO_OFFSET_DATE_TIME`), e.g.
+  `DateFormaterService.serializeZDT(...)` / the `Instant` serializers — don't hand-roll
+  a format string and never emit a date without an offset.
+- **Storage** — PostgreSQL uses `timestamp with timezone` via doobie
+  (`import doobie.postgres.implicits.*`, which binds `Instant`); LDAP uses the
+  dedicated `GeneralizedTime` (`scala-ldap`).
+- **Web pages** — display with a shared timezone (user preference, else server TZ);
+  objects with an explicit TZ (e.g. campaigns) may render in their own.
+
+## JSON
+
+Custom `Instant`/date codecs live with the types that use them (e.g. the `Instant`
+codec inside the `AcceptationDateTime` `JsonCodec`) — see [`401`](401-json-zio-json.md).
+Encode to the RFC 3339 / UTC form above.

--- a/.claude/skills/rudder-scala/600-security-in-depth.md
+++ b/.claude/skills/rudder-scala/600-security-in-depth.md
@@ -1,0 +1,110 @@
+# 600 — Security in depth
+
+Security is a **design constraint integrated from the start** — in the API/arch design,
+the implementation, and the system integration — not a layer bolted on at the end. When
+designing or changing anything, ask where the trust boundary is and what enforces it.
+
+## Principles
+
+- **Defense in depth.** Don't rely on a single check. Enforce authorization/scoping at
+  each layer that can: API, service, repository, storage query. A bug in one layer
+  should not silently grant access.
+- **Parse at the boundary.** Untrusted input becomes typed domain objects immediately
+  (see [`201`](201-parse-dont-validate.md)); the domain never handles raw,
+  unvalidated input. This is itself a security control.
+- **Least privilege / explicit scope.** Operations that must be restricted carry their
+  security context in the signature rather than reading ambient/global state — e.g.
+  repository methods take `(implicit qc: QueryContext)` so the caller's scope is
+  always present and enforced at query time
+  (see `PropertiesRepository`, [`200`](200-persistence-repositories.md)). Splitting
+  read/write repositories (`Ro*`/`Wo*`) lets you grant only the access a caller needs
+  (see [`200`](200-persistence-repositories.md)).
+- **Authorization is declared on every API endpoint** (`authz: List[AuthorizationType]`),
+  enforced by the framework, not re-checked by hand in handlers (see
+  [`103`](103-rest-api-and-endpoints.md)).
+
+## Tenants / multi-tenancy
+
+Some domain objects carry a `SecurityTag` (tenants) and there's a `HasSecurityTag`
+type class to read/update it (see `HasSecurityTag[ActiveTechnique]` in
+`rudder-core/.../policies/ActiveTechnique.scala`). When adding tenant-scoped data:
+
+- model the scope on the object (`security: Option[SecurityTag]`),
+- filter by scope in the repository/persistence layer (the right place to enforce —
+  e.g. tenant-filtering proxy repositories), not only in the UI.
+
+## Lift snippets: get `QueryContext` safely (ADR 28452)
+
+A Lift snippet that needs the authenticated user / their tenants must obtain its
+`QueryContext` from a **guaranteed-present** source — **not** by reading the global
+`CurrentUser#queryContext`, which can spuriously return no user under ZIO and is a
+security/auditability hole.
+
+Extend **`SecureDispatchSnippet`**: it injects the `QueryContext` as a context function
+and renders nothing (logging a warning) when no authenticated context exists — failing
+closed.
+
+```scala
+trait SecureDispatchSnippet extends DispatchSnippet {
+  def secureDispatch: QueryContext ?=> DispatchIt   // QueryContext guaranteed
+  override def dispatch: DispatchIt =
+    CurrentUser.queryContext.withQCOr(loggedInsecureDispatch)(secureDispatch)
+}
+```
+
+Migrate snippets that need a `QueryContext` to this trait; don't reach for
+`CurrentUser#queryContext` elsewhere.
+
+## Path traversal: always enforce a root scope
+
+Path traversal (a.k.a. directory traversal / "zip slip") is **ubiquitous and almost
+always catastrophic** — a `../../etc/...` or an absolute path lets an attacker read or
+overwrite files anywhere. Treat it as a default hazard: **any time you build a file path
+from input that isn't fully under your control** (user input, API params, names from an
+archive, git, LDAP, config…), pin a **root directory** and verify the resolved path
+**cannot escape** it.
+
+Don't hand-roll the check — use the helpers:
+
+- `com.normation.utils.FileUtils.sanitizePath(baseFolder, subpath)` /
+  `sanitizePath(baseFolder, path: List[String])` → `IOResult[File]`, fails if the
+  resolved path escapes `baseFolder`. Use it whenever you turn an untrusted name into a
+  file under a known root.
+- `com.normation.rudder.git.ZipUtils.checkForZipSlip(entry)` → `IOResult[Unit]`, call it
+  for **every** entry before extracting an archive.
+
+Rules:
+
+- Resolve and validate **before** opening/creating the file, and fail closed
+  (`SecurityError`/error channel) on any escape — never "best-effort clean and continue".
+- A bare `String`/`File` path from outside is untrusted input: parse it through a
+  sanitizer at the boundary (this is parse-don't-validate for paths, see
+  [`201`](201-parse-dont-validate.md)).
+- Reject absolute paths and symlink escapes too, not just `..` — the helpers handle the
+  resolution for you, so go through them.
+
+## Security errors
+
+Failures caused by a security concern use the `SecurityError` marker (see
+[`301`](301-error-model.md)); they render as `SecurityError: …`. Use it so security
+denials are distinguishable from ordinary inconsistencies — and **fail closed**: on
+doubt, deny rather than allow.
+
+## More security topics
+
+- **Web & output safety** — XML parsing (`XmlSafe`/XXE), Lift `JsRaw`/XSS, CSRF, CSP,
+  sessions: [`601`](601-web-and-output-security.md).
+- **Authentication & authorization** — Spring auth vs Rudder authz, password/token
+  crypto, RBAC/ACL `AuthorizationType`: [`602`](602-authentication-and-authorization.md).
+
+## Checklist when changing security-relevant code
+
+- Is untrusted input parsed into typed values before use (incl. XML via `XmlSafe`, paths
+  via `sanitizePath`, see [`601`](601-web-and-output-security.md))?
+- Is authorization checked at *every* layer that can enforce it, not just the UI
+  (endpoint `authz`, `checkRights`, see [`602`](602-authentication-and-authorization.md))?
+- Does data access carry and respect the caller's scope (`QueryContext`/tenants)?
+- Is untrusted data escaped on output (no unjustified `JsRaw`)?
+- Do denials fail closed and surface as `SecurityError`?
+- Did you avoid logging secrets (passwords, hashes, tokens) / leaking internal detail in
+  error `msg`s shown to users?

--- a/.claude/skills/rudder-scala/601-web-and-output-security.md
+++ b/.claude/skills/rudder-scala/601-web-and-output-security.md
@@ -1,0 +1,72 @@
+# 601 — Web & output security (XML, XSS, CSRF, CSP)
+
+Rules for handling untrusted input/output safely. The recurring theme: data from nodes
+(inventories, reports), from users, and from URLs is **untrusted** and has historically
+been the source of real vulnerabilities — parse it safely, escape it on output.
+
+## Parse XML only with `XmlSafe`
+
+**Never** parse XML with the default `scala.xml.XML` loader (or a raw
+`SAXParser`/`DocumentBuilder`). Use **`com.normation.utils.XmlSafe`**
+(`utils/.../XmlSafe.scala`), which builds a SAX parser hardened against **XXE / external
+entity** attacks (`FEATURE_SECURE_PROCESSING`, `disallow-doctype-decl`, no XInclude).
+
+```scala
+import com.normation.utils.XmlSafe
+
+val elem = XmlSafe.load(inputStream)   // also loadFile(file), loadString(s), load(source)
+```
+
+- `XmlSafe` is a drop-in `scala.xml.factory.XMLLoader[Elem]`, so it has the same
+  `load*` methods as `scala.xml.XML` — just swap the object.
+- This matters most for anything coming from outside: inventories, reports, technique
+  files, API payloads, configuration-repository files. When in doubt, it's untrusted.
+- It is already used across the XML parsing code (techniques, doobie XML columns, git
+  archives) — match that.
+
+## Don't emit raw JavaScript; if you must, justify and escape it
+
+We avoid generating JavaScript from the Lift backend, preferring safe, escaped
+abstractions. Raw JS through Lift's **`JsRaw`** is a **DOM-XSS hazard** whenever the
+string embeds untrusted data (this has caused real CVEs, e.g. GHSA-fc5g-p464-qpp9).
+
+Every `JsRaw` call has been audited and annotated; keep that discipline. When `JsRaw` is
+unavoidable, you **must justify why it is safe** with an inline comment, and escape any
+interpolated value:
+
+```scala
+val ruleId = StringEscapeUtils.escapeEcmaScript(rule.id.serialize)
+JsRaw(s"""sessionStorage.removeItem('tags-${ruleId}');""") // JsRaw ok, ruleId escaped
+```
+
+The accepted justifications (state which one applies):
+
+- `// JsRaw ok, const` — the string is a compile-time constant with no interpolation;
+- `// JsRaw ok, escaped` — every interpolated value is escaped (`escapeEcmaScript`, etc.);
+- the value provably comes from a known-safe source (and say which).
+
+If you can't write one of those truthfully, don't use `JsRaw`. Prefer Lift's typed
+`JsCmd`/`JE` builders or render through Elm. Lift pages are being replaced page by page,
+so don't add new `JsRaw`.
+
+## Escape untrusted data before it hits the DOM
+
+Beyond `JsRaw`, any untrusted value rendered into HTML/attributes must be escaped
+(server side, or in Elm via an `htmlEscape` helper). Vanilla JS that reads HTML
+attributes (e.g. bootstrap tooltips with `data-html="true"`) bypasses Elm's built-in
+escaping, so the value must be escaped *before* it is put in the attribute.
+
+## CSRF, CSP, sessions (be aware, don't regress)
+
+- **CSRF.** Internal API calls (`/rudder/secure/api/...`) require the custom header
+  `X-Requested-With: XMLHttpRequest` (built into jQuery and our Elm HTTP clients) — keep
+  sending it. Lift forms carry their own CSRF tokens; the session cookie is
+  `SameSite=Lax`. Don't disable these mitigations.
+- **CSP.** Content-Security-Policy is mandatory, strict (nonce-based).
+  Don't introduce inline scripts/styles that force loosening it; on new pages,
+  work within the nonce-based strict policy.
+- **Sessions.** Session cookies are `Secure; HttpOnly; SameSite=Lax` — don't weaken
+  these flags.
+
+See [`600`](600-security-in-depth.md) for the security-in-depth principles and
+[`602`](602-authentication-and-authorization.md) for auth.

--- a/.claude/skills/rudder-scala/602-authentication-and-authorization.md
+++ b/.claude/skills/rudder-scala/602-authentication-and-authorization.md
@@ -1,0 +1,106 @@
+# 602 — Authentication & authorization
+
+Two clearly separated concerns, with one firm split:
+
+- **Authentication** (who are you?) is structured **entirely around Spring Security**.
+- **Authorization** (what may you do?) is **entirely Rudder's own** — Spring Security's
+  authorization features are *not* used.
+
+Keep that boundary when you touch either side.
+
+## Authentication — go through Spring Security
+
+We do **not** write HTTP authentication logic, session-consistency checks, or protocol
+handling (LDAP, OIDC, OAuth2) ourselves — we delegate to **Spring Security** and only
+plug into its configuration points (it's popular, audited, and maintained). When you
+need to change authentication, extend the Spring configuration/filters, don't reinvent
+them.
+
+- Providers are tried by `RudderProviderManager` in the order of the
+  `rudder.auth.provider` property (the in-memory `rootAdmin` fallback is always tried
+  first). External backends (LDAP/OIDC/OAuth2) are registered by the **auth-backends**
+  plugin.
+- The authenticated user is mapped to a Rudder `RudderUserDetail` (status, roles, API
+  authz, tenant/`NodeSecurityContext`). In Lift, the request-scoped `CurrentUser` holds
+  it — get it safely via `SecureDispatchSnippet` (see [`600`](600-security-in-depth.md),
+  ADR 28452), never from a global.
+- After authentication, `UserSessionInvalidationFilter` checks an in-memory cache of
+  each user's status on every request: a disabled/removed user, or a
+  permission change, invalidates the session. Preserve that behaviour when touching user
+  state.
+
+### Cryptography: BouncyCastle, and the right hash for the job
+
+- Use **BouncyCastle for all cryptographic needs** — do **not** use Spring Security's
+  crypto implementations. Passwords go through Rudder's custom `PasswordEncoder`.
+- **Passwords** are hashed with **bcrypt** (default, cost `rudder.bcrypt.cost` = 12,
+  via BouncyCastle `OpenBSDBCrypt`). md5/sha1/sha256/sha512 are deprecated (unsalted),
+  kept only for migration — don't use them for new password storage.
+- **API tokens** are 32 random alphanumeric chars from `SecureRandom` (~190 bits),
+  stored as a **SHA-512** hash prefixed `v2:`. A fast unsalted hash is correct *here*
+  precisely because the secret is high-entropy random — unlike a password. Don't confuse
+  the two cases: bcrypt for human-chosen secrets, fast hash for high-entropy random ones.
+- Token value is shown to the user **once**, at creation, then only its hash is stored.
+
+### Public vs internal API authentication
+
+- **Public API** under `/api` — stateless, authenticated by token in the `X-API-Token`
+  header (`RestAuthenticationFilter`). Only `/api/status` (healthcheck) is unauthenticated.
+- **Internal API** under `/secure/api` — authenticated by the *user session* (cookies)
+  plus the CSRF header `X-Requested-With: XMLHttpRequest` (see [`601`](601-web-and-output-security.md)).
+
+## Authorization — Rudder's RBAC + ACL
+
+The atom is a **unitary right**: an object kind (`authzKind`) plus an `action`
+(`read` / `edit` / `write`). It is modelled as `AuthorizationType`
+(`rudder-core/.../Authorizations.scala`), an **enumeratum** enum
+(see [`401`](401-json-zio-json.md#enums)):
+
+```scala
+sealed trait Administration extends EnumEntry with AuthorizationType { def authzKind = "administration" }
+object Administration extends Enum[Administration] {
+  case object Read  extends Administration with ActionType.Read  with AuthorizationType
+  case object Edit  extends Administration with ActionType.Edit  with AuthorizationType
+  case object Write extends Administration with ActionType.Write with AuthorizationType
+  val values: IndexedSeq[Administration] = findValues
+}
+// id = s"${authzKind}_${action}", e.g. "administration_write"
+```
+
+The **same** `AuthorizationType` drives both:
+
+- **Users → RBAC.** Roles are named sets of rights (built-in roles, or custom roles in
+  the `rudder-users.xml` file). Rights/roles are declared in the users file.
+- **API accounts → ACL.** Per-endpoint access lists. User tokens get the user's rights;
+  standard API accounts get configurable ACLs (fine-grained ACLs need the
+  **api-authorizations** plugin; otherwise just RO/RW).
+
+A plugin may define its own authorization kinds (e.g. `cve_read`,
+`system_update_write`) and gate its endpoints on them.
+
+### Enforcing it
+
+- **API/endpoint level:** every `EndpointSchema` declares the authz it requires; the
+  framework checks it after Spring authentication — you don't re-check by hand (see
+  [`103`](103-rest-api-and-endpoints.md)).
+- **Object/feature level in Scala:** check with `CurrentUser.checkRights(...)` (the path
+  used in Lift snippets).
+- **In HTML templates:** `lift:authz` / `lift:Authz.whenhasrights`; pages may expose a
+  marker like `var hasWriteRights` to the frontend.
+- **Fail closed** and surface denials as `SecurityError` (see [`600`](600-security-in-depth.md),
+  [`301`](301-error-model.md)).
+
+### Tenants (RBAC zones)
+
+Tenant scoping (a tenant = a zone of nodes, via the multi-tenants plugin) is layered on
+top — model the scope on the object and enforce it in the repository, carrying the
+caller's `QueryContext`/`NodeSecurityContext`. See the tenants section in
+[`600`](600-security-in-depth.md).
+
+## Don't leak secrets in logs
+
+A real incident came from logging a `RudderUserDetail` whose case-class `toString`
+printed the hashed password. **Never** log objects that may contain passwords, password
+hashes, or API tokens. Use dedicated types / redacted renderings for anything carrying a
+secret, and keep secrets out of error messages (see [`303`](303-logging.md),
+[`301`](301-error-model.md)).

--- a/.claude/skills/rudder-scala/700-dependencies-ecosystem.md
+++ b/.claude/skills/rudder-scala/700-dependencies-ecosystem.md
@@ -1,0 +1,56 @@
+# 700 — Dependencies & ecosystem
+
+We are **strict** about dependencies. Adding one is a deliberate decision, not a
+reflex.
+
+## License policy (hard rule)
+
+- Dependencies **must** be under an **Apache-2.0 / BSD-compatible** license (MIT,
+  Apache-2.0, BSD-2/3-Clause…).
+- Anything else (GPL/LGPL/MPL/CDDL/EPL, "source-available", custom licenses…) must be
+  **carefully validated before use** — do not add it on your own initiative; flag it.
+- License compliance is enforced in CI (see `deny.toml`, `LICENSES/`,
+  `dependency-check-suppression.xml`). A new dep that trips these will fail the build.
+
+## Minimize dependencies
+
+- The default posture is to **remove** dependencies, not add them. We actively prefer
+  shrinking the dependency surface.
+- Before adding a library, check whether an already-present one does the job:
+  - effects/concurrency → **zio** (core)
+  - JSON → **zio-json**
+  - object mapping → **chimney**
+  - immutable updates → **quicklens**
+  - enumerations → **enumeratum** (see [`401`](401-json-zio-json.md#enums))
+  - SQL / PostgreSQL access → **doobie** (in the persistence layer, see
+    [`200`](200-persistence-repositories.md))
+  - generic type-level / category-theory abstractions ZIO doesn't cover (functors,
+    `traverse`, `Semigroup`, `NonEmptyList`, `Ior`…) → **cats** (used sparingly, for
+    these data types and syntax — *not* as a second effect system)
+  - dates → **java.time** (+ `DateFormaterService`)
+- Adding a new dependency *is* allowed when there's a genuine need and no reasonable
+  in-tree option — but justify it (need, license, maintenance health, size) and prefer
+  small, well-maintained, permissively-licensed libs.
+
+## ZIO ecosystem scope (important)
+
+The ZIO *ecosystem* is fragile and shrinking, so among **`zio-*` modules** we restrict
+ourselves to:
+
+- **`zio`** — the core framework (effects), and
+- **`zio-json`** — serialization.
+
+**Do not** introduce other `zio-*` modules (zio-http, zio-config, zio-streams as a
+public dependency, zio-prelude, zio-cli, …) without explicit team approval. If you need
+something they offer, prefer composing it from zio core, from cats, or from a tiny
+dedicated lib.
+
+This restriction is about the ZIO *ecosystem* specifically. It does **not** forbid the
+other sanctioned libraries above (cats, doobie, chimney, quicklens, enumeratum), which
+are established, permissively-licensed dependencies.
+
+## When proposing a dependency change
+
+State: what it's for, its license, whether an existing dep already covers it, and what
+(if anything) it lets us **remove**. Net-negative dependency changes are the most
+welcome kind.

--- a/.claude/skills/rudder-scala/800-build-and-formatting.md
+++ b/.claude/skills/rudder-scala/800-build-and-formatting.md
@@ -1,0 +1,72 @@
+# 800 — Build, tooling & formatting
+
+The Scala lives in `webapp/sources` (Maven multi-module, Scala 3, Java 25). This file
+captures the gotchas that bite when building/formatting here.
+
+## Building (this devcontainer/sandbox)
+
+- **Maven isn't on PATH.** Install once with `mise install maven`, then run from
+  `webapp/sources` as `mise exec maven -- mvn ...`.
+- **Skip the frontend** (no node/npm here): add `-Dexec.skip=true` so the
+  `build-frontend` exec step doesn't fail.
+- **Offline (`-o`) is reliable once deps are cached.** If offline resolution breaks on
+  stale metadata, delete `~/.m2/repository/**/_remote.repositories` and
+  `*.jar.lastUpdated`, then run **online once** (omit `-o`) to fetch, and go offline.
+- **Targeted test run:**
+  ```
+  mvn -o -pl rudder/rudder-core -am test -Dtest=SomeSpec \
+      -Dsurefire.failIfNoSpecifiedTests=false -Dexec.skip=true
+  ```
+- Building the reactor: prefer
+  `-pl rudder/rudder-core,rudder/rudder-rest,rudder/rudder-web -am`
+  (the root pulls in `rudder-templates-cli`, which needs `scopt_3`, often uncached).
+
+(See the `build-env-maven` memory for the full detail.)
+
+## Formatting & lint — must pass
+
+- **Spotless** (wrapping **scalafmt**) is bound before compile and is enforced. Fix
+  formatting with:
+  ```
+  mvn -o -pl <module> spotless:apply
+  ```
+- **`-Werror` is on.** Warnings fail the build. In particular **unused imports are
+  fatal** — keep imports tight (which also aligns with our "minimize imports" style,
+  see [`001`](001-scala3-idioms.md)).
+
+## License header on every file
+
+Every new `.scala` file starts with a copyright header. **The header must match the
+repository's root `LICENSE` file and be consistent within that repo.**
+
+- For all `rudder` projects the rule is the **GPLv3 "with the Additional permissions"
+  (Related Module) exception** — the long block beginning:
+  ```
+  /*
+   *************************************************************************************
+   * Copyright <YEAR> Normation SAS
+   *************************************************************************************
+   *
+   * This file is part of Rudder.
+   *
+   * Rudder is free software: you can redistribute it and/or modify
+   * it under the terms of the GNU General Public License ... version 3 ...
+   *
+   * In accordance with the terms of section 7 ... the following Additional
+   * permissions: ... "Related Module" ...
+   ...
+   */
+  ```
+  Copy it verbatim from a neighbouring file and set the current year.
+- Some **dependency-style modules can be ASL2** (Apache-2.0) instead — e.g. `utils`
+  (see `ZioCommons.scala`). Use Apache **only** where the surrounding module already
+  does and its `LICENSE` says so.
+- Rule of thumb: **match the neighbouring files / the repo's root `LICENSE`.** Don't mix
+  licenses within a repo, and don't invent a header — when unsure, ask.
+
+## Before you call a change done
+
+1. Compiles with `-Werror` (no unused imports / warnings).
+2. `spotless:apply` run so formatting is clean.
+3. Relevant tests run and pass (report real output — don't claim green if you didn't run
+   them).

--- a/.claude/skills/rudder-scala/900-testing.md
+++ b/.claude/skills/rudder-scala/900-testing.md
@@ -1,0 +1,69 @@
+# 900 — Testing
+
+Two frameworks coexist; pick by what you're testing.
+
+## specs2 — the established style
+
+Most tests are **specs2** `mutable.Specification`, run under JUnit so they integrate
+with Maven/surefire:
+
+```scala
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class BundleOrderTest extends Specification {
+  "a BundleOrder" should {
+    "sort lexicographically" in {
+      BundleOrder.compare(a, b) must beLessThan(0)
+    }
+  }
+}
+```
+
+- The `@RunWith(classOf[JUnitRunner])` annotation is required for these to run.
+- For JSON assertions, use the project matcher `JsonSpecMatcher` / `beEqualToJson`
+  (`rudder-core/.../JsonSpecMatcher.scala`) rather than comparing raw strings. These
+  tests **lock the user-facing serialization contract** — assert the exact JSON of REST
+  responses and persisted forms so a format change can't slip in unnoticed (see
+  [`404`](404-serialization-contracts.md)).
+
+## zio-test — preferred for new pure / ZIO code
+
+For new code that is pure or returns `IOResult`, prefer **zio-test**
+`ZIOSpecDefault` — tests are values, effects compose, no `.runNow` needed:
+
+```scala
+import zio.test.*
+
+object TechniqueGenerationModeTest extends ZIOSpecDefault {
+  def spec = suite("TechniqueGenerationMode")(
+    test("round-trips through its codec") {
+      val mode = TechniqueGenerationMode.MergeTechniqueDirective
+      assertTrue(parse(mode.serialize) == Right(mode))
+    },
+    test("an effect succeeds") {
+      for {
+        res <- service.compute(input)        // IOResult[...]
+      } yield assertTrue(res.size == 2)
+    }
+  )
+}
+```
+
+Guideline: **new pure/effectful logic → zio-test**; extending an existing specs2 suite
+→ stay in specs2 to match the file.
+
+## Test doubles
+
+There is **no mocking library** (no mockito/scalamock). A test double is just another
+implementation of the trait, passed via the constructor (see
+[`102`](102-traits-and-dependency-injection.md)) — e.g. an in-memory repository
+implementing the repository trait. This is a direct payoff of programming to traits.
+
+## Running
+
+See [`800`](800-build-and-formatting.md) for the maven invocation (targeted runs need
+`-Dsurefire.failIfNoSpecifiedTests=false -Dexec.skip=true`). Always run the relevant
+suite and report real output — don't claim green without running it.

--- a/.claude/skills/rudder-scala/SKILL.md
+++ b/.claude/skills/rudder-scala/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: rudder-scala
+description: >-
+  Conventions and idioms for writing Scala in the Rudder codebase (webapp/sources).
+  Use whenever reading, writing, reviewing, or refactoring Scala in the rudder repo.
+  Covers functional style, ZIO effects and the RudderError model (IOResult), DDD /
+  hexagonal architecture, repositories, parse-don't-validate, zio-json / chimney /
+  quicklens data handling, java.time, security-in-depth, and dependency policy.
+---
+
+# Writing Scala in Rudder
+
+Rudder is a long-lived codebase (Scala 2.8 in 2009 → Scala 3 today). We migrate
+**step by step** toward a more functional style with **ZIO** as the effect handler.
+New and changed code follows the conventions below; we do not rewrite untouched
+legacy code just to modernize it, but we leave every file we touch a little better.
+
+**Scope — applies to all the Rudder Scala repos.** These conventions hold for the Scala
+code in `rudder`, **`rudder-plugins`, and `rudder-plugins-private`** alike (the plugin
+repos build on rudder-core and use the same stack: `IOResult`/`RudderError`, zio-json,
+chimney, quicklens, enumeratum, the plugin API framework, etc.). This skill file lives
+in the `rudder` repo, and its links to ADRs and example code are relative to that repo —
+but when you write Scala in either plugins repo, **follow this skill too** (look up the
+referenced rudder code/ADR in the `rudder` checkout). Plugin-specific points: the
+dynamic plugin-status API framework ([`103`](103-rest-api-and-endpoints.md)) and license
+parsing live in the plugin repos.
+
+## Golden rules (always apply)
+
+1. **Functional first.** Immutable data, no shared mutable state, effects reified as
+   values. Any mutation or I/O *must* be wrapped in `IOResult` (see `300`).
+2. **Less code is better code.** Minimize boilerplate and lines. Prefer the simple,
+   short solution. Don't implement a pattern "fully" if a smaller version is clearer.
+3. **No type-level acrobatics.** Scala is powerful — lean on that power, but get it
+   from well-chosen *libraries* (zio, chimney, quicklens, zio-json), not from
+   hand-rolled implicit/type-level machinery.
+4. **Dumb data, smart companions.** Business objects are plain `case class`es with as
+   few methods as possible. Serialization, conversion and mapping live in companion
+   objects or `extension` methods (see `001`, `400`).
+5. **Program to traits.** Every service/repository has a trait defining its API, even
+   with a single implementation. DI is constructor-only, wired in `RudderConfig`
+   (see `102`).
+6. **Parse, don't validate.** User input is parsed into typed domain objects at the
+   boundary; persistence goes through a repository (see `200`, `201`).
+7. **Security in depth** is a design constraint, not an afterthought (see `600`).
+8. **Be strict about dependencies.** Apache2/BSD-compatible licenses only; prefer
+   removing deps over adding them (see `700`).
+
+## How to use this skill
+
+Before doing substantial work in a given area, read the matching topic file. Files
+are named `NNN-topic.md`; the **first digit** is the subject area (table below), the
+other two digits identify the topic within it.
+
+| 1st digit | Subject area |
+|-----------|--------------|
+| 0 | Generalities — coding philosophy & Scala 3 idioms |
+| 1 | Architecture — DDD, hexagonal, traits & dependency injection |
+| 2 | Persistence — repositories, parse-don't-validate |
+| 3 | Effects & errors — ZIO, `IOResult`, bridging legacy code |
+| 4 | Data & serialization — case classes, zio-json, chimney, quicklens |
+| 5 | Datetime — `java.time` |
+| 6 | Security — defense in depth, web/output safety, authn/authz |
+| 7 | Dependencies & ecosystem |
+| 8 | Build, tooling & formatting |
+| 9 | Testing |
+
+### Topic index
+
+- [`000-coding-philosophy.md`](000-coding-philosophy.md) — FP, immutability, minimal LOC, no type acrobatics
+- [`001-scala3-idioms.md`](001-scala3-idioms.md) — companions, extensions, `derives`, `given`, opaque types, minimizing imports
+- [`100-package-layout.md`](100-package-layout.md) — bounded-context-first packages, not technical-layer; migrating off legacy `domain`/`repository`/`services`
+- [`101-architecture-ddd-hexagonal.md`](101-architecture-ddd-hexagonal.md) — bounded contexts, hexagonal, "pragmatic DDD"
+- [`102-traits-and-dependency-injection.md`](102-traits-and-dependency-injection.md) — program-to-trait, constructor DI, `RudderConfig`
+- [`103-rest-api-and-endpoints.md`](103-rest-api-and-endpoints.md) — declarative `EndpointSchema`, versioning, per-endpoint `authz`, lift handlers
+- [`104-bootstrap-and-migrations.md`](104-bootstrap-and-migrations.md) — `BootstrapChecks` early/end phases, self-managed async DB/schema migrations, `Boot.scala`
+- [`200-persistence-repositories.md`](200-persistence-repositories.md) — repository as single point of change, optional persistence layer
+- [`201-parse-dont-validate.md`](201-parse-dont-validate.md) — typed parsing at I/O boundaries
+- [`300-effects-zio-ioresult.md`](300-effects-zio-ioresult.md) — `IOResult` / `PureResult`, when & how to use ZIO
+- [`301-error-model.md`](301-error-model.md) — `RudderError`, `Chained`, `Accumulated`, domain errors
+- [`302-bridging-toio-runnow.md`](302-bridging-toio-runnow.md) — `.toIO`, `.toBox`, minimizing `.runNow`
+- [`303-logging.md`](303-logging.md) — `NamedZioLogger` pure loggers, migrating off lift `extends Logger`
+- [`400-domain-case-classes.md`](400-domain-case-classes.md) — dumb case classes, value/opaque wrappers, ADTs
+- [`401-json-zio-json.md`](401-json-zio-json.md) — `derives JsonCodec`, manual codecs, discriminators
+- [`402-chimney-transformers.md`](402-chimney-transformers.md) — mapping between representations
+- [`403-quicklens-updates.md`](403-quicklens-updates.md) — `.modify(...).setTo(...)` instead of `.copy`
+- [`404-serialization-contracts.md`](404-serialization-contracts.md) — user-facing serialization is a contract; DTOs + chimney, stable tokens, test-enforced
+- [`500-datetime-java-time.md`](500-datetime-java-time.md) — `java.time`, migrating off joda
+- [`600-security-in-depth.md`](600-security-in-depth.md) — `SecurityError`, tenants, path traversal, defense in depth
+- [`601-web-and-output-security.md`](601-web-and-output-security.md) — `XmlSafe` (XXE), Lift `JsRaw`/XSS, CSRF, CSP, sessions
+- [`602-authentication-and-authorization.md`](602-authentication-and-authorization.md) — Spring auth vs Rudder authz, BouncyCastle, tokens, RBAC/ACL `AuthorizationType`
+- [`700-dependencies-ecosystem.md`](700-dependencies-ecosystem.md) — license policy, minimizing deps, ZIO scope
+- [`800-build-and-formatting.md`](800-build-and-formatting.md) — maven/spotless/scalafmt, `-Werror`, license headers
+- [`900-testing.md`](900-testing.md) — specs2 + JUnitRunner, zio-test for new code, trait-based test doubles
+
+> The effect type is `com.normation.errors.IOResult[A] = ZIO[Any, RudderError, A]`.
+
+## Sources of truth
+
+The **error-management philosophy** behind `RudderError`/`IOResult` (nominal cases vs
+errors vs defects, WYSIWYG contracts, errors-as-signal) comes from the talk
+**"Systematic error management in application"** (DevoxxFR 2021, F. Armand).
+See [`000`](000-coding-philosophy.md), [`301`](301-error-model.md).
+
+This skill summarizes and operationalizes decisions; the **authoritative records are
+the ADRs** in [`rudder/adr/webapp/`](../../../adr/webapp/) (and some in
+[`rudder/adr/system/`](../../../adr/system/)). When a topic touches an ADR, the topic
+file cites it — **follow the link and read the ADR** for the full context and rationale,
+and prefer the ADR if it ever conflicts with the summary here. If you make a decision
+that isn't captured yet, add an ADR (see [`adr/template.md`](../../../adr/template.md))
+and then update the matching topic file. ADRs already reflected here include:
+
+- `18879` zio-json is the only JSON library → [`401`](401-json-zio-json.md)
+- `28515` use `java.time` (prefer `Instant`) and `27084` explicit-timezone/RFC-3339
+  dates → [`500`](500-datetime-java-time.md)
+- `28452` safe `QueryContext` in Lift snippets (`SecureDispatchSnippet`) → [`600`](600-security-in-depth.md)
+- `28612` central plugin-status checks for menus/APIs → [`103`](103-rest-api-and-endpoints.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# Agent guide
+
+Guidance for any coding agent (Claude, or otherwise) working in this repository.
+
+## Responsible use (read first)
+
+Human contributors must follow the **[Responsible use of AI agents](AI_POLICY.md)**
+policy. Key points an agent should help uphold: no "vibe coding" (code must be understood
+by the human who submits it), **any** AI/LLM use must be **disclosed traceably** — record
+the exact tool, model, and version in **commit trailers** (e.g.
+`Assisted-by: Claude Code 2.0.1 (model: claude-opus-4-8)`) so contributions stay auditable
+later, all code is human-reviewed, and a **human is always responsible** for what is
+contributed, reviewed, and maintained (and signs the CLA).
+
+If you are an agent, you operate **confined**: do **not** access secrets/credentials or
+production/customer data, do **not** push, open/merge PRs, comment, or otherwise act on
+GitHub or CI directly, and never act "in the name of" the human. Produce changes locally;
+the human reviews the diff and performs all commits, pushes, PRs, and merges. Remind the
+contributor to disclose AI assistance in the PR.
+
+## Scala conventions — read the skill first
+
+Before reading, writing, reviewing, or refactoring **Scala** in this repo, read the
+project's Scala conventions, which live as plain Markdown under:
+
+> [`.claude/skills/rudder-scala/`](.claude/skills/rudder-scala/)
+
+Start with **[`.claude/skills/rudder-scala/SKILL.md`](.claude/skills/rudder-scala/SKILL.md)**
+— it's the router: it states the always-apply "golden rules" and indexes the per-topic
+files. Each topic is its own file named `NNN-topic.md`, where the first digit is the
+subject area:
+
+| 1st digit | Subject area |
+|-----------|--------------|
+| 0 | Generalities — coding philosophy & Scala 3 idioms |
+| 1 | Architecture — package layout, DDD/hexagonal, traits & DI, REST |
+| 2 | Persistence — repositories, parse-don't-validate |
+| 3 | Effects & errors — ZIO, `IOResult`, `RudderError`, logging |
+| 4 | Data & serialization — case classes, zio-json, chimney, quicklens, contracts |
+| 5 | Datetime — `java.time` |
+| 6 | Security — security in depth |
+| 7 | Dependencies & ecosystem |
+| 8 | Build, tooling & formatting |
+| 9 | Testing |
+
+These files are vendor-neutral Markdown — read them directly regardless of your tooling.
+(The `.claude/skills/` path is also where Claude Code auto-discovers the same content as
+a "skill", but nothing in the files is Claude-specific.)
+
+## Scope
+
+The conventions apply to the Scala code in **`rudder`** and in the sibling plugin repos
+**`rudder-plugins`** and **`rudder-plugins-private`** (same stack: `IOResult`/
+`RudderError`, zio-json, chimney, quicklens, enumeratum, the plugin API framework). The
+skill physically lives in this repo; when working in a plugin repo, follow it too and
+look up referenced code/ADRs in this `rudder` checkout.
+
+## Other sources of truth
+
+- **ADRs** (architecture decisions) in [`adr/webapp/`](adr/webapp/) and
+  [`adr/system/`](adr/system/) are authoritative; the skill cites the relevant ADR per
+  topic. Add an ADR (see [`adr/template.md`](adr/template.md)) for new decisions.
+- The Scala build/test specifics live in the skill's
+  [`800-build-and-formatting.md`](.claude/skills/rudder-scala/800-build-and-formatting.md).


### PR DESCRIPTION
https://issues.rudder.io/issues/29072

The clause skill I'm teaching it so that it outputs code that follow what we are doing. 

It's also a big base of documentation on the general architecture and design principle of Rudder. It was written assisted by `Claude Code 2.0.1 (0pus 3.8)` but I proof readed it, and make it so that it will be usefull for a latter me or any human dev. 

I keep adding things to it, even extremelly blattant and important ones that I just missed until now. Don't imagine it's "finish" or "the whole thing", but what is written is based on what we really do. 