### PR TITLE
Fixes #29075: Error when changing expiration date of an expired API token

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountDiff.scala
@@ -56,7 +56,7 @@ final case class ModifyApiAccountDiff(
     modDescription:         Option[SimpleDiff[String]] = None,
     modIsEnabled:           Option[SimpleDiff[Boolean]] = None,
     modCreationDate:        Option[SimpleDiff[Instant]] = None,
-    modLastAuthenticated:   Option[SimpleDiff[Option[Instant]]] = None,
+    modLastAuthentication:  Option[SimpleDiff[Option[Instant]]] = None,
     modExpirationDate:      Option[SimpleDiff[Option[Instant]]] = None,
     modAPIKind:             Option[SimpleDiff[String]] = None,
     modAccountKind:         Option[SimpleDiff[String]] = None,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -587,6 +587,12 @@ object AccountLastAuthentication {
       case AtDate(date) => Some(date)
       case _            => None
     }
+
+    def schemaVersion: ApiAccountSchemaVersion = self match {
+      case AtDate(_) => V2 // version when date was added: V2
+      case Never     => V2
+      case Unknown   => V1
+    }
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -697,8 +697,16 @@ class LDAPDiffMapper(
                                 diff.map(
                                   _.copy(modAPITenants = Some(SimpleDiff(oldAccount.tenants.serialize, mod.getOptValueDefault("-"))))
                                 )
-
-                              case x => Left(Err.UnexpectedObject("Unknown diff attribute: " + x))
+                              case A_API_SCHEMA_VERSION          =>
+                                val newVersion = ApiAccountSchemaVersion(mod.getOptValue())
+                                val oldDate    = oldAccount.lastAuthentication.date
+                                val newDate    = AccountLastAuthentication.from(newVersion, oldDate).date
+                                // keep old date, if version changed having impact on date, then we have a diff
+                                val lastDiff   = if (oldDate == newDate) None else Some(SimpleDiff(oldDate, newDate))
+                                diff.map(
+                                  _.copy(modLastAuthentication = lastDiff)
+                                )
+                              case x                             => Left(Err.UnexpectedObject("Unknown diff attribute: " + x))
                             }
                           }
           } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -1002,41 +1002,45 @@ class EventLogDetailsServiceImpl(
     import cats.implicits.*
 
     for {
-      entry             <- getEntryContent(xml)
-      apiAccount        <- (entry \ XML_TAG_API_ACCOUNT).headOption ?~!
-                           (s"Entry type is not a Api Account: ${entry}")
-      id                <-
+      entry                 <- getEntryContent(xml)
+      apiAccount            <- (entry \ XML_TAG_API_ACCOUNT).headOption ?~!
+                               (s"Entry type is not a Api Account: ${entry}")
+      id                    <-
         (apiAccount \ "id").headOption.map(_.text) ?~! ("Missing attribute 'id' in entry type API Account : " + entry.toString())
-      modName           <- getFromToString((apiAccount \ "name").headOption)
-      modToken          <- getFromToString((apiAccount \ "token").headOption)
-      modDescription    <- getFromToString((apiAccount \ "description").headOption)
-      modIsEnabled      <- getFromTo[Boolean]((apiAccount \ "enabled").headOption, s => tryo(s.text.toBoolean))
-      modTokenGenDate   <- getFromTo[Instant](
-                             (apiAccount \ "tokenGenerationDate").headOption,
-                             s => tryo(Instant.parse(s.text))
-                           )
-      modExpirationDate <- getFromTo[Option[Instant]](
-                             (apiAccount \ "expirationDate").headOption,
-                             s => Full(tryo(Instant.parse(s.text)).toOption)
-                           )
-      modAccountKind    <- getFromToString((apiAccount \ "accountKind").headOption)
-      modAcls           <- getFromTo[List[ApiAclElement]](
-                             (apiAccount \ "acls").headOption,
-                             { s =>
-                               ((s \ "acl").toList.traverse { x =>
-                                 for {
-                                   path    <- AclPath.parse((x \ "@path").head.text)
-                                   actions <- (x \ "@actions").head.text.split(",").toList.traverse(HttpAction.parse)
-                                 } yield {
-                                   ApiAclElement(path, actions.toSet)
+      modName               <- getFromToString((apiAccount \ "name").headOption)
+      modToken              <- getFromToString((apiAccount \ "token").headOption)
+      modDescription        <- getFromToString((apiAccount \ "description").headOption)
+      modIsEnabled          <- getFromTo[Boolean]((apiAccount \ "enabled").headOption, s => tryo(s.text.toBoolean))
+      modTokenGenDate       <- getFromTo[Instant](
+                                 (apiAccount \ "tokenGenerationDate").headOption,
+                                 s => tryo(Instant.parse(s.text))
+                               )
+      modExpirationDate     <- getFromTo[Option[Instant]](
+                                 (apiAccount \ "expirationDate").headOption,
+                                 s => Full(tryo(Instant.parse(s.text)).toOption)
+                               )
+      modAccountKind        <- getFromToString((apiAccount \ "accountKind").headOption)
+      modLastAuthentication <- getFromTo[Option[Instant]](
+                                 (apiAccount \ "lastAuthentication").headOption,
+                                 s => Full(tryo(Instant.parse(s.text)).toOption)
+                               )
+      modAcls               <- getFromTo[List[ApiAclElement]](
+                                 (apiAccount \ "acls").headOption,
+                                 { s =>
+                                   ((s \ "acl").toList.traverse { x =>
+                                     for {
+                                       path    <- AclPath.parse((x \ "@path").head.text)
+                                       actions <- (x \ "@actions").head.text.split(",").toList.traverse(HttpAction.parse)
+                                     } yield {
+                                       ApiAclElement(path, actions.toSet)
+                                     }
+                                   }) match {
+                                     case Left(e)  => Failure(e)
+                                     case Right(x) => Full(x)
+                                   }
                                  }
-                               }) match {
-                                 case Left(e)  => Failure(e)
-                                 case Right(x) => Full(x)
-                               }
-                             }
-                           )
-      fileFormatOk      <- TestFileFormat(apiAccount)
+                               )
+      fileFormatOk          <- TestFileFormat(apiAccount)
     } yield {
       ModifyApiAccountDiff(
         id = ApiAccountId(id),
@@ -1045,6 +1049,7 @@ class EventLogDetailsServiceImpl(
         modDescription = modDescription,
         modIsEnabled = modIsEnabled,
         modTokenGenerationDate = modTokenGenDate,
+        modLastAuthentication = modLastAuthentication,
         modExpirationDate = modExpirationDate,
         modAccountKind = modAccountKind,
         modAccountAcl = modAcls

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -1067,17 +1067,21 @@ class EventLogFactoryImpl(
         diff.modIsEnabled.map(x => SimpleDiff.booleanToXml(<enabled/>, x)) ++
         diff.modTokenGenerationDate.map(x => SimpleDiff.toXml[Instant](<tokenGenerationDate/>, x)(x => Text(x.toString))) ++
         diff.modExpirationDate.map(x => {
-          SimpleDiff.toXml[Option[Instant]](<expirationDate/>, x) { x =>
-            x match {
-              case None    => NodeSeq.Empty
-              case Some(d) => Text(d.toString)
-            }
+          SimpleDiff.toXml[Option[Instant]](<expirationDate/>, x) {
+            case None    => NodeSeq.Empty
+            case Some(d) => Text(d.toString)
           }
         }) ++
         diff.modAccountKind.map(x => SimpleDiff.stringToXml(<accountKind/>, x)) ++
         diff.modAccountAcl.map(x => {
           SimpleDiff.toXml[List[ApiAclElement]](<acls/>, x) { x =>
             x.map(acl => <acl path={acl.path.value} actions={acl.actions.map(_.name).mkString(",")} />)
+          }
+        }) ++
+        diff.modLastAuthentication.map(x => {
+          SimpleDiff.toXml[Option[Instant]](<lastAuthentication/>, x) {
+            case None    => NodeSeq.Empty
+            case Some(d) => Text(d.toString)
           }
         })
       }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -995,6 +995,10 @@ class EventLogDetailsGenerator(
                         apiAccountDiff.modExpirationDate,
                         _.fold("")(_.toString)
                       ) &
+                      "#lastAuthentication *" #> mapSimpleDiffT[Option[Instant]](
+                        apiAccountDiff.modLastAuthentication,
+                        _.fold("")(_.toString)
+                      ) &
                       "#accountKind *" #> mapSimpleDiff(apiAccountDiff.modAccountKind) &
                       // make list of ACL unsderstandable
                       "#acls *" #> mapSimpleDiff(apiAccountDiff.modAccountAcl.map(o => {


### PR DESCRIPTION
https://issues.rudder.io/issues/29075

When an old API account, without the attribute for "last used", is modified on other fields (e.g. expiration), the schema version can change: it may receive a new version v2 (added in this PR: https://github.com/Normation/rudder/pull/6852).

So it's mainly about intercepting the event, and produce the correct diff on the "last used" date.
Also, event logs for that are not displayed correctly, so just add the missing bits for display of event logs 