### PR TITLE
Fixes #28958: Titles in main dashboard Score breakdown should be centered for each donut graph

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
@@ -78,7 +78,7 @@ const homePage = (
   scoreDetails.forEach(function(score) {
     $("#scoreBreakdown .node-charts").append(
               `<div class="node-chart px-1 px-xl-3 mb-4">
-                <h4 class="px-2">${score.name}</h4>
+                <h4 class="px-2 text-center">${score.name}</h4>
                 <div class="d-flex align-items-center justify-content-between">
                   <canvas id="score-${score.scoreId}" > </canvas>
                   <div  id="score-${score.scoreId}-legend"></div>

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-dashboard.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-dashboard.scss
@@ -100,6 +100,7 @@ $doughnut-size : 180px;
   color: rudder.$txt-light;
   margin-bottom: 15px;
   font-size: 1.3em;
+  width : $doughnut-size;
 }
 /* Statistics */
 .stats li {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
@@ -137,7 +137,7 @@
                                 <div class="node-charts gap-1 gap-lg-2 gap-xl-4">
 
                                     <div class="node-chart px-1 px-xl-3 mb-4">
-                                        <h4 class="px-2">By OS</h4>
+                                        <h4 class="px-2 text-center">By OS</h4>
                                         <div class="d-flex align-items-center justify-content-between">
                                             <canvas id="nodeOs"></canvas>
                                             <div  id="nodeOs-legend"></div>
@@ -146,7 +146,7 @@
                                     </div>
 
                                     <div class="node-chart px-1 px-xl-3 mb-4">
-                                        <h4 class="px-2">By agent version</h4>
+                                        <h4 class="px-2 text-center">By agent version</h4>
                                         <div class="d-flex align-items-center justify-content-between">
                                             <canvas id="nodeAgents" > </canvas>
                                             <div  id="nodeAgents-legend"></div>


### PR DESCRIPTION
https://issues.rudder.io/issues/28958

<img width="1600" height="761" alt="image" src="https://github.com/user-attachments/assets/8b25744e-0654-47bd-b48b-acd555dc341b" />
