### PR TITLE
Fixes #26026: Add a size limit on files handled by relayd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5581,6 +5581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0a808122a8a77eecdabaefd88ddb1913c4be5ea1465399f63ba64c7aa705fea"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "headers",
  "http",

--- a/relay/sources/api-doc/paths/remote-run/all.yml
+++ b/relay/sources/api-doc/paths/remote-run/all.yml
@@ -9,6 +9,10 @@ post:
   responses:
     200:
       $ref: "../../components/responses/agent-output.yml"
+    411:
+      description: The `Content-Length` header is missing
+    413:
+      description: The request body is larger than the 1 MiB limit
   tags:
     - Remote run
   x-codeSamples:

--- a/relay/sources/api-doc/paths/remote-run/node.yml
+++ b/relay/sources/api-doc/paths/remote-run/node.yml
@@ -11,6 +11,10 @@ post:
   responses:
     200:
       $ref: "../../components/responses/agent-output.yml"
+    411:
+      description: The `Content-Length` header is missing
+    413:
+      description: The request body is larger than the 1 MiB limit
   tags:
     - Remote run
   x-codeSamples:

--- a/relay/sources/api-doc/paths/remote-run/nodes.yml
+++ b/relay/sources/api-doc/paths/remote-run/nodes.yml
@@ -9,6 +9,10 @@ post:
   responses:
     200:
       $ref: "../../components/responses/agent-output.yml"
+    411:
+      description: The `Content-Length` header is missing
+    413:
+      description: The request body is larger than the 1 MiB limit
   tags:
     - Remote run
   x-codeSamples:

--- a/relay/sources/api-doc/paths/shared-files.yml
+++ b/relay/sources/api-doc/paths/shared-files.yml
@@ -44,6 +44,11 @@ put:
     separated by an empty line. The receiving relay will either directly share it
     if the target node is a sub node, or forward the request to the appropriate
     relay (sub relay or upstream depending if it is under the current relay or not).
+
+
+    The request body is buffered in memory, so its size is limited. The limit is
+    configurable through the `max_body_size` setting (in bytes) of the
+    `[shared_files]` section of the relay configuration, and defaults to 50 MiB.
   operationId: putSharedFiles
   parameters:
     - $ref: "../components/parameters/source-node-id.yml"
@@ -115,5 +120,11 @@ put:
       description: The file exists and the content matches the provided hash
     "404":
       description: The file does not exist
+    "411":
+      description: The `Content-Length` header is missing
+    "413":
+      description: >-
+        The request body is larger than the configured `max_body_size`
+        (50 MiB by default)
   tags:
     - Shared files

--- a/relay/sources/relayd/Cargo.toml
+++ b/relay/sources/relayd/Cargo.toml
@@ -62,3 +62,4 @@ proptest = "1"
 tempfile = "3"
 pretty_assertions = "1"
 rand = "0.10"
+warp = { version = "0.4", default-features = false, features = ["server", "test"] }

--- a/relay/sources/relayd/src/api.rs
+++ b/relay/sources/relayd/src/api.rs
@@ -140,6 +140,20 @@ async fn customize_error(reject: Rejection) -> Result<impl Reply, Rejection> {
         ))
     } else if let Some(e) = reject.find::<RudderReject>() {
         Ok(reply::with_status(format!("{e}"), StatusCode::BAD_REQUEST))
+    } else if let Some(_e) = reject.find::<reject::PayloadTooLarge>() {
+        // Checked before `MethodNotAllowed`: a body-accepting route is built as
+        // `head.or(put)`, so an oversized PUT yields a combined rejection holding
+        // both `MethodNotAllowed` (from `head`) and `PayloadTooLarge` (from `put`).
+        // `MethodNotAllowed` must not shadow the more specific size/length errors.
+        Ok(reply::with_status(
+            "PAYLOAD TOO LARGE".to_string(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+        ))
+    } else if let Some(_e) = reject.find::<reject::LengthRequired>() {
+        Ok(reply::with_status(
+            "LENGTH REQUIRED".to_string(),
+            StatusCode::LENGTH_REQUIRED,
+        ))
     } else if let Some(_e) = reject.find::<reject::MethodNotAllowed>() {
         // TODO find why we only have MethodNotAllowed when file in found in fs::dir
         Ok(reply::with_status(
@@ -236,5 +250,47 @@ mod tests {
             .unwrap(),
             "{\"result\":\"error\",\"action\":\"actionName3\",\"errorDetails\":\"inconsistent run log\"}".to_string()
         );
+    }
+
+    // Mirrors how body-accepting endpoints are built: a body size limit followed by
+    // body extraction, recovered through `customize_error`. Checks that the rejections
+    // produced by `content_length_limit` are mapped to the expected HTTP status codes.
+    #[tokio::test]
+    async fn it_rejects_oversized_body_with_413() {
+        let filter = warp::body::content_length_limit(10)
+            .and(warp::body::bytes())
+            .map(|_body| warp::reply::reply())
+            .recover(customize_error);
+        let res = warp::test::request()
+            .method("PUT")
+            .body("this body is definitely longer than ten bytes")
+            .reply(&filter)
+            .await;
+        assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn it_rejects_missing_content_length_with_411() {
+        let filter = warp::body::content_length_limit(10)
+            .and(warp::body::bytes())
+            .map(|_body| warp::reply::reply())
+            .recover(customize_error);
+        // No `.body()` call, so the request carries no `Content-Length` header.
+        let res = warp::test::request().method("PUT").reply(&filter).await;
+        assert_eq!(res.status(), StatusCode::LENGTH_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn it_accepts_body_within_limit() {
+        let filter = warp::body::content_length_limit(10)
+            .and(warp::body::bytes())
+            .map(|_body| warp::reply::reply())
+            .recover(customize_error);
+        let res = warp::test::request()
+            .method("PUT")
+            .body("short")
+            .reply(&filter)
+            .await;
+        assert_eq!(res.status(), StatusCode::OK);
     }
 }

--- a/relay/sources/relayd/src/api/remote_run.rs
+++ b/relay/sources/relayd/src/api/remote_run.rs
@@ -31,6 +31,10 @@ use warp::{
     path, Filter, Reply,
 };
 
+/// Maximum size of a remote-run request body. These are small forms
+/// (a node list and condition names), 1MiB is enough.
+const MAX_BODY_SIZE: u64 = 1024 * 1024;
+
 pub fn routes_1(job_config: Arc<JobConfig>) -> BoxedFilter<(impl Reply,)> {
     let base = path!("remote-run" / ..);
 
@@ -39,6 +43,7 @@ pub fn routes_1(job_config: Arc<JobConfig>) -> BoxedFilter<(impl Reply,)> {
         .map(move || job_config_node.clone())
         .and(base)
         .and(path!("nodes" / String))
+        .and(body::content_length_limit(MAX_BODY_SIZE))
         .and(body::form())
         .and_then(move |j, node_id, params| handlers::node(node_id, params, j));
 
@@ -47,6 +52,7 @@ pub fn routes_1(job_config: Arc<JobConfig>) -> BoxedFilter<(impl Reply,)> {
         .and(base)
         .and(path!("nodes"))
         .map(move || job_config_nodes.clone())
+        .and(body::content_length_limit(MAX_BODY_SIZE))
         .and(body::form())
         .and_then(move |j, params| handlers::nodes(params, j));
 
@@ -55,6 +61,7 @@ pub fn routes_1(job_config: Arc<JobConfig>) -> BoxedFilter<(impl Reply,)> {
         .and(base)
         .and(path!("all"))
         .map(move || job_config_all.clone())
+        .and(body::content_length_limit(MAX_BODY_SIZE))
         .and(body::form())
         .and_then(move |j, params| handlers::all(params, j));
 

--- a/relay/sources/relayd/src/api/shared_files.rs
+++ b/relay/sources/relayd/src/api/shared_files.rs
@@ -42,11 +42,15 @@ pub fn routes_1(job_config: Arc<JobConfig>) -> BoxedFilter<(impl Reply,)> {
             handlers::head(target_id, source_id, file_id, params, j)
         });
 
+    // Bound the in-memory buffered body to mitigate denial-of-service from
+    // oversized uploads (the whole body is read into memory below).
+    let max_body_size = job_config.cfg.shared_files.max_body_size;
     let job_config_put = job_config;
     let put = method::put()
         .map(move || job_config_put.clone())
         .and(base)
         .and(query::<SharedFilesPutParams>())
+        .and(body::content_length_limit(max_body_size))
         .and(body::bytes())
         .and_then(move |j, target_id, source_id, file_id, params, buf| {
             handlers::put(target_id, source_id, file_id, params, buf, j)

--- a/relay/sources/relayd/src/configuration/main.rs
+++ b/relay/sources/relayd/src/configuration/main.rs
@@ -419,6 +419,9 @@ impl Default for SharedFilesCleanupConfig {
 pub struct SharedFiles {
     #[serde_inline_default(PathBuf::from("/var/rudder/shared-files/"))]
     pub path: PathBuf,
+    /// Max uploaded shared file size in bytes
+    #[serde_inline_default(50 * 1024 * 1024)]
+    pub max_body_size: u64,
     #[serde(default)]
     pub cleanup: SharedFilesCleanupConfig,
 }
@@ -602,6 +605,7 @@ mod tests {
             },
             shared_files: SharedFiles {
                 path: PathBuf::from("/var/rudder/shared-files/"),
+                max_body_size: 50 * 1024 * 1024,
                 cleanup: SharedFilesCleanupConfig {
                     frequency: Duration::from_secs(600),
                 },
@@ -705,6 +709,7 @@ mod tests {
             },
             shared_files: SharedFiles {
                 path: PathBuf::from("tests/api_shared_files"),
+                max_body_size: 8192,
                 cleanup: SharedFilesCleanupConfig {
                     frequency: Duration::from_secs(43),
                 },

--- a/relay/sources/relayd/tests/files/config/main.conf
+++ b/relay/sources/relayd/tests/files/config/main.conf
@@ -58,6 +58,9 @@ use_sudo = false
 
 [shared_files]
 path = "tests/api_shared_files"
+# Small on purpose so the size-limit integration test can send a tiny over-limit
+# body (still well above the ~2 KB legitimate uploads used by other tests).
+max_body_size = 8192
 
 [shared_files.cleanup]
 frequency = "43s"

--- a/relay/sources/relayd/tests/shared_files.rs
+++ b/relay/sources/relayd/tests/shared_files.rs
@@ -118,3 +118,37 @@ fn it_shares_files() {
     remove_file(file).unwrap();
     remove_file(format!("{file}.metadata")).unwrap();
 }
+
+#[test]
+fn it_rejects_too_large_shared_file_upload() {
+    let cli_cfg = CliConfiguration::new("tests/files/config/", false);
+    let (api_port, https_port) = random_ports();
+
+    thread::spawn(move || {
+        start(
+            cli_cfg,
+            init_logger().unwrap(),
+            Some((api_port, https_port)),
+        )
+        .unwrap();
+    });
+    assert!(common::start_api(api_port).is_ok());
+
+    let client = reqwest::blocking::Client::new();
+    let url = format!(
+        "http://localhost:{api_port}/rudder/relay-api/1/shared-files/37817c4d-fbf7-4850-a985-50021f4e8f41/e745a140-40bc-4b86-b6dc-084488fc906b/file2?ttl=1d"
+    );
+
+    // `tests/files/config/main.conf` sets `[shared_files] max_body_size = 8192`.
+    let too_large = vec![b'a'; 9000];
+    let upload = client.put(&url).body(too_large).send().unwrap();
+    assert_eq!(reqwest::StatusCode::PAYLOAD_TOO_LARGE, upload.status());
+
+    // A request within the bound is not rejected by the size limit (it fails
+    // later, on signature validation, with a 500 - not a 413).
+    let within_limit = client.put(&url).body(vec![b'a'; 100]).send().unwrap();
+    assert_ne!(
+        reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+        within_limit.status()
+    );
+}

--- a/relay/sources/relayd/tools/config/main.conf
+++ b/relay/sources/relayd/tools/config/main.conf
@@ -138,6 +138,10 @@ password = "PASSWORD"
 # Path of files shared between individual nodes
 #path = "/var/rudder/shared-files/"
 
+# Maximum size in bytes of an uploaded shared file (buffered in memory).
+# Default is 50MiB.
+#max_body_size = 52428800
+
 [shared_files.cleanup]
 # Job frequency
 #frequency = "10min"


### PR DESCRIPTION
https://issues.rudder.io/issues/26026

Hardening to prevent (voluntary or involuntary) DoS in endpoinds reading the body in memory (and writing it to the FS). Targeting 9.2 as it _could_ break in exotic contexts and does not fix an actual vulnerability.

_Asssited with Claude Code (Opus 3.8)_