### PR TITLE
Fixes #29025: Implement TOTP for Rudder users

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
@@ -75,6 +75,14 @@ CREATE TABLE Users (
 , otherInfo      jsonb -- general additional user info
 );
 
+
+CREATE TABLE userstotp (
+  user_id TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE
+, secret TEXT NOT NULL
+, created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+
 CREATE TABLE UserSessions (
   userId       text NOT NULL CHECK (userId <> '')
 , sessionId    text NOT NULL CHECK (sessionId <> '')

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/Totp.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/Totp.scala
@@ -1,0 +1,69 @@
+/*
+ * *************************************************************************************
+ * Copyright 2026 Normation SAS
+ * *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * *************************************************************************************
+ */
+package com.normation.rudder.users
+
+import java.time.Instant
+
+opaque type UserId = String
+object UserId {
+  def apply(s: String): UserId = s
+
+  extension (self: UserId) {
+    def value: String = self
+  }
+}
+
+// Need to be a class because opaque type doesn't allow toString override
+final class TotpSecret private (secret: String) extends AnyVal {
+  // Avoid printing the value
+  override def toString: String = "[REDACTED TotpSecret]"
+
+  def exposeSecret(): String = {
+    secret
+  }
+}
+object TotpSecret {
+  def apply(secret: String) = new TotpSecret(secret)
+}
+
+/**
+ * Represents a TOTP (Time-based One-Time Password) configuration for a user.
+ * Stores the secret and creation timestamp.
+ */
+case class Totp(
+    secret:  TotpSecret,
+    created: Instant
+)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/TotpRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/TotpRepository.scala
@@ -1,0 +1,98 @@
+/*
+ * *************************************************************************************
+ * Copyright 2026 Normation SAS
+ * *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * *************************************************************************************
+ */
+package com.normation.rudder.users
+
+import com.normation.errors.IOResult
+import com.normation.rudder.db.Doobie
+import doobie.*
+import doobie.implicits.*
+import doobie.postgres.implicits.*
+import doobie.util.*
+import zio.interop.catz.*
+
+trait TotpRepository {
+  def getByUserId(userId: UserId): IOResult[Option[Totp]]
+  def create(userId:      UserId, totp: Totp): IOResult[Unit]
+  def delete(userId:      UserId): IOResult[Unit]
+  def getEnabledUsers(): IOResult[Set[UserId]]
+}
+
+object JdbcTotpRepository {
+
+  given Meta[UserId]     = Meta[String].imap(UserId(_))(_.value)
+  given Meta[TotpSecret] = Meta[String].imap(TotpSecret(_))(_.exposeSecret())
+  given Read[Totp]       = Read.derived
+  given Write[Totp]      = Write.derived
+
+  def getByUserIdSQL(userId: UserId): Query0[Totp] =
+    sql"SELECT secret, created_at FROM userstotp WHERE user_id = ${userId.value}".query[Totp]
+
+  def upsertQuerySQL(userId: UserId, totp: Totp): Update0 =
+    sql"INSERT INTO userstotp (user_id, secret, created_at) VALUES (${userId.value}, ${totp}) ON CONFLICT (user_id) DO UPDATE SET secret=EXCLUDED.secret, created_at=EXCLUDED.created_at".update
+
+  def deleteQuerySQL(userId: UserId): Update0 =
+    sql"DELETE FROM userstotp WHERE user_id=${userId.value}".update
+
+  def getAllByUserSQL(): Query0[String] =
+    sql"SELECT user_id FROM userstotp".query[String]
+}
+
+class JdbcTotpRepository(doobie: Doobie) extends TotpRepository {
+  import JdbcTotpRepository.*
+  import doobie.*
+
+  def getByUserId(userId: UserId): IOResult[Option[Totp]] = {
+    transactIOResult(s"Error when getting TOTP for user ${userId.value}")(xa => getByUserIdSQL(userId).option.transact(xa))
+  }
+
+  def create(userId: UserId, totp: Totp): IOResult[Unit] = {
+    transactIOResult(s"Error when creating TOTP for user ${userId.value}")(
+      upsertQuerySQL(userId, totp).run.transact(_).unit
+    )
+  }
+
+  def delete(userId: UserId): IOResult[Unit] = {
+    transactIOResult(s"Error deleting TOTP for user ${userId.value}")(
+      deleteQuerySQL(userId).run.transact(_).unit
+    )
+  }
+
+  def getEnabledUsers(): IOResult[Set[UserId]] = {
+    transactIOResult("Error when getting enabled TOTP users")(
+      getAllByUserSQL().to[Set].map(_.map(UserId(_))).transact(_)
+    )
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -153,6 +153,13 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
+    <!-- OTP verification -->
+    <dependency>
+      <groupId>com.github.bastiaanjansen</groupId>
+      <artifactId>otp-java</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+
     <!-- tool used to profile compliance perf in RunTestCompliance -->
     <dependency>
       <groupId>tools.profiler</groupId>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -1793,6 +1793,34 @@ object QuickSearchApi       extends Enum[QuickSearchApi] with ApiModuleProvider[
 }
 
 /*
+ * OTP (Two-Factor Authentication) internal API
+ * Used by the Elm OTP frontend application
+ */
+sealed trait OtpApi extends EnumEntry with EndpointSchema with InternalApi with SortIndex {
+  override def dataContainer: Option[String] = None
+}
+object OtpApi       extends Enum[OtpApi] with ApiModuleProvider[OtpApi]                   {
+
+  case object OtpStatus extends OtpApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get OTP status for current user"
+    val (action, path) = GET / "otp" / "status"
+    val authz: List[AuthorizationType] = Nil
+  }
+
+  case object OtpGenerate extends OtpApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Generate a new OTP secret for current user"
+    val (action, path) = POST / "otp" / "generate"
+    val authz: List[AuthorizationType] = Nil
+  }
+
+  def endpoints: List[OtpApi] = values.toList.sortBy(_.z)
+
+  def values = findValues
+}
+
+/*
  * All API.
  */
 object AllApi {
@@ -1812,6 +1840,7 @@ object AllApi {
     HookApi.endpoints :::
     ApiAccounts.endpoints :::
     QuickSearchApi.endpoints :::
+    OtpApi.endpoints :::
     // UserApi is not declared here, it will be contributed by plugin
     Nil
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/OtpApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/OtpApi.scala
@@ -1,0 +1,98 @@
+/*
+ * *************************************************************************************
+ * Copyright 2026 Normation SAS
+ * *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * *************************************************************************************
+ */
+
+package com.normation.rudder.rest.lift
+
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.rest.{OtpApi as API, *}
+import com.normation.rudder.rest.RudderJsonResponse.syntax.*
+import com.normation.rudder.users.*
+import net.liftweb.common.*
+import net.liftweb.http.*
+import zio.*
+
+/**
+ * OTP API implementation following the LiftApiModuleProvider pattern.
+ */
+class OtpApi(
+    otpGeneratorService: TotpService
+) extends LiftApiModuleProvider[API] {
+
+  def schemas: ApiModuleProvider[API] = API
+
+  def getLiftEndpoints(): List[LiftApiModule] = {
+    API.endpoints.map {
+      case API.OtpStatus   => OtpStatus
+      case API.OtpGenerate => OtpGenerate
+    }
+  }
+
+  object OtpStatus extends LiftApiModule0 {
+    val schema: API.OtpStatus.type = API.OtpStatus
+
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      val userId         = UserId(authzToken.user.name)
+      val needGeneration = otpGeneratorService.needGeneration(userId)
+      val status         = needGeneration.map(n => TotpStatus(n))
+      status.toLiftResponseOne(params, schema, None)
+    }
+  }
+
+  object OtpGenerate extends LiftApiModule0 {
+    val schema: API.OtpGenerate.type = API.OtpGenerate
+
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      val userId = UserId(authzToken.user.name)
+      (for {
+        secret <- otpGeneratorService.generateUserSecret(userId)
+      } yield {
+        TotpSecretContainer(secret)
+      }).toLiftResponseOne(params, schema, None)
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -73,7 +73,9 @@ import com.normation.rudder.users.JsonUpdatedUserInfo
 import com.normation.rudder.users.JsonUser
 import com.normation.rudder.users.JsonUserFormData
 import com.normation.rudder.users.Serialisation.*
+import com.normation.rudder.users.TotpService
 import com.normation.rudder.users.UpdateUserInfo
+import com.normation.rudder.users.UserId
 import com.normation.rudder.users.UserInfo
 import com.normation.rudder.users.UserManagementIO
 import com.normation.rudder.users.UserManagementService
@@ -201,6 +203,16 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
+  case object ResetUserOtp extends UserManagementApi with OneParam with StartsAtVersion24 {
+    val z              = implicitly[Line].value
+    val description    = "Reset the TOTP configuration for a user (admin action)"
+    val (action, path) = POST / "usermanagement" / "otp" / "reset" / "{username}"
+
+    override def dataContainer: Option[String] = None
+
+    val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
+  }
+
   def endpoints = values.toList.sortBy(_.z)
   def values    = findValues
 }
@@ -210,6 +222,7 @@ class UserManagementApiImpl(
     userService:               FileUserDetailListProvider,
     userManagementService:     UserManagementService,
     tenantRepository:          TenantService,
+    totpService:               TotpService,
     getProviderRoleExtensions: () => Map[String, ProviderRoleExtension],
     getAuthBackendsProviders:  () => Set[String]
 ) extends LiftApiModuleProvider[UserManagementApi] {
@@ -230,6 +243,7 @@ class UserManagementApiImpl(
       case UserManagementApi.DisableUser     => DisableUser
       case UserManagementApi.RoleCoverage    => RoleCoverage
       case UserManagementApi.GetRoles        => GetRoles
+      case UserManagementApi.ResetUserOtp    => ResetUserOtp
     }
   }
 
@@ -242,113 +256,121 @@ class UserManagementApiImpl(
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
 
       (for {
-        users     <- userRepo.getAll()
-        allRoles  <- RudderRoles.getAllRoles
-        file       = userService.authConfig
-        roles      = allRoles.values.toSet
-        jsonUsers <-
-          ZIO
-            .foreach(users)(u => {
-              implicit val currentRoles: Set[Role] = roles
-              // we take last session to get last known roles and authz of the user
-              // we need to merge at the level of JsonUser because last session roles are just String
+        users       <- userRepo.getAll()
+        allRoles    <- RudderRoles.getAllRoles
+        file         = userService.authConfig
+        roles        = allRoles.values.toSet
+        otpUsers    <- totpService.getEnabledUsers()
+        otpEnforced <- totpService.getGlobalStatus()
+        jsonUsers   <-
+          ZIO.foreach(users)(u => {
+            implicit val currentRoles: Set[Role] = roles
+            // we take last session to get last known roles and authz of the user
+            // we need to merge at the level of JsonUser because last session roles are just String
+            for {
+              s                                <- userRepo
+                                                    .getLastPreviousLogin(u.id, closedSessionsOnly = false)
+              // Query may return both closed and opened sessions: get "lastClosedSession" when last session is still opened
+              (lastClosedSession, lastSession) <- s match {
+                                                    case last @ Some(lastSession) => {
+                                                      if (lastSession.isOpen) {
+                                                        userRepo
+                                                          .getLastPreviousLogin(u.id, closedSessionsOnly = true)
+                                                          .map((_, last))
+                                                      } else {
+                                                        (last, last).succeed
+                                                      }
+                                                    }
+                                                    case None                     =>
+                                                      (None, None).succeed
+                                                  }
+            } yield {
+              implicit val previousLogin: Option[OffsetDateTime] = lastClosedSession.map(_.creationDate)
 
-              userRepo
-                .getLastPreviousLogin(u.id, closedSessionsOnly = false)
-                .flatMap { // Query may return both closed and opened sessions: get "lastClosedSession" when last session is still opened
-                  case last @ Some(lastSession) => {
-                    if (lastSession.isOpen) {
-                      userRepo
-                        .getLastPreviousLogin(u.id, closedSessionsOnly = true)
-                        .map((_, last))
-                    } else {
-                      (last, last).succeed
+              // depending on provider property configuration, we should merge or override roles
+              val mainProviderRoleExtension = getProviderRoleExtensions().get(u.managedBy)
+              val otpEnabled                = otpUsers.contains(UserId(u.id))
+
+              val userWithoutPermissions = transformUser(
+                u.id,
+                u.status,
+                TenantAccessGrant.None,
+                Rights(),
+                u,
+                Map(u.managedBy -> JsonProviderInfo.from(Set.empty, Rights(), u.managedBy)),
+                lastSession.map(_.creationDate),
+                otpEnabled
+              )
+
+              file.users.get(u.id) match {
+                case None    => {
+                  // we still need to consider one role extension case : if provider cannot define roles, user cannot have any role
+                  mainProviderRoleExtension match {
+                    case Some(ProviderRoleExtension.None) => userWithoutPermissions.copy(otpEnabled = otpEnabled)
+                    case _                                =>
+                      transformProvidedUser(
+                        u,
+                        TenantAccessGrant.All,
+                        lastSession,
+                        otpEnabled
+                      ) // default value for tenants is "all" if not in file
+                  }
+                }
+                case Some(x) => {
+                  // we need to update the status to the latest one from database
+                  val currentUserDetails = x.copy(status = u.status)
+
+                  // since file definition does not depend on session use the file user as base for file-managed users
+                  val fileProviderInfo = JsonProviderInfo.from(x.roles, x.authz, "file")
+
+                  if (u.managedBy == "file") {
+                    transformUser(
+                      currentUserDetails.getUsername,
+                      currentUserDetails.status,
+                      currentUserDetails.accessGrant,
+                      currentUserDetails.authz,
+                      u,
+                      Map(fileProviderInfo.provider -> fileProviderInfo),
+                      lastSession.map(_.creationDate),
+                      otpEnabled
+                    ).withRoleCoverage(currentUserDetails)
+                  } else {
+                    // we need to merge the two users, the one from the file and the one from the session
+                    mainProviderRoleExtension match {
+                      case Some(ProviderRoleExtension.WithOverride) =>
+                        // Do not recompute roles nor roles coverage, because file roles are overridden by provider roles
+                        transformProvidedUser(u, currentUserDetails.accessGrant, lastSession, otpEnabled)
+                          .addProviderInfo(fileProviderInfo)
+                      case Some(ProviderRoleExtension.NoOverride)   =>
+                        // Merge the previous session roles with the file roles and recompute role coverage over the merge result
+                        transformProvidedUser(u, currentUserDetails.accessGrant, lastSession, otpEnabled)
+                          .merge(fileProviderInfo)
+                          .withRoleCoverage(currentUserDetails)
+                      case Some(ProviderRoleExtension.None)         =>
+                        // Ignore the session roles which may have previously been saved with another role extension mode
+                        userWithoutPermissions
+                          .merge(fileProviderInfo)
+                          .withRoleCoverage(currentUserDetails)
+                      case None                                     =>
+                        // Provider no longer known, fallback to file provider
+                        transformUser(
+                          currentUserDetails.getUsername,
+                          currentUserDetails.status,
+                          currentUserDetails.accessGrant,
+                          currentUserDetails.authz,
+                          u,
+                          Map(fileProviderInfo.provider -> fileProviderInfo),
+                          lastSession.map(_.creationDate),
+                          otpEnabled
+                        ).withRoleCoverage(currentUserDetails)
                     }
                   }
-                  case None                     =>
-                    (None, None).succeed
                 }
-                .map {
-                  case (lastClosedSession, lastSession) =>
-                    implicit val previousLogin: Option[OffsetDateTime] = lastClosedSession.map(_.creationDate)
-
-                    // depending on provider property configuration, we should merge or override roles
-                    val mainProviderRoleExtension = getProviderRoleExtensions().get(u.managedBy)
-
-                    val userWithoutPermissions = transformUser(
-                      u.id,
-                      u.status,
-                      TenantAccessGrant.None,
-                      Rights(),
-                      u,
-                      Map(u.managedBy -> JsonProviderInfo.from(Set.empty, Rights(), u.managedBy)),
-                      lastSession.map(_.creationDate)
-                    )
-
-                    file.users.get(u.id) match {
-                      case None    => {
-                        // we still need to consider one role extension case : if provider cannot define roles, user cannot have any role
-                        mainProviderRoleExtension match {
-                          case Some(ProviderRoleExtension.None) => userWithoutPermissions
-                          case _                                =>
-                            transformProvidedUser(
-                              u,
-                              TenantAccessGrant.All,
-                              lastSession
-                            ) // default value for tenants is "all" if not in file
-                        }
-                      }
-                      case Some(x) => {
-                        // we need to update the status to the latest one from database
-                        val currentUserDetails = x.copy(status = u.status)
-
-                        // since file definition does not depend on session use the file user as base for file-managed users
-                        val fileProviderInfo = JsonProviderInfo.from(x.roles, x.authz, "file")
-
-                        if (u.managedBy == "file") {
-                          transformUser(
-                            currentUserDetails.getUsername,
-                            currentUserDetails.status,
-                            currentUserDetails.accessGrant,
-                            currentUserDetails.authz,
-                            u,
-                            Map(fileProviderInfo.provider -> fileProviderInfo),
-                            lastSession.map(_.creationDate)
-                          ).withRoleCoverage(currentUserDetails)
-                        } else {
-                          // we need to merge the two users, the one from the file and the one from the session
-                          mainProviderRoleExtension match {
-                            case Some(ProviderRoleExtension.WithOverride) =>
-                              // Do not recompute roles nor roles coverage, because file roles are overridden by provider roles
-                              transformProvidedUser(u, currentUserDetails.accessGrant, lastSession)
-                                .addProviderInfo(fileProviderInfo)
-                            case Some(ProviderRoleExtension.NoOverride)   =>
-                              // Merge the previous session roles with the file roles and recompute role coverage over the merge result
-                              transformProvidedUser(u, currentUserDetails.accessGrant, lastSession)
-                                .merge(fileProviderInfo)
-                                .withRoleCoverage(currentUserDetails)
-                            case Some(ProviderRoleExtension.None)         =>
-                              // Ignore the session roles which may have previously been saved with another role extension mode
-                              userWithoutPermissions.merge(fileProviderInfo).withRoleCoverage(currentUserDetails)
-                            case None                                     =>
-                              // Provider no longer known, fallback to file provider
-                              transformUser(
-                                currentUserDetails.getUsername,
-                                currentUserDetails.status,
-                                currentUserDetails.accessGrant,
-                                currentUserDetails.authz,
-                                u,
-                                Map(fileProviderInfo.provider -> fileProviderInfo),
-                                lastSession.map(_.creationDate)
-                              ).withRoleCoverage(currentUserDetails)
-                          }
-                        }
-                      }
-                    }
-                }
-            })
+              }
+            }
+          })
       } yield {
-        serialize(jsonUsers.sortBy(_.id))
+        serialize(jsonUsers.sortBy(_.id), otpEnforced)
       }).chainError("Error when retrieving user list").toLiftResponseOne(params, schema, _ => None)
     }
   }
@@ -592,15 +614,42 @@ class UserManagementApiImpl(
     }
   }
 
+  object ResetUserOtp extends LiftApiModule {
+    val schema: UserManagementApi.ResetUserOtp.type = UserManagementApi.ResetUserOtp
+
+    def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        id:         String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      (for {
+        _ <- totpService.reset(UserId(id))
+      } yield {
+        "ok"
+      }).chainError(s"Could not reset TOTP for user '${id}'").toLiftResponseOne(params, schema, _ => Some(id))
+    }
+  }
+
   def serialize(
-      users: List[JsonUser]
+      users:       List[JsonUser],
+      otpEnforced: Boolean
   ): JsonAuthConfig = {
     // Aggregate all provider properties, if any provider can override user roles then it means there is a global override
     val providerRoleExtensions = getProviderRoleExtensions()
     val roleListOverride       = providerRoleExtensions.values.max
     val providersProperties    = providerRoleExtensions.view.mapValues(_.transformInto[JsonProviderProperty]).toMap
 
-    JsonAuthConfig(roleListOverride, getAuthBackendsProviders(), providersProperties, users, tenantRepository.tenantsEnabled)
+    JsonAuthConfig(
+      roleListOverride,
+      getAuthBackendsProviders(),
+      providersProperties,
+      users,
+      tenantRepository.tenantsEnabled,
+      otpEnforced
+    )
   }
 
   private def transformUser(
@@ -610,7 +659,8 @@ class UserManagementApiImpl(
       authz:         Rights,
       info:          UserInfo,
       providersInfo: Map[String, JsonProviderInfo],
-      lastLogin:     Option[OffsetDateTime]
+      lastLogin:     Option[OffsetDateTime],
+      otpEnabled:    Boolean
   )(implicit previousLogin: Option[OffsetDateTime]): JsonUser = {
     // NoRights and AnyRights directly map to known user permissions. AnyRights takes precedence over NoRights.
     if (authz.authorizationTypes.contains(AuthorizationType.AnyRights)) {
@@ -623,7 +673,8 @@ class UserManagementApiImpl(
         providersInfo,
         getDisplayTenants(nodePerms),
         lastLogin = lastLogin.map(_.toJodaDateTime),
-        previousLogin = previousLogin.map(_.toJodaDateTime)
+        previousLogin = previousLogin.map(_.toJodaDateTime),
+        otpEnabled = otpEnabled
       )
     } else if (authz.authorizationTypes.isEmpty || authz.authorizationTypes.contains(AuthorizationType.NoRights)) {
       JsonUser.noRights(
@@ -635,7 +686,8 @@ class UserManagementApiImpl(
         providersInfo,
         getDisplayTenants(nodePerms),
         lastLogin = lastLogin.map(_.toJodaDateTime),
-        previousLogin = previousLogin.map(_.toJodaDateTime)
+        previousLogin = previousLogin.map(_.toJodaDateTime),
+        otpEnabled = otpEnabled
       )
     } else {
       JsonUser(
@@ -647,7 +699,8 @@ class UserManagementApiImpl(
         providersInfo,
         getDisplayTenants(nodePerms),
         lastLogin = lastLogin.map(_.toJodaDateTime),
-        previousLogin = previousLogin.map(_.toJodaDateTime)
+        previousLogin = previousLogin.map(_.toJodaDateTime),
+        otpEnabled = otpEnabled
       )
     }
   }
@@ -655,7 +708,8 @@ class UserManagementApiImpl(
   implicit def transformDbUserToJsonUser(implicit
       userInfo:      UserInfo,
       nodePerms:     TenantAccessGrant,
-      previousLogin: Option[OffsetDateTime]
+      previousLogin: Option[OffsetDateTime],
+      otpEnabled:    Boolean
   ): Transformer[UserSession, JsonUser] = {
     def getDisplayPermissions(userSession: UserSession): JsonRoles = {
       JsonRoles(userSession.permissions.flatMap {
@@ -693,6 +747,7 @@ class UserManagementApiImpl(
       .withFieldConst(_.tenants, getDisplayTenants(nodePerms))
       .withFieldConst(_.previousLogin, previousLogin.map(_.toJodaDateTime))
       .withFieldConst(_.customRights, JsonRights.empty)
+      .withFieldConst(_.otpEnabled, otpEnabled)
       .buildTransformer
   }
 
@@ -703,7 +758,12 @@ class UserManagementApiImpl(
    * Current user permissions may be different if they have changed since we saved the user info, roles may also no longer exist,
    * so we do not attempt to parse as roles, but we still need to transform roles that are aliases or that are unnamed.
    */
-  private def transformProvidedUser(userInfo: UserInfo, nodePerms: TenantAccessGrant, lastSession: Option[UserSession])(implicit
+  private def transformProvidedUser(
+      userInfo:      UserInfo,
+      nodePerms:     TenantAccessGrant,
+      lastSession:   Option[UserSession],
+      otpEnabled:    Boolean
+  )(implicit
       allRoles:      Set[Role],
       previousLogin: Option[OffsetDateTime]
   ): JsonUser = {
@@ -716,12 +776,14 @@ class UserManagementApiImpl(
           Rights(),
           userInfo,
           Map(userInfo.managedBy -> JsonProviderInfo.from(Set.empty, Rights(), userInfo.managedBy)),
-          lastSession.map(_.creationDate)
+          lastSession.map(_.creationDate),
+          otpEnabled
         )
       }
       case Some(userSession) => {
-        implicit val user:    UserInfo          = userInfo
-        implicit val tenants: TenantAccessGrant = nodePerms
+        implicit val user:          UserInfo          = userInfo
+        implicit val tenants:       TenantAccessGrant = nodePerms
+        implicit val otpEnabledVal: Boolean           = otpEnabled
         userSession.transformInto[JsonUser]
       }
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/TotpService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/TotpService.scala
@@ -1,0 +1,278 @@
+/*
+ * *************************************************************************************
+ * Copyright 2026 Normation SAS
+ * *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * *************************************************************************************
+ */
+package com.normation.rudder.users
+
+import com.bastiaanjansen.otp.*
+import com.normation.errors.*
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
+import com.normation.rudder.users.Totp.*
+import com.normation.utils.DateFormaterService
+import java.net.URI
+import java.time.Instant
+import java.time.ZoneId
+import zio.*
+import zio.json.*
+import zio.syntax.*
+
+/**
+ * Service which has a state of generated OTP and can verify and register them
+ */
+trait TotpService {
+
+  /**
+   * Check if the user needs to enroll (generate) a new OTP secret.
+   * Returns true if the user does not yet have an OTP configured.
+   */
+  def needGeneration(userId: UserId): IOResult[Boolean]
+
+  def generateUserSecret(userId: UserId): IOResult[TotpSecretData]
+
+  /**
+   * Verify the generated one
+   */
+  def verifyGenerated(
+      userId: UserId,
+      code:   String
+  ): IOResult[Totp]
+
+  /**
+   * Reset (delete) the user's TOTP configuration, allowing a new one to be generated.
+   */
+  def reset(userId: UserId): IOResult[Unit]
+
+  /**
+   * Check if OTP is globally enforced for all users.
+   */
+  def getGlobalStatus(): IOResult[Boolean]
+
+  /**
+   * Get the set of users that have an OTP configured.
+   */
+  def getEnabledUsers(): IOResult[Set[UserId]]
+
+  def verify(userId: UserId, code: String): IOResult[Unit]
+}
+
+/**
+ * Status of OTP enrollment for a user
+ */
+case class TotpStatus(
+    needEnrollment: Boolean
+) derives JsonEncoder
+
+private given JsonEncoder[TotpSecret] = JsonEncoder[String].contramap(_.exposeSecret())
+private given JsonEncoder[URI]        = JsonEncoder[String].contramap(_.toString)
+
+/**
+ * Different secret formats to expose
+ */
+case class TotpSecretData(
+    value: TotpSecret,
+    uri:   URI
+) derives JsonEncoder
+
+case class TotpSecretContainer(
+    secret: TotpSecretData
+) derives JsonEncoder
+
+trait TotpSecretGenerator {
+  def generate: IOResult[TotpSecret]
+}
+
+/**
+ * Logic:
+ *  - if user does not exist, reject
+ *  - if user already has one, reject (we only support 1 OTP, to simplify management page, but WRT storage it could be extended to more)
+ */
+class UserTotpValidator(userRepository: UserRepository, totpRepository: TotpRepository) {
+  def validateUserCanCreateTotp(userId: UserId): IOResult[Unit] = {
+    for {
+      _ <- userRepository.get(userId.value).notOptional(s"User '${userId.value}' is not known, cannot create TOTP")
+      _ <- totpRepository.getByUserId(userId).reject {
+             case Some(value) =>
+               Inconsistency(
+                 s"User '${userId.value}' already has a TOTP (created on ${DateFormaterService.getDisplayDate(value.created)}), reset it first to create a new one"
+               )
+           }
+    } yield ()
+  }
+}
+
+sealed private trait TotpVerificator {
+  def verify(secret: TotpSecret, at: Instant, code: String): PureResult[Instant]
+}
+
+/**
+ * Verifies in-memory secrets that have been created upon "request new OTP" from user interface.
+ *
+ * These OTP secrets are not stored until they are verified, since they are not verified, and lost on reboot.
+ *
+ * It could be expired to avoid risking a user having the secret displayed for too long,
+ * therefore the use of a Caffeine cache could be more secure.
+ */
+class InMemoryVerificationTotpService(
+    enabledOtp:     Boolean,
+    in:             Ref[Map[UserId, TotpSecret]],
+    generator:      TotpSecretGenerator,
+    validator:      UserTotpValidator,
+    totpRepository: TotpRepository,
+    verificator:    TotpVerificator
+) extends TotpService {
+  override def needGeneration(userId: UserId): IOResult[Boolean] = {
+    totpRepository.getByUserId(userId).map(_.isEmpty)
+  }
+
+  override def generateUserSecret(userId: UserId): IOResult[TotpSecretData] = {
+    for {
+      _      <- validator.validateUserCanCreateTotp(userId)
+      secret <- generator.generate
+      _      <- in.update(_.updated(userId, secret)) // just forget previously generated secret
+      uri    <- totpUri(userId.value, secret)
+    } yield {
+      TotpSecretData(secret, uri)
+    }
+  }
+
+  override def verifyGenerated(userId: UserId, code: String): IOResult[Totp] = {
+    for {
+      map <- in.get
+      opt  = map.get(userId)
+      s   <- opt.notOptional("User has no known generated TOTP")
+      now <- Clock.instant
+      _   <- verificator.verify(s, now, code).toIO
+      totp = Totp(s, now)
+      _   <-
+        totpRepository
+          .create(userId, totp)
+          .chainError("Could not store user TOTP in Rudder")
+          .tapError(err => ApplicationLoggerPure.Auth.error(s"User '${userId.value}' TOTP registration failed: ${err.fullMsg}"))
+      // on success, user secret can be removed from cache
+      _   <- in.update(_ - userId)
+    } yield {
+      totp
+    }
+  }
+
+  override def verify(userId: UserId, code: String): IOResult[Unit] = {
+    for {
+      t   <- totpRepository.getByUserId(userId).map(_.map(_.secret))
+      s   <- t.notOptional(s"User '${userId.value}' OTP was not found")
+      now <- Clock.instant
+      _   <-
+        verificator.verify(s, now, code).toIO.chainError(s"TOTP secret for user '${userId.value}' does not match provided code")
+    } yield ()
+  }
+
+  override def reset(userId: UserId): IOResult[Unit] = {
+    for {
+      _ <- totpRepository.delete(userId)
+      _ <- in.update(_ - userId)
+    } yield ()
+  }
+
+  override def getGlobalStatus(): IOResult[Boolean] = {
+    enabledOtp.succeed
+  }
+
+  override def getEnabledUsers(): IOResult[Set[UserId]] = {
+    totpRepository.getEnabledUsers()
+  }
+
+}
+
+private def totpUri(userId: String, secret: TotpSecret): IOResult[URI] = {
+  val query = s"secret=${secret.exposeSecret()}&issuer=Rudder"
+  // this URI constructor handles encoding
+  IOResult.attempt(URI("otpauth", "totp", s"/Rudder:${userId}", query, null))
+}
+
+object OtpJavaTotpService {
+
+  /** Default TOTP period: 30 seconds */
+  private val DEFAULT_PERIOD: Duration = 30.seconds
+
+  /** Verification delay window: accept codes valid for 1 previous/next window (±30s tolerance) */
+  private val DEFAULT_DELAY_WINDOW: Int = 1
+
+  /** Generates a cryptographically secure base32-encoded TOTP secret using otp-java */
+  private class OtpJavaSecretGenerator extends TotpSecretGenerator {
+    override def generate: IOResult[TotpSecret] = {
+      val secret = SecretGenerator.generate()
+      TotpSecret(new String(secret)).succeed
+    }
+  }
+
+  /** Verifies TOTP codes using otp-java TOTPGenerator with configurable delay window */
+  private class OtpJavaTotpVerificator extends TotpVerificator {
+    override def verify(secret: TotpSecret, at: Instant, code: String): PureResult[Instant] = {
+      val totp = TOTPGenerator
+        .Builder(secret.exposeSecret())
+        .withClock(java.time.Clock.fixed(at, ZoneId.systemDefault()))
+        .withPeriod(DEFAULT_PERIOD)
+        .build
+
+      val valid = totp.verify(code, DEFAULT_DELAY_WINDOW)
+
+      if (valid) Right(at)
+      else {
+        Left(
+          Inconsistency(
+            s"Invalid TOTP code submitted at ${DateFormaterService.getDisplayDate(at)}, code is wrong or may be too old"
+          )
+        )
+      }
+    }
+  }
+
+  def make(
+      enabledOtp:     Boolean,
+      validator:      UserTotpValidator,
+      totpRepository: TotpRepository
+  ): UIO[InMemoryVerificationTotpService] = {
+    Ref
+      .make(Map.empty[UserId, TotpSecret])
+      .map(
+        InMemoryVerificationTotpService(
+          enabledOtp,
+          _,
+          OtpJavaSecretGenerator(),
+          validator,
+          totpRepository,
+          OtpJavaTotpVerificator()
+        )
+      )
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
@@ -41,6 +41,8 @@ import com.normation.rudder.AuthorizationType
 import com.normation.rudder.Rights
 import com.normation.rudder.Role
 import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.rest.AuthzForApi
+import com.normation.rudder.rest.OtpApi
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.rudder.users.UserPassword.HashedUserPassword
@@ -78,14 +80,51 @@ object RudderAuthType {
     Seq(new SimpleGrantedAuthority(s): GrantedAuthority).asJavaCollection
   }
 
-  case object User extends RudderAuthType {
+  case object PreAuthUser extends RudderAuthType {
+    override val grantedAuthorities: Collection[GrantedAuthority] = buildAuthority("ROLE_PRE_AUTH")
+  }
+  case object User        extends RudderAuthType {
     override val grantedAuthorities: Collection[GrantedAuthority] = buildAuthority("ROLE_USER")
   }
-  case object Api  extends RudderAuthType {
+  case object Api         extends RudderAuthType {
     override val grantedAuthorities: Collection[GrantedAuthority] = buildAuthority("ROLE_REMOTE")
 
     val apiRudderRights = Rights.NoRights
     val apiRudderRole: Set[Role] = Set(Role.NoRights)
+  }
+}
+
+/**
+ * A user in pending authentication, bound with [[RudderAuthType.PreAuthUser]] authorities.
+ * Such user is set on SpringSecurity context and upon retrieval should be handled as a non-fully authenticated user,
+ * until authentication is finished.
+ * Useful for MFA cases.
+ */
+final case class RudderPreAuthUser(authenticatingUser: RudderUserDetail) extends AuthenticatedUser with UserDetails {
+  // We need to provide minimal API authorizations to generate and get info from OTP API
+  // Only initial api authz need to be overridden, others should not be for authz check during MFA authentication flow
+  export authenticatingUser.accessGrant
+  export authenticatingUser.account
+  export authenticatingUser.actorIp
+  export authenticatingUser.authz
+  export authenticatingUser.checkRights
+  export authenticatingUser.getPassword
+  export authenticatingUser.getUsername
+  export authenticatingUser.roles
+  export authenticatingUser.status
+
+  override val apiAuthz: ApiAuthorization = {
+    ApiAuthorization.ACL(OtpApi.values.map(AuthzForApi(_)).toList)
+  }
+
+  override val getAuthorities: Collection[GrantedAuthority] = RudderAuthType.PreAuthUser.grantedAuthorities
+}
+
+extension (rudderUser: RudderPreAuthUser | RudderUserDetail) {
+  // Used in UserInformation snippet, actually unused since pre-auth user has no access to page
+  def roles: Set[Role] = rudderUser match {
+    case u: RudderPreAuthUser => u.roles
+    case u: RudderUserDetail  => u.roles
   }
 }
 
@@ -154,7 +193,7 @@ case class RudderUserDetail(
  * We can't use ContainerVar because spring migrates jetty session and we don't want
  * to impose a MigratingSession to everything just to that variable.
  */
-object CurrentUser extends RequestVar[Option[RudderUserDetail]](None) with UserService {
+object CurrentUser extends RequestVar[Option[RudderUserDetail | RudderPreAuthUser]](None) with UserService {
   // it's ok if that request var is not read in all/most request - but it must be
   // set in case it's needed.
   override def logUnreadVal = false

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -128,6 +128,7 @@ final case class JsonAuthConfig(
     providerProperties:     Map[String, JsonProviderProperty],
     users:                  List[JsonUser],
     tenantsEnabled:         Boolean,
+    otpEnabled:             Boolean,
     digest:                 PasswordEncoderType = PasswordEncoderType.DEFAULT // default value
 )
 
@@ -217,7 +218,8 @@ final case class JsonUser(
     providersInfo:                   Map[String, JsonProviderInfo],
     tenants:                         String,
     lastLogin:                       Option[DateTime],
-    previousLogin:                   Option[DateTime]
+    previousLogin:                   Option[DateTime],
+    otpEnabled:                      Boolean
 ) {
   def merge(providerInfo: JsonProviderInfo): JsonUser = {
     JsonUser(
@@ -229,7 +231,8 @@ final case class JsonUser(
       providersInfo + (providerInfo.provider -> providerInfo),
       tenants,
       lastLogin,
-      previousLogin
+      previousLogin,
+      otpEnabled
     )
   }
 
@@ -275,7 +278,8 @@ object JsonUser {
       providersInfo: Map[String, JsonProviderInfo],
       tenants:       String,
       lastLogin:     Option[DateTime],
-      previousLogin: Option[DateTime]
+      previousLogin: Option[DateTime],
+      otpEnabled:    Boolean
   ): JsonUser = {
     JsonUser(
       username,
@@ -291,7 +295,8 @@ object JsonUser {
       providersInfo,
       tenants,
       lastLogin,
-      previousLogin
+      previousLogin,
+      otpEnabled
     )
   }
   def anyRights(
@@ -303,7 +308,8 @@ object JsonUser {
       providersInfo: Map[String, JsonProviderInfo],
       tenants:       String,
       lastLogin:     Option[DateTime],
-      previousLogin: Option[DateTime]
+      previousLogin: Option[DateTime],
+      otpEnabled:    Boolean
   ): JsonUser = {
     JsonUser(
       username,
@@ -319,7 +325,8 @@ object JsonUser {
       providersInfo,
       tenants,
       lastLogin,
-      previousLogin
+      previousLogin,
+      otpEnabled
     )
   }
 
@@ -333,7 +340,8 @@ object JsonUser {
       providersInfo: Map[String, JsonProviderInfo],
       tenants:       String,
       lastLogin:     Option[DateTime],
-      previousLogin: Option[DateTime]
+      previousLogin: Option[DateTime],
+      otpEnabled:    Boolean
   ): JsonUser = {
     val authz        = providersInfo.values.map(_.authz).foldLeft(JsonRights.empty)(_ ++ _)
     val roles        = providersInfo.values.map(_.roles).foldLeft(JsonRoles.empty)(_ ++ _)
@@ -353,7 +361,8 @@ object JsonUser {
       providersInfo,
       tenants,
       lastLogin,
-      previousLogin
+      previousLogin,
+      otpEnabled
     )
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
@@ -96,7 +96,8 @@ response:
                 "customRights" : []
               }
             },
-            "tenants" : "zoneA"
+            "tenants" : "zoneA",
+            "otpEnabled" : false
           },
           {
             "login" : "user2",
@@ -159,7 +160,8 @@ response:
             },
             "tenants" : "all",
             "lastLogin" : "2024-02-29T00:00:00Z",
-            "previousLogin" : "2024-02-28T12:34:00Z"
+            "previousLogin" : "2024-02-28T12:34:00Z",
+            "otpEnabled" : false
           },
           {
             "login" : "user3",
@@ -184,10 +186,12 @@ response:
                 "customRights" : []
               }
             },
-            "tenants" : "none"
+            "tenants" : "none",
+            "otpEnabled" : false
           }
         ],
         "tenantsEnabled" : false,
+        "otpEnabled" : false,
         "digest" : "ARGON2ID"
       }
     }
@@ -523,7 +527,8 @@ response:
                 "customRights" : []
               }
             },
-            "tenants" : "zoneA"
+            "tenants" : "zoneA",
+            "otpEnabled" : false
           },
           {
             "login" : "user2",
@@ -586,7 +591,8 @@ response:
             },
             "tenants" : "all",
             "lastLogin" : "2024-02-29T00:00:00Z",
-            "previousLogin" : "2024-02-28T12:34:00Z"
+            "previousLogin" : "2024-02-28T12:34:00Z",
+            "otpEnabled" : false
           },
           {
             "login" : "user3",
@@ -611,10 +617,12 @@ response:
                 "customRights" : []
               }
             },
-            "tenants" : "none"
+            "tenants" : "none",
+            "otpEnabled" : false
           }
         ],
         "tenantsEnabled" : false,
+        "otpEnabled" : false,
         "digest" : "ARGON2ID"
         }
       }
@@ -688,7 +696,8 @@ response:
                 "customRights" : []
               }
             },
-            "tenants" : "zoneA"
+            "tenants" : "zoneA",
+            "otpEnabled" : false
           },
           {
             "login" : "user2",
@@ -751,7 +760,8 @@ response:
             },
             "tenants" : "all",
             "lastLogin" : "2024-02-29T00:00:00Z",
-            "previousLogin" : "2024-02-28T12:34:00Z"
+            "previousLogin" : "2024-02-28T12:34:00Z",
+            "otpEnabled" : false
           },
           {
             "login" : "user3",
@@ -776,10 +786,12 @@ response:
                 "customRights" : []
               }
             },
-            "tenants" : "none"
+            "tenants" : "none",
+            "otpEnabled" : false
           }
         ],
         "tenantsEnabled" : false,
+        "otpEnabled" : false,
         "digest" : "ARGON2ID"
         }
       }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -1050,6 +1050,16 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       } else Empty
     }
   }
+  val otpService = new TotpService {
+    override def getEnabledUsers(): IOResult[Set[UserId]] = Set.empty.succeed
+    override def getGlobalStatus(): IOResult[Boolean]     = false.succeed
+
+    override def needGeneration(userId:     UserId): IOResult[Boolean] = ???
+    override def generateUserSecret(userId: UserId): IOResult[TotpSecretData] = ???
+    override def verifyGenerated(userId:    UserId, code: String): IOResult[Totp] = ???
+    override def reset(userId:              UserId): IOResult[Unit] = ???
+    override def verify(userId:             UserId, code: String): IOResult[Unit] = ???
+  }
 
   val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema & SortIndex]] = List(
     systemApi,
@@ -1110,6 +1120,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       mockUserManagement.fileUserDetailListProvider,
       mockUserManagement.userManagementService,
       mockTenants.tenantRepo,
+      otpService,
       () => mockUserManagement.providerRoleExtension,
       () => mockUserManagement.authBackendProviders
     ),

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
@@ -41,10 +41,22 @@ class UserSerializationTest extends Specification {
         providersInfo,
         "",
         None,
-        None
+        None,
+        false
       )
 
-      JsonUser("user", None, None, Json.Obj(), UserStatus.Active, providersInfo, "", None, None) must beEqualTo(expected)
+      JsonUser(
+        "user",
+        None,
+        None,
+        Json.Obj(),
+        UserStatus.Active,
+        providersInfo,
+        "",
+        None,
+        None,
+        false
+      ) must beEqualTo(expected)
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
@@ -53,7 +53,8 @@
             "toastal/either": "3.6.3",
             "visotype/elm-dom": "1.1.3",
             "webbhuset/elm-json-decode": "1.2.0",
-            "zwilias/elm-html-string": "2.0.2"
+            "zwilias/elm-html-string": "2.0.2",
+            "pablohirafuji/elm-qrcode": "4.0.3"
         },
         "indirect": {
             "NoRedInk/elm-string-conversions": "1.0.1",
@@ -62,7 +63,10 @@
             "TSFoster/elm-sha1": "2.1.1",
             "danfishgold/base64-bytes": "1.1.0",
             "kuon/elm-string-normalize": "1.0.6",
-            "rtfeldman/elm-hex": "1.0.0"
+            "rtfeldman/elm-hex": "1.0.0",
+            "avh4/elm-color": "1.0.0",
+            "folkertdev/elm-flate": "2.0.6",
+            "justgook/elm-image": "5.0.0"
         }
     },
     "test-dependencies": {

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp.elm
@@ -1,0 +1,219 @@
+module Otp exposing (..)
+
+import Browser
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Http.Detailed as Detailed
+import Json.Decode exposing (decodeString, string)
+import List
+import Maybe.Extra
+import Otp.ApiCalls exposing (..)
+import Otp.DataTypes exposing (..)
+import Otp.Init exposing (..)
+import Otp.JsonDecoder exposing (..)
+import Otp.View exposing (..)
+import Result
+import String
+import Url exposing (Url)
+import Url.Parser as Parser exposing ((</>), (<?>), Parser, parse, query, top)
+import Url.Parser.Query as Query
+
+
+
+-- MAIN
+
+
+main : Program Flags Model Msg
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.batch
+        [ readUrl UrlChanged ]
+
+
+
+-- UPDATE
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        SetCode code ->
+            ( { model | code = code }, Cmd.none )
+
+        GenerateOtp ->
+            ( { model | isLoading = True }, generateOtp model )
+
+        VerifyOtp code ->
+            ( { model | isLoading = True }, verifyOtp model code )
+
+        OtpStatusResponse result ->
+            case result of
+                Ok ( _, status ) ->
+                    ( { model | needEnrollment = Just status, isLoading = False }, Cmd.none )
+
+                Err err ->
+                    processApiError "Failed to fetch OTP status" err model
+
+        GenerateResponse result ->
+            case result of
+                Ok ( _, resp ) ->
+                    ( { model | isLoading = False, needEnrollment = Just True, generatedSecret = Just resp.secret }, Cmd.none )
+
+                Err err ->
+                    processApiError "Failed to generate OTP secret" err model
+
+        VerifyResponse result ->
+            case result of
+                Ok _ ->
+                    case model.redirectUrl of
+                        Just url ->
+                            ( model, pushUrl url )
+
+                        Nothing ->
+                            ( model, pushUrl <| model.contextPath ++ "/secure/index.html" )
+
+                Err (Detailed.BadStatus metadata errMsg) ->
+                    case metadata.statusCode of
+                        -- Handled verification error case on server
+                        403 ->
+                            ( { model | isLoading = False, errorMsg = Just errMsg }, Cmd.none )
+
+                        code ->
+                            ( { model | isLoading = False, errorMsg = Just <| "Error when verifying OTP code: unexpected server response " ++ String.fromInt code }, Cmd.none )
+
+                Err _ ->
+                    ( { model | isLoading = False, errorMsg = Just "Error when verifying OTP code" }, Cmd.none )
+
+        UrlChanged url ->
+            case Url.fromString url of
+                Just parsedUrl ->
+                    let
+                        validated =
+                            parseRedirect parsedUrl
+                                |> Maybe.andThen (validateRedirect parsedUrl)
+                    in
+                    case validated of
+                        Just redirect ->
+                            ( { model | redirectUrl = Just redirect }, Cmd.none )
+
+                        Nothing ->
+                            ( { model | redirectUrl = Just <| Url.toString { parsedUrl | path = model.contextPath ++ "/secure/index.html" } }, Cmd.none )
+
+                Nothing ->
+                    ( model, Cmd.none )
+
+
+parseRedirect : Url -> Maybe String
+parseRedirect url =
+    let
+        -- 1. Force the path to "/" so it matches Parser.top, ignoring the 3 segments
+        normalizedUrl =
+            { url | path = "/" }
+
+        -- 2. Create a parser that targets the "redirect" query parameter
+        redirectParser =
+            Parser.map identity (Parser.top <?> Query.string "redirect")
+    in
+    -- 3. Run the parser and flatten the resulting Maybe (Maybe String) into Maybe String
+    Parser.parse redirectParser normalizedUrl
+        |> Maybe.andThen identity
+
+
+validateRedirect : Url -> String -> Maybe String
+validateRedirect originalUrl redirectStr =
+    case Url.fromString redirectStr of
+        Just redirectUrl ->
+            let
+                isSameProtocol =
+                    redirectUrl.protocol == originalUrl.protocol
+
+                isSameHost =
+                    redirectUrl.host == originalUrl.host
+
+                isSamePort =
+                    redirectUrl.port_ == originalUrl.port_
+            in
+            if isSameProtocol && isSameHost && isSamePort then
+                Just redirectStr
+
+            else
+                Nothing
+
+        Nothing ->
+            Nothing
+
+
+
+{- Consumes all path segments, to ignore them -}
+
+
+anyPath =
+    Parser.custom "ANY_PATH" <| \a -> Just [ a ]
+
+
+
+-- Generic API error handler
+
+
+processApiError : String -> Detailed.Error String -> Model -> ( Model, Cmd Msg )
+processApiError msg err model =
+    let
+        message =
+            case err of
+                Detailed.BadUrl url ->
+                    "The URL " ++ url ++ " was invalid"
+
+                Detailed.Timeout ->
+                    "Unable to reach the server, try again"
+
+                Detailed.NetworkError ->
+                    "Unable to reach the server, check your network connection"
+
+                Detailed.BadStatus metadata body ->
+                    let
+                        ( title, errors ) =
+                            decodeErrorDetails body
+                    in
+                    title ++ "\n" ++ errors
+
+                Detailed.BadBody metadata body m ->
+                    m
+    in
+    ( model, errorNotification (msg ++ ", details: \n" ++ message) )
+
+
+decodeErrorDetails : String -> ( String, String )
+decodeErrorDetails json =
+    let
+        errorMsg =
+            decodeString (Json.Decode.at [ "errorDetails" ] string) json
+
+        msg =
+            case errorMsg of
+                Ok s ->
+                    s
+
+                Err e ->
+                    "fail to process errorDetails"
+
+        errors =
+            String.split "<-" msg
+
+        title =
+            List.head errors
+    in
+    case title of
+        Nothing ->
+            ( "", "" )
+
+        Just s ->
+            ( s, String.join " \n " (List.drop 1 (List.map (\err -> "\t ‣ " ++ err) errors)) )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/ApiCalls.elm
@@ -1,0 +1,64 @@
+module Otp.ApiCalls exposing (..)
+
+import Http exposing (expectStringResponse, header)
+import Http.Detailed as Detailed
+import Json.Encode as J
+import Otp.DataTypes exposing (..)
+import Otp.JsonDecoder exposing (..)
+import Url
+import Url.Builder
+
+
+apiBaseUrl : Model -> String
+apiBaseUrl m =
+    Url.Builder.relative (m.contextPath :: "secure" :: "api" :: []) []
+
+
+fetchOtpStatus : Model -> Cmd Msg
+fetchOtpStatus model =
+    Http.request
+        { method = "GET"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = Url.Builder.relative (model.contextPath :: "secure" :: "api" :: "otp" :: "status" :: []) []
+        , body = Http.emptyBody
+        , expect = Detailed.expectJson OtpStatusResponse decodeStatus
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+generateOtp : Model -> Cmd Msg
+generateOtp model =
+    Http.request
+        { method = "POST"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = Url.Builder.relative (model.contextPath :: "secure" :: "api" :: "otp" :: "generate" :: []) []
+        , body = Http.emptyBody
+        , expect = Detailed.expectJson GenerateResponse decodeGenerate
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+verifyOtp : Model -> String -> Cmd Msg
+verifyOtp model code =
+    let
+        body =
+            Http.stringBody "application/x-www-form-urlencoded" ("code=" ++ Url.percentEncode code)
+    in
+    Http.request
+        { method = "POST"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = Url.Builder.relative (model.contextPath :: "secure" :: "otp" :: "verify" :: []) []
+        , body = body
+        , expect = expectWhateverStringError VerifyResponse
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+{-| Expect for a result that is ignored, but a BadStatus that needs to be read as String (e.g. JSON response from API)
+-}
+expectWhateverStringError : (Result (Detailed.Error String) () -> msg) -> Http.Expect msg
+expectWhateverStringError toMsg =
+    expectStringResponse (Result.map (\_ -> ()) >> toMsg) Detailed.responseToString

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/DataTypes.elm
@@ -1,0 +1,55 @@
+module Otp.DataTypes exposing (..)
+
+import Http exposing (Error)
+import Http.Detailed as Detailed
+
+
+
+-- Secret data from the generate endpoint
+
+
+type alias TotpSecretData =
+    { value : String
+    , uri : String
+    }
+
+
+
+-- Container wrapping TotpSecretData
+
+
+type alias TotpSecretContainer =
+    { secret : TotpSecretData }
+
+
+
+-- Response from the generate endpoint
+
+
+type alias GenerateResponse =
+    TotpSecretContainer
+
+
+
+-- Request to verify OTP code
+
+
+type alias Model =
+    { contextPath : String
+    , needEnrollment : Maybe Bool
+    , generatedSecret : Maybe TotpSecretData
+    , code : String
+    , errorMsg : Maybe String
+    , isLoading : Bool
+    , redirectUrl : Maybe String
+    }
+
+
+type Msg
+    = SetCode String
+    | GenerateOtp
+    | VerifyOtp String
+    | OtpStatusResponse (Result (Detailed.Error String) ( Http.Metadata, Bool ))
+    | GenerateResponse (Result (Detailed.Error String) ( Http.Metadata, GenerateResponse ))
+    | VerifyResponse (Result (Detailed.Error String) ())
+    | UrlChanged String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/Init.elm
@@ -1,0 +1,40 @@
+port module Otp.Init exposing (..)
+
+import Otp.ApiCalls exposing (fetchOtpStatus)
+import Otp.DataTypes exposing (..)
+
+
+
+-- PORT
+
+
+port errorNotification : String -> Cmd msg
+
+
+port pushUrl : String -> Cmd msg
+
+
+port readUrl : (String -> msg) -> Sub msg
+
+
+type alias Flags =
+    { contextPath : String }
+
+
+init : Flags -> ( Model, Cmd Msg )
+init flags =
+    let
+        initModel =
+            { contextPath = flags.contextPath
+            , needEnrollment = Nothing
+            , generatedSecret = Nothing
+            , code = ""
+            , errorMsg = Nothing
+            , isLoading = False
+            , redirectUrl = Nothing
+            }
+
+        initActions =
+            fetchOtpStatus initModel
+    in
+    ( initModel, initActions )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/JsonDecoder.elm
@@ -1,0 +1,45 @@
+module Otp.JsonDecoder exposing (..)
+
+import Http.Detailed as Detailed
+import Json.Decode as D
+import Json.Decode.Pipeline exposing (required)
+import Otp.DataTypes exposing (..)
+
+
+
+-- Decode status response: { action, result, data: { needEnrollment: Bool } }
+
+
+decodeStatus : D.Decoder Bool
+decodeStatus =
+    D.at [ "data", "needEnrollment" ] D.bool
+
+
+
+-- Decode secret data: { value, uri }
+
+
+decodeTotpSecretData : D.Decoder TotpSecretData
+decodeTotpSecretData =
+    D.succeed TotpSecretData
+        |> required "value" D.string
+        |> required "uri" D.string
+
+
+
+-- Decode secret container: { secret: { value, uri } }
+
+
+decodeTotpSecretContainer : D.Decoder TotpSecretContainer
+decodeTotpSecretContainer =
+    D.succeed TotpSecretContainer
+        |> required "secret" decodeTotpSecretData
+
+
+
+-- Decode generate response: { action, result, data: { secret: { value, uri } } }
+
+
+decodeGenerate : D.Decoder GenerateResponse
+decodeGenerate =
+    D.at [ "data" ] decodeTotpSecretContainer

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/View.elm
@@ -1,0 +1,130 @@
+module Otp.View exposing (..)
+
+import Browser.Events exposing (onKeyDown)
+import Html exposing (..)
+import Html.Attributes exposing (class, disabled, placeholder, size, type_, value)
+import Html.Events exposing (onClick, onInput)
+import Html.Events.Extra exposing (onEnter)
+import Maybe.Extra
+import Otp.DataTypes exposing (..)
+import QRCode
+import Svg
+import Svg.Attributes as SvgA
+
+
+
+-- View
+
+
+view : Model -> Html Msg
+view model =
+    div [ class "otp-container" ]
+        [ h1 [ class "fs-3" ] [ text "Two-factor authentication" ]
+        , hr [] []
+        , enrollmentBanner model
+        , actions model
+        ]
+
+
+enrollmentBanner : Model -> Html Msg
+enrollmentBanner model =
+    case model.needEnrollment of
+        Just True ->
+            div [ class "alert alert-warning mt-3" ]
+                [ i [ class "fa fa-warning me-2" ] []
+                , text "You need to enable a two-factor authentication. Generate a TOTP secret for your authenticator app below."
+                ]
+
+        _ ->
+            div [ class "alert alert-info d-flex justify-content-center" ]
+                [ text "TOTP code verification required for login" ]
+
+
+actions : Model -> Html Msg
+actions model =
+    let
+        showEnrollment =
+            Maybe.Extra.isNothing model.generatedSecret
+                && (model.needEnrollment
+                        |> Maybe.withDefault False
+                   )
+    in
+    div [ class "d-flex flex-column align-items-center" ]
+        [ case model.errorMsg of
+            Just msg ->
+                div [ class "alert alert-danger" ]
+                    [ text msg ]
+
+            Nothing ->
+                text ""
+        , if showEnrollment then
+            div [ class "d-flex justify-content-center" ]
+                [ button
+                    [ class "btn btn-primary my-3"
+                    , disabled model.isLoading
+                    , onClick GenerateOtp
+                    ]
+                    [ if model.isLoading then
+                        text "Generating..."
+
+                      else
+                        text "Generate TOTP"
+                    ]
+                ]
+
+          else
+            text ""
+        , case model.generatedSecret of
+            Just secret ->
+                div [ class "mt-3 d-flex flex-column align-items-center" ]
+                    [ h2 [ class "fs-5" ] [ text "Scan QR Code with your authenticator app" ]
+                    , qrCodeView secret.uri
+                    , div [ class "mt-2 d-flex flex-column align-items-center" ]
+                        [ label [] [ text "Or enter this key manually:" ]
+                        , pre [] [ text secret.value ]
+                        ]
+                    ]
+
+            Nothing ->
+                text ""
+        , if showEnrollment then
+            text ""
+
+          else
+            div [ class "mt-3 d-flex flex-column align-items-center" ]
+                [ input
+                    [ class "form-control mb-2"
+                    , type_ "text"
+                    , placeholder "Enter 6-digit code"
+                    , value model.code
+                    , size 12
+                    , onInput SetCode
+                    , onEnter (VerifyOtp model.code)
+                    ]
+                    []
+                , button
+                    [ class "my-3 px-4 btn btn-success"
+                    , disabled (model.code == "" || model.isLoading)
+                    , onClick (VerifyOtp model.code)
+                    ]
+                    [ if model.isLoading then
+                        text "Verifying..."
+
+                      else
+                        text "Verify"
+                    ]
+                ]
+        ]
+
+
+qrCodeView : String -> Html Msg
+qrCodeView input =
+    QRCode.fromString input
+        |> Result.map
+            (QRCode.toSvg
+                [ SvgA.width "200px"
+                , SvgA.height "200px"
+                ]
+            )
+        |> Result.withDefault
+            (Html.text "")

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement.elm
@@ -5,7 +5,7 @@ import Dict exposing (fromList)
 import Http exposing (..)
 import List
 import String exposing (isEmpty)
-import UserManagement.ApiCalls exposing (activateUser, addUser, disableUser, getRoleConf, getUsersConf, postReloadConf, updateUser, updateUserInfo)
+import UserManagement.ApiCalls exposing (activateUser, addUser, disableUser, getRoleConf, getUsersConf, postReloadConf, resetUserOtp, updateUser, updateUserInfo)
 import UserManagement.DataTypes exposing (AddUserForm, Model, Msg(..), PanelMode(..), StateInput(..), UserAuth, mergeUserNewInfo, userProviders, userToUserInfoForm)
 import UserManagement.Init exposing (init, subscriptions)
 import UserManagement.View exposing (view)
@@ -66,7 +66,7 @@ update msg model =
                             { ui | panelMode = newPanelMode }
 
                         newModel =
-                            { model | roleListOverride = u.roleListOverride, users = users, ui = newUI, digest = u.digest, providers = userProviders u.authenticationBackends, providersProperties = u.providersProperties, tenantsEnabled = u.tenantsEnabled }
+                            { model | roleListOverride = u.roleListOverride, users = users, ui = newUI, digest = u.digest, providers = userProviders u.authenticationBackends, providersProperties = u.providersProperties, tenantsEnabled = u.tenantsEnabled, otpEnabled = u.otpEnabled }
                     in
                     ( newModel, getRoleConf model )
 
@@ -448,6 +448,14 @@ update msg model =
 
         DisableUser username ->
             ( model, disableUser model username )
+
+        ResetUserOtp username result ->
+            case result of
+                Ok () ->
+                    ( model, Cmd.batch [ getUsersConf model, successNotification ("OTP successfully reset for " ++ username) ] )
+
+                Err err ->
+                    processApiError err model
 
         PreHashedPasswd bool ->
             let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/ApiCalls.elm
@@ -168,3 +168,20 @@ getRoleConf model =
                 }
     in
     req
+
+
+resetUserOtp : Model -> Username -> Cmd Msg
+resetUserOtp model username =
+    let
+        req =
+            request
+                { method = "POST"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model ("/usermanagement/otp/reset/" ++ username)
+                , body = emptyBody
+                , expect = expectWhatever (ResetUserOtp username)
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
+    req

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/DataTypes.elm
@@ -81,6 +81,7 @@ type alias User =
     , tenants : String
     , lastLogin : Maybe String
     , previousLogin : Maybe String
+    , otpEnabled : Bool
     }
 
 
@@ -214,6 +215,7 @@ type alias UsersConf =
     , providersProperties : Dict String ProviderProperties
     , users : List User
     , tenantsEnabled : Bool
+    , otpEnabled : Bool
     }
 
 
@@ -246,6 +248,7 @@ type alias Model =
     , userId : String
     , digest : String
     , tenantsEnabled : Bool
+    , otpEnabled : Bool
     , users : Users
     , roles : Roles
     , rolesConf : RoleConf -- from API
@@ -269,6 +272,7 @@ type SortBy
     | Providers
     | Tenants
     | PreviousLogin
+    | OtpEnabled
 
 
 type alias TableFilters =
@@ -295,6 +299,7 @@ type Msg
     | UpdateUser (Result Error String)
     | UpdateUserInfo (Result Error ())
     | UpdateUserStatus (Result Error Username)
+    | ResetUserOtp Username (Result Error ())
     | CallApi (Model -> Cmd Msg)
     | ActivePanelSettings User
     | ActivePanelAddUser

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/Init.elm
@@ -25,7 +25,7 @@ init flags =
             UserForm "" "" True False [] initUserInfoForm [] ValidInputs
 
         initModel =
-            Model flags.contextPath flags.userId "" False (fromList []) (fromList []) [] None initUserForm initUi [] Dict.empty
+            Model flags.contextPath flags.userId "" False False (fromList []) (fromList []) [] None initUserForm initUi [] Dict.empty
     in
     ( initModel
     , getUsersConf initModel

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
@@ -34,6 +34,7 @@ decodeCurrentUsersConf =
         |> required "providerProperties" (D.dict decodeProviderProperties)
         |> required "users" (D.list <| decodeUser)
         |> required "tenantsEnabled" D.bool
+        |> required "otpEnabled" D.bool
 
 
 decodeProviderProperties : Decoder ProviderProperties
@@ -94,6 +95,7 @@ decodeUser =
         |> required "tenants" D.string
         |> optional "lastLogin" (D.maybe D.string) Nothing
         |> optional "previousLogin" (D.maybe D.string) Nothing
+        |> required "otpEnabled" D.bool
 
 
 decodeUserStatus : Decoder UserStatus

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
@@ -12,7 +12,7 @@ import Maybe.Extra exposing (isJust)
 import NaturalOrdering as N
 import Set
 import String exposing (isEmpty)
-import UserManagement.ApiCalls exposing (deleteUser)
+import UserManagement.ApiCalls exposing (deleteUser, resetUserOtp)
 import UserManagement.DataTypes exposing (..)
 import Utils.TooltipUtils exposing (buildTooltipContent)
 
@@ -90,6 +90,47 @@ hashPasswordMenu isHashedPasswd =
     div [ class "btn-group", attribute "role" "group" ]
         [ a [ class ("btn btn-default " ++ clearPasswdIsActivate), onClick (PreHashedPasswd False) ] [ text "Password to hash" ]
         , a [ class ("btn btn-default " ++ hashPasswdIsActivate), onClick (PreHashedPasswd True) ] [ text "Enter pre-hashed value" ]
+        ]
+
+
+displayOtpBlock : Model -> User -> Html Msg
+displayOtpBlock ({ otpEnabled } as model) user =
+    let
+        title =
+            h3 [] [ text "TOTP" ]
+
+        content =
+            if user.otpEnabled then
+                div []
+                    [ p []
+                        [ if otpEnabled then
+                            em [] [ text "Reset user TOTP to enable them register on next login:" ]
+
+                          else
+                            em [] [ text "Login with TOTP is globally disabled, reset of user OTP will have no effect until it is enabled:" ]
+                        ]
+                    , button
+                        [ class "btn btn-danger"
+                        , type_ "button"
+                        , onClick (CallApi (\_ -> resetUserOtp model user.login))
+                        ]
+                        [ text "Reset", i [ class "ms-2 fa fa-repeat fa-flip-horizontal" ] [] ]
+                    ]
+
+            else
+                div [ class "alert alert-warning" ]
+                    [ i [ class "fa fa-exclamation-triangle" ] []
+                    , text "User has no TOTP registered."
+                    , if otpEnabled then
+                        p [] [ text "User will be asked to register TOTP on their next login." ]
+
+                      else
+                        text ""
+                    ]
+    in
+    div []
+        [ title
+        , content
         ]
 
 
@@ -498,6 +539,8 @@ displayRightPanel model user =
                             [ em [] [ text ("Previous login: " ++ String.replace "T" " " l) ] ]
                     )
                 ]
+             , displayOtpBlock model user
+             , hr [] []
              , displayPasswordBlock model (Just user)
              ]
                 ++ displayedProviders
@@ -892,6 +935,15 @@ displayUsersTable model users =
                     [ displayUserPreviousLogin user
                     ]
                 , td []
+                    [ text
+                        (if user.otpEnabled then
+                            "✓"
+
+                         else
+                            "-"
+                        )
+                    ]
+                , td []
                     [ button
                         [ class "btn btn-default"
                         , onClick (ActivePanelSettings user)
@@ -933,18 +985,19 @@ displayUsersTable model users =
                   else
                     text ""
                 , th [ class (thClass model.ui.tableFilters PreviousLogin), onClick (UpdateTableFilters (sortTable filters PreviousLogin)) ] [ text "Previous login" ]
+                , th [ class (thClass model.ui.tableFilters OtpEnabled), onClick (UpdateTableFilters (sortTable filters OtpEnabled)) ] [ text "TOTP" ]
                 , th [ style "width" "220px" ] [ text "Actions" ]
                 ]
             ]
         , tbody []
             (if Dict.isEmpty model.users then
                 [ tr []
-                    [ td [ class "empty", colspan 7 ] [ i [ class "fa fa-exclamation-triangle" ] [], text "There are no users defined" ] ]
+                    [ td [ class "empty", colspan 8 ] [ i [ class "fa fa-exclamation-triangle" ] [], text "There are no users defined" ] ]
                 ]
 
              else if List.isEmpty users then
                 [ tr []
-                    [ td [ class "empty", colspan 7 ] [ i [ class "fa fa-exclamation-triangle" ] [], text "No users match your filters" ] ]
+                    [ td [ class "empty", colspan 8 ] [ i [ class "fa fa-exclamation-triangle" ] [], text "No users match your filters" ] ]
                 ]
 
              else
@@ -1011,6 +1064,18 @@ searchField user =
 getSortFunction : Model -> User -> User -> Order
 getSortFunction model u1 u2 =
     let
+        compareBool : Bool -> Bool -> Order
+        compareBool l1 l2 =
+            case ( l1, l2 ) of
+                ( True, False ) ->
+                    LT
+
+                ( False, True ) ->
+                    GT
+
+                _ ->
+                    EQ
+
         compareStringList : List String -> List String -> Order
         compareStringList l1 l2 =
             let
@@ -1085,6 +1150,9 @@ getSortFunction model u1 u2 =
 
         Tenants ->
             checkOrder (N.compare u1.name u2.name)
+
+        OtpEnabled ->
+            checkOrder (compareBool u1.otpEnabled u2.otpEnabled)
 
         PreviousLogin ->
             case ( u1.previousLogin, u2.previousLogin ) of

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-elm.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-elm.js
@@ -26,12 +26,4 @@ $(document).ready(function(){
   createInfoNotification = function (msg, code){
     appNotif.ports.infoNotification.send(msg, code);
   };
-  appNode  = document.querySelector("rudder-quicksearch");
-  appQuicksearch = Elm.QuickSearch.init({
-    node  : appNode,
-    flags : flags
-  });
-  appQuicksearch.ports.errorNotification.subscribe(function (str) {
-    createErrorNotification(str);
-  });
 });

--- a/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
@@ -49,6 +49,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 <!--        <protect-pointcut expression="execution(* bigbank.*Service.post*(..))" access="ROLE_TELLER"/>-->
 <!--        -->
 <!--    </global-method-security>-->
+    <beans:bean id="otpAuthFilter" class="bootstrap.liftweb.OtpAuthenticationFilter">
+      <beans:property name="authenticationManager" ref="org.springframework.security.authenticationManager"/>
+    </beans:bean>
+
+
     <beans:bean id="userSessionInvalidationFilter" class="bootstrap.liftweb.UserSessionInvalidationFilter" />
 
 
@@ -65,7 +70,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- same config as mainHttpSecurityFilters but applies to authenticated API calls (/secure/api/): they need a custom filter for CSRF mitigation -->
     <http pattern="/secure/api/**" disable-url-rewriting="true"  entry-point-ref="restAuthenticationEntryPoint">
-        <intercept-url pattern="/**" access="isAuthenticated()" />
+        <!-- For API access of frontend OTP page -->
+        <intercept-url pattern="/secure/api/otp/**" access="hasRole('ROLE_PRE_AUTH')" />
+
+        <!-- Same as for /secure/**, we don't allow preauth -->
+        <intercept-url pattern="/**" access="isAuthenticated() and !hasRole('ROLE_PRE_AUTH')" />
+
         <custom-filter after="LAST" ref="restSecureAuthenticationFilter" />
         <headers>
             <xss-protection disabled="true"/>
@@ -76,6 +86,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
         <session-management session-fixation-protection="migrateSession" />
     </http>
 
+    <!-- Security context is mutated in many places (among which RudderUrlAuthenticationSuccessHandler, so keep value to false) -->
     <http use-expressions="true" disable-url-rewriting="true" name="mainHttpSecurityFilters" security-context-explicit-save="false">
         <headers>
             <xss-protection disabled="true"/>
@@ -93,13 +104,21 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
           <concurrency-control max-sessions="2" error-if-maximum-exceeded="true" />
           -->
         </session-management>
+
+        <!-- OTP login for already logged-in user with ROLE_PRE_AUTH authority to access the OTP submit page -->
+	    <intercept-url pattern="/secure/otp.html" access="hasRole('ROLE_PRE_AUTH')" />
+
+        <!-- For API access of frontend OTP page and OTP check filter -->
+	    <intercept-url pattern="/secure/otp/verify" access="permitAll" />
+
         <!--
            Comment to allows "no auth required", but the login form is still valid
            May be used for development or demo.
         -->
         <!-- Start comment -->
 
-        <intercept-url pattern="/secure/**" access="isAuthenticated()" />
+        <!-- Need user to have the right authority and not the one for OTP verification (it implies being authenticated) -->
+        <intercept-url pattern="/secure/**" access="isAuthenticated() and !hasRole('ROLE_PRE_AUTH')" />
 
         <!-- End comment -->
 
@@ -109,11 +128,13 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
         <form-login
             login-page="/index.html"
             login-processing-url="/j_spring_security_check"
-            default-target-url="/secure/index.html"
+            authentication-success-handler-ref="rudderWebAuthenticationSuccessHandler"
             authentication-failure-handler-ref="rudderWebAuthenticationFailureHandler"
-            always-use-default-target="false"
         />
 <!--        <remember-me />-->
+
+        <!-- For OTP verification, auth upgrade -->
+        <custom-filter after="FORM_LOGIN_FILTER" ref="otpAuthFilter"/>
 
         <custom-filter after="BASIC_AUTH_FILTER" ref="userSessionInvalidationFilter" />
 

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -82,6 +82,7 @@ rudder.server.hstsIncludeSubDomains=false
 #
 # LDAP directory connection information
 #
+
 ldap.host=localhost
 ldap.port=389
 ldap.authdn=cn=manager,cn=rudder-configuration
@@ -688,6 +689,13 @@ rudder.users.cleanup.sessions.purgeAfter=30 days
 # your existing entreprise Active Directory or LDAP directory.
 #
 rudder.auth.provider=file
+
+
+# OTP configuration property
+# - Enforce TOTP confirmation code step during login for users which have configured a TOTP
+# Default: false (OTP is optional, but recommended especially for administrators)
+rudder.auth.otp.enforce=false
+
 
 #
 # To disable access to the REST API using user-generated API token

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -39,7 +39,10 @@ package bootstrap.liftweb
 
 import bootstrap.liftweb.LogFailedLogin.DisabledUserException
 import bootstrap.liftweb.LogFailedLogin.getRemoteAddr
+import bootstrap.liftweb.RestAuthenticationFilter.SYSTEM_API_ACL
+import bootstrap.liftweb.RudderParsedProperties
 import bootstrap.liftweb.checks.earlyconfig.db.CheckUsersFile
+import cats.syntax.apply.*
 import com.normation.errors.*
 import com.normation.rudder.Role
 import com.normation.rudder.api.*
@@ -49,6 +52,7 @@ import com.normation.rudder.rest.ProviderRoleExtension
 import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.rudder.tenants.TenantService
 import com.normation.rudder.users.*
+import com.normation.rudder.users.RudderAuthType
 import com.normation.rudder.web.services.UserSessionLogEvent
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
@@ -61,6 +65,8 @@ import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.Collection
 import net.liftweb.common.*
@@ -89,7 +95,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.ldap.userdetails.UserDetailsContextMapper
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache
 import scala.annotation.nowarn
 import scala.util.Try
 import zio.syntax.*
@@ -112,9 +121,6 @@ import zio.syntax.*
 @ComponentScan(Array("bootstrap.rudder.plugin"))
 class AppConfigAuth extends ApplicationContextAware {
   import bootstrap.liftweb.RudderProperties.config
-
-  // we define the System ApiAcl as one that is all mighty and can manage everything
-  val SYSTEM_API_ACL = ApiAuthorization.RW
 
   // Configuration values within an authentication provider config from which we get provider properties
   val A_ROLES_ENABLED  = "roles.enabled"
@@ -312,6 +318,10 @@ class AppConfigAuth extends ApplicationContextAware {
   @Bean(name = Array("org.springframework.security.authenticationManager"))
   def authenticationManager = new RudderProviderManager(RudderConfig.authenticationProviders, userRepository)
 
+  @Bean def rudderWebAuthenticationSuccessHandler: AuthenticationSuccessHandler = new RudderUrlAuthenticationSuccessHandler(
+    RudderParsedProperties.ENFORCE_OTP_AUTH
+  )
+
   @Bean def rudderWebAuthenticationFailureHandler: AuthenticationFailureHandler = new RudderUrlAuthenticationFailureHandler(
     "/index.html?login_error=true"
   )
@@ -354,50 +364,16 @@ class AppConfigAuth extends ApplicationContextAware {
   }
 
   @Bean def rootAdminAuthenticationProvider: AuthenticationProvider = {
-    // We want to be able to disable that account.
-    // For that, we let the user either let undefined rudder.auth.admin.login,
-    // or let empty udder.auth.admin.login or rudder.auth.admin.password
-
     implicit val encoder: RudderPasswordEncoder = RudderPasswordEncoder(passwordEncoderDispatcher)
-    val admin = if (config.hasPath("rudder.auth.admin.login") && config.hasPath("rudder.auth.admin.password")) {
-      val login    = config.getString("rudder.auth.admin.login")
-      val password = config.getString("rudder.auth.admin.password")
-
-      if (login.isEmpty || password.isEmpty) {
-        None
-      } else {
-        Some(
-          RudderUserDetail(
-            RudderAccount.User(
-              login,
-              UserPassword.unsafeHashed(password)
-            ),
-            UserStatus.Active,
-            Set(Role.Administrator),
-            SYSTEM_API_ACL,
-            TenantAccessGrant.All
-          )
-        )
-      }
-    } else {
-      None
-    }
-
-    if (admin.isEmpty) {
-      ApplicationLoggerPure.logEffect.info(
-        "No master admin account is defined. You can define one with 'rudder.auth.admin.login' and 'rudder.auth.admin.password' properties in the configuration file"
-      )
-    }
-
     val authConfigProvider = new UserDetailListProvider {
-      override def authConfig: UserList = SingleUserList(encoder, admin)
+      override def authConfig: UserList = SingleUserList(encoder, RudderParsedProperties.RUDDER_ROOT_ADMIN)
     }
     (for {
       now                 <- currentOffsetDateTimeUTC
       rootAccountUserRepo <- InMemoryUserRepository.make()
       _                   <- rootAccountUserRepo.setExistingUsers(
                                "root-account",
-                               admin.map(_.getUsername).toList,
+                               RudderParsedProperties.RUDDER_ROOT_ADMIN.map(_.getUsername).toList,
                                EventTrace(com.normation.rudder.domain.eventlog.RudderEventActor, now)
                              )
     } yield {
@@ -415,7 +391,6 @@ class AppConfigAuth extends ApplicationContextAware {
       RudderConfig.woApiAccountRepository,
       rudderUserDetailsService,
       RudderConfig.tenantService,
-      SYSTEM_API_ACL,
       RestAuthenticationFilter.API_TOKEN_HEADER
     )
   }
@@ -441,6 +416,97 @@ class AppConfigAuth extends ApplicationContextAware {
 
   // userSessionLogEvent must not be lazy, because not used by anybody directly
   @Bean def userSessionLogEvent = new UserSessionLogEvent(RudderConfig.eventLogRepository, RudderConfig.stringUuidGenerator)
+}
+
+/*
+ * The "success login" handler:
+ *  - extends the original Spring handler based with default URL (root of application when authenticated)
+ *  - handles OTP registration logic:
+ *    - for users without OTP, when OTP verification are enforced, they must register an OTP
+ *    - for users already with OTP, they must enter a valid code before being redirected
+ *
+ * Implementation is similar to one of SavedRequestAwareAuthenticationSuccessHandler
+ */
+class RudderUrlAuthenticationSuccessHandler(enforceOtp: Boolean)
+    extends SimpleUrlAuthenticationSuccessHandler("/secure/index.html") {
+  private val otpRedirect = enforceOtp
+
+  private val otpRedirectUri = "/secure/otp.html"
+
+  private val requestCache = new HttpSessionRequestCache()
+
+  /**
+   * Saves the SecurityContext with a ROLE_PRE_AUTH authority, only possible because of security-context-explicit-save="false"
+   */
+  override def onAuthenticationSuccess(
+      request:        HttpServletRequest,
+      response:       HttpServletResponse,
+      authentication: Authentication
+  ): Unit = {
+    (for {
+      (preAuthPrincipal, grantedAuthorities) <- withUserOtpRequired(authentication)(
+                                                  u => (u, u.getAuthorities),
+                                                  // PRE_AUTH does not grant more access than for OTP, keeps the authentication flow consistent: empty would lead nowhere
+                                                  fallback = (_, RudderAuthType.PreAuthUser.grantedAuthorities)
+                                                )
+    } yield {
+      new UsernamePasswordAuthenticationToken(
+        preAuthPrincipal,
+        null,
+        grantedAuthorities
+      )
+    }).foreach(preAuthToken => SecurityContextHolder.getContext().setAuthentication(preAuthToken))
+
+    super.onAuthenticationSuccess(request, response, authentication)
+  }
+
+  // Logic to do some action, ONLY WHEN OTP is required, i.e. contains the logic for "user needs OTP", could include
+  // When need an explicit fallback default to take "no known auth => provided no user grants", keeping the OTP workflow consistent
+  // None means: we can safely redirect to home, without otpRedirect
+  private def withUserOtpRequired[A](
+      authentication: Authentication
+  )(action: RudderPreAuthUser => A, fallback: Object => A): Option[A] = {
+    // OTP is not set, skip with the "unless" pattern
+    Option.unless(!otpRedirect)(()) *> {
+      // here we should check that it's a Rudder user, and if their OTP is already enabled/freshly verified to determine if OTP flow is required
+      val principal = authentication.getPrincipal
+
+      principal match {
+        case u: RudderUserDetail if RudderParsedProperties.RUDDER_ROOT_ADMIN.map(_.getUsername).contains(u.getUsername) =>
+          // rootAdmin account doesn't need OTP, and is always attempted to auth first, so we can skip OTP
+          None
+
+        case u: RudderUserDetail =>
+          // already fixes up the authority to make spring-security config give access to MFA enrollment/verification page
+          Some(action(RudderPreAuthUser(u)))
+
+        case o =>
+          Some(fallback(o))
+      }
+    }
+  }
+
+  // To correctly apply override of defaultRedirectUri (defaultTargetUrl), we need OTP customization
+  override protected def determineTargetUrl(
+      request:        HttpServletRequest,
+      response:       HttpServletResponse,
+      authentication: Authentication
+  ): String = {
+    def nextOtpRedirect = {
+      Option(requestCache.getRequest(request, response))
+        .map(_.getRedirectUrl)
+        .map(url => {
+          requestCache.removeRequest(request, response) // clean is recommended since we intercept it only in this request
+          s"?redirect=${URLEncoder.encode(url, StandardCharsets.UTF_8)}"
+        })
+        .getOrElse("")
+    }
+    def fallback        = super.determineTargetUrl(request, response, authentication)
+    withUserOtpRequired(authentication)(
+      _ => otpRedirectUri + nextOtpRedirect,
+      _ => fallback
+    ).getOrElse(fallback)
+  }
 }
 
 /*
@@ -797,7 +863,6 @@ class RestAuthenticationFilter(
     writeApiTokenRepository: WoApiAccountRepository,
     userDetailsService:      RudderInMemoryUserDetailsService,
     tenantRepo:              TenantService,
-    systemApiAcl:            ApiAuthorization,
     apiTokenHeaderName:      String
 ) extends Filter with Loggable {
   override def destroy(): Unit = {}
@@ -932,7 +997,7 @@ class RestAuthenticationFilter(
                     RudderAccount.Api(systemAccount),
                     UserStatus.Active,
                     Set(Role.Administrator), // this token has "admin rights - use with care
-                    systemApiAcl,
+                    SYSTEM_API_ACL,
                     TenantAccessGrant.All
                   ),
                   httpRequest,
@@ -960,7 +1025,7 @@ class RestAuthenticationFilter(
                             RudderAccount.Api(principal),
                             UserStatus.Active,
                             Set(Role.Administrator), // this token has "admin rights - use with care
-                            systemApiAcl,
+                            SYSTEM_API_ACL,
                             TenantAccessGrant.All
                           ),
                           httpRequest,
@@ -1071,7 +1136,8 @@ class RestAuthenticationFilter(
 }
 
 object RestAuthenticationFilter {
-  val API_TOKEN_HEADER: String = "X-API-Token"
+  val API_TOKEN_HEADER: String           = "X-API-Token"
+  val SYSTEM_API_ACL:   ApiAuthorization = ApiAuthorization.RW // the almighty authorization that can manage everything
 }
 
 /*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -72,6 +72,7 @@ import com.normation.rudder.rest.lift.GenericLiftApiModuleProvider
 import com.normation.rudder.rest.lift.InfoApi
 import com.normation.rudder.rest.v1.RestStatus
 import com.normation.rudder.users.CurrentUser
+import com.normation.rudder.users.RudderPreAuthUser
 import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.web.snippet.CustomPageJs
 import com.normation.rudder.web.snippet.WithCachedResource
@@ -220,7 +221,6 @@ object Boot {
   def needPermsWith(isEnabled: => Boolean, requiredAuthz: AuthorizationType*): TestAccess = {
     TestAccess(() => userIsAllowedWith("/secure/index", isEnabled, requiredAuthz*))
   }
-
 }
 
 /*
@@ -414,12 +414,13 @@ final case class LogoutPostAction(id: String, exec: Authentication => IOResult[O
  */
 object FindCurrentUser {
 
-  def get(): Option[RudderUserDetail] = {
+  def get(): Option[RudderUserDetail | RudderPreAuthUser] = {
     SecurityContextHolder.getContext.getAuthentication match {
       case null => None
       case auth =>
         auth.getPrincipal match {
-          case u: RudderUserDetail => Some(u)
+          case u: RudderPreAuthUser => Some(u)
+          case u: RudderUserDetail  => Some(u)
           case _ => None
         }
     }
@@ -740,7 +741,7 @@ class Boot extends Loggable {
       }
     }
 
-    // All the following is related to the sitemap
+    // All the following gives access to Rudder pages and snippets, and is related to the sitemap
     // format: off
     def nodeManagerMenu = {
       (Menu(MenuUtils.nodeManagementMenu, <i class="fa fa-sitemap"></i> ++ <span>Node management</span>: NodeSeq) /
@@ -814,7 +815,8 @@ class Boot extends Loggable {
     def rootMenu = List(
       Menu("000-dashboard", <i class="fa fa-dashboard"></i> ++ <span>Dashboard</span>: NodeSeq) / "secure" / "index",
       Menu("010-login") / "index" >> Hidden,
-      Menu("020-templates") / "templates" / ** >> Hidden, // allows access to html files used by js
+      Menu("020-login-otp") / "secure" / "otp" >> Hidden,
+      Menu("030-templates") / "templates" / ** >> Hidden, // allows access to html files used by js
       nodeManagerMenu,
       policyMenu,
       administrationMenu,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/OtpAuthenticationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/OtpAuthenticationFilter.scala
@@ -1,0 +1,132 @@
+/*
+ * *************************************************************************************
+ * Copyright 2026 Normation SAS
+ * *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * *************************************************************************************
+ */
+package bootstrap.liftweb
+
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
+import com.normation.rudder.users.*
+import com.normation.zio.UnsafeRun
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.*
+import org.springframework.security.authentication.*
+import org.springframework.security.core.*
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.*
+import scala.jdk.CollectionConverters.*
+import zio.*
+
+/**
+ * Filter for OTP check which is run when the enrollment/verify page submits the verification code
+ */
+class OtpAuthenticationFilter extends AbstractAuthenticationProcessingFilter("/secure/otp/verify") {
+
+  private val otpService = RudderConfig.otpService
+
+  @throws[AuthenticationException]
+  override def attemptAuthentication(req: HttpServletRequest, res: HttpServletResponse): Authentication = {
+    val current = SecurityContextHolder.getContext().getAuthentication
+
+    val validAuthorities = RudderAuthType.PreAuthUser.grantedAuthorities.asScala.toSet
+    if (
+      current == null || !current
+        .getAuthorities()
+        .stream()
+        .anyMatch(a => validAuthorities.contains(a))
+    ) {
+      throw new InsufficientAuthenticationException("OTP step requires prior password auth");
+    }
+
+    (Option(req.getParameter("code")), current.getPrincipal) match {
+      case (Some(code), preAuth: RudderPreAuthUser) =>
+        val u        = preAuth.authenticatingUser
+        val userId   = u.getUsername
+        def errorMsg =
+          "Could not verify user OTP, please retry with a valid code, generate a new OTP, or ask admin to reset your OTP if you lost it"
+        // need to verify a newly generated OTP too
+        otpService
+          .verifyGenerated(UserId(userId), code)
+          .tap(totp => ApplicationLoggerPure.Auth.info(s"User '${userId}' registered OTP at ${totp.created}"))
+          .orElse(
+            otpService
+              .verify(UserId(userId), code)
+          )
+          .chainError(errorMsg)
+          .foldZIO(
+            err =>
+              // Send only error msg
+              ApplicationLoggerPure.Auth
+                .debug(err.fullMsg)
+                .as(
+                  errorResponse(res, HttpStatus.FORBIDDEN, errorMsg)
+                ),
+            _ => {
+              ApplicationLoggerPure.Auth
+                .debug(s"User '${userId}' submitted a valid OTP code")
+                .as(
+                  new UsernamePasswordAuthenticationToken(u, null, RudderAuthType.User.grantedAuthorities)
+                )
+            }
+          )
+          .runNow
+
+      case (_, u: RudderUserDetail) =>
+        errorResponse(
+          res,
+          HttpStatus.CONFLICT,
+          "User is already authenticated"
+        )
+      case _                        =>
+        errorResponse(
+          res,
+          HttpStatus.UNAUTHORIZED,
+          "Unknown user or code, not able to authenticate OTP"
+        )
+    }
+  }
+
+  private def errorResponse(
+      response:   HttpServletResponse,
+      httpStatus: HttpStatus,
+      message:    String
+  ): Authentication = {
+    response.setStatus(httpStatus.value())
+    val writer = response.getWriter()
+    writer.write(message)
+    writer.flush()
+    // need to return an invalid authentication to avoid stack trace (Spring is sadly happy about this)
+    null
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -62,6 +62,7 @@ import com.normation.ldap.sdk.*
 import com.normation.plugins.*
 import com.normation.plugins.cli.RudderPackageCmdService
 import com.normation.plugins.settings.*
+import com.normation.rudder.Role
 import com.normation.rudder.api.*
 import com.normation.rudder.apidata.*
 import com.normation.rudder.batch.*
@@ -1188,6 +1189,20 @@ object RudderParsedProperties {
     }
   }
 
+  // Enforce TOTP login during auth (default: false). OTP is optional for compatibility (when "enabled" is added, be careful with defaults)
+  val ENFORCE_OTP_AUTH: Boolean = {
+    val default = false
+    try {
+      config.getBoolean("rudder.auth.otp.enforce")
+    } catch {
+      case ex: ConfigException =>
+        ApplicationLogger.info(
+          "Property 'rudder.auth.otp.enforce' is absent in rudder.configFile, defaulting to false (OTP optional)."
+        )
+        default
+    }
+  }
+
   val RUDDERC_CMD: String = {
     try {
       config.getString("rudder.technique.compiler.rudderc.cmd")
@@ -1269,6 +1284,50 @@ object RudderParsedProperties {
           "value is not formatted as a long digit and time unit (ms, s, m, h, d), example: 5 days or 5d. Leave it empty to keep forever",
           Some(ex)
         )
+    }
+  }
+
+  // ROOT admin user
+  // We want to be able to disable that account.
+  // For that, we let the user either let undefined rudder.auth.admin.login,
+  // or let empty rudder.auth.admin.login or rudder.auth.admin.password
+  val RUDDER_ROOT_ADMIN: Option[RudderUserDetail] = {
+    def noRootAdmin = Option.empty[RudderUserDetail]
+    try {
+      val admin = if (config.hasPath("rudder.auth.admin.login") && config.hasPath("rudder.auth.admin.password")) {
+        val login    = config.getString("rudder.auth.admin.login")
+        val password = config.getString("rudder.auth.admin.password")
+
+        if (login.isEmpty || password.isEmpty) {
+          noRootAdmin
+        } else {
+          Some(
+            RudderUserDetail(
+              RudderAccount.User(
+                login,
+                UserPassword.unsafeHashed(password)
+              ),
+              UserStatus.Active,
+              Set(Role.Administrator),
+              ApiAuthorization.RW,
+              TenantAccessGrant.All
+            )
+          )
+        }
+      } else {
+        noRootAdmin
+      }
+      if (admin.isEmpty) {
+        ApplicationLoggerPure.logEffect.info(
+          "No master admin account is defined. You can define one with 'rudder.auth.admin.login' and 'rudder.auth.admin.password' properties in the configuration file"
+        )
+      }
+      admin
+    } catch {
+      // presence of both fields is already checked, other configuration exception may happen consider it's absent
+      case ex: Exception =>
+        logger.error("Configuration of root admin has error, falling back to no root admin.", ex)
+        noRootAdmin
     }
   }
 
@@ -1473,6 +1532,7 @@ object RudderConfig extends Loggable {
   val userPropertyService:                 UserPropertyService                      = rci.userPropertyService
   val userRepository:                      UserRepository                           = rci.userRepository
   val userService:                         UserService                              = rci.userService
+  val otpService:                          TotpService                              = rci.otpService
   val woApiAccountRepository:              WoApiAccountRepository                   = rci.woApiAccountRepository
   val woDirectiveRepository:               WoDirectiveRepository                    = rci.woDirectiveRepository
   val woNodeGroupRepository:               WoNodeGroupRepository                    = rci.woNodeGroupRepository
@@ -1616,6 +1676,7 @@ case class RudderServiceApi(
     userService:                         UserService,
     apiVersions:                         List[ApiVersion],
     apiDispatcher:                       RudderEndpointDispatcher,
+    otpService:                          TotpService,
     configurationRepository:             ConfigurationRepository,
     roParameterService:                  RoParameterService,
     agentRegister:                       AgentRegister,
@@ -2193,6 +2254,17 @@ object RudderConfigInit {
 
     lazy val systemTokenSecret = ApiTokenSecret.generate(tokenGenerator, suffix = "system")
 
+    // OTP (Two-Factor Authentication) service
+    lazy val totpRepository    = new JdbcTotpRepository(doobie)
+    lazy val userTotpValidator = new UserTotpValidator(userRepository, totpRepository)
+    lazy val totpService       = OtpJavaTotpService
+      .make(
+        enabledOtp = ENFORCE_OTP_AUTH,
+        validator = userTotpValidator,
+        totpRepository = totpRepository
+      )
+      .runNow
+
     // we need to init API internal services into the {} block to avoid bug https://issues.rudder.io/issues/26416
     // need to be out of RudderApi else "Platform restriction: a parameter list's length cannot exceed 254."
     lazy val rudderApi = ApiInit.api
@@ -2224,6 +2296,8 @@ object RudderConfigInit {
         ),
         linkUtil
       )
+
+      lazy val otpApi = new OtpApi(totpService)
 
       lazy val ruleApiService13 = {
         new RuleApiService14(
@@ -2411,6 +2485,7 @@ object RudderConfigInit {
               UserFileProcessing.getUserResourceFile()
             ),
             tenantService,
+            totpService,
             () => authenticationProviders.getProviderProperties().view.mapValues(_.providerRoleExtension).toMap,
             () => authenticationProviders.getConfiguredProviders().map(_.name).toSet
           ),
@@ -2440,7 +2515,8 @@ object RudderConfigInit {
           archiveApi,
           new ScoreApiImpl(scoreService),
           eventLogApi,
-          quicksearchApi
+          quicksearchApi,
+          otpApi
           // info api must be resolved latter, because else it misses plugin apis !
         )
       }
@@ -3434,6 +3510,7 @@ object RudderConfigInit {
         BootstrapLogger.Early.DB,
         new CheckPostgreConnection(dataSourceProvider),
         new CreateTableNodeFacts(doobie),
+        new CreateTableUsersTotp(doobie),
         new CheckTableScore(doobie),
         new CheckTableUsers(doobie),
         new CheckTableNodeLastCompliance(doobie),
@@ -4047,6 +4124,7 @@ object RudderConfigInit {
       userService,
       SupportedApiVersion.apiVersions,
       apiDispatcher,
+      totpService,
       configurationRepository,
       roParameterService,
       agentRegister,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -40,6 +40,7 @@ import com.normation.errors.*
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.users.FileUserDetailListProvider
 import com.normation.rudder.users.RudderAuthorizationFileReloadCallback
+import com.normation.rudder.users.RudderPreAuthUser
 import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.users.UserRepository
 import com.normation.rudder.users.UserStatus
@@ -50,6 +51,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpSession
 import java.io.IOException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
@@ -94,46 +96,12 @@ class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailLi
         val userDetails = auth.getPrincipal
         userDetails match { // we should only do session invalidation in specific cases : status is disabled/deleted, user is unknown
           case user: RudderUserDetail =>
-            val username = user.getUsername
-            implicit val userDetail: RudderUserDetail = user
-            // we need to NOT put doFilter into ZIO effect, so we exec immediately, see https://issues.rudder.io/issues/29034
-            userCache.get
-              .map(_.get(username))
-              .flatMap {
-                case checkUser(reason) =>
-                  val endSessionReason = s"Session invalidated because ${reason}"
-                  IOResult.attempt {
-                    session.invalidate()
-                    response.sendRedirect(request.getContextPath)
-                  }
-                    .foldZIO(
-                      {
-                        case SystemError(_, _: IllegalStateException) =>
-                          ApplicationLoggerPure.info(
-                            s"User session for user '${username}' is already invalidated because : ${reason}"
-                          )
-                        case err                                      =>
-                          err
-                            .copy(msg = {
-                              s"User session for user '${username}' could not be invalidated for reason : ${reason}. " +
-                              s"Please contact Rudder developers with the following explanation : ${err.fullMsg}"
-                            })
-                            .fail
-                      },
-                      _ => {
-                        for {
-                          now <- currentOffsetDateTimeUTC
-                          _   <- userRepository.logCloseSession(user.getUsername, now, endSessionReason)
-                          _   <-
-                            ApplicationLoggerPure.info(s"User session for user '${username}' is invalidated because : ${reason}")
-                        } yield ()
-                      }
-                    )
-                case _                 =>
-                  ZIO.unit
-              }
-              .either
-              .runNow match {
+            checkUser(user)(session, request, response).either.runNow match {
+              case Left(err) => throw new RuntimeException(err.fullMsg)
+              case Right(()) => filterChain.doFilter(request, response)
+            }
+          case RudderPreAuthUser(user) =>
+            checkUser(user)(session, request, response).either.runNow match {
               case Left(err) => throw new RuntimeException(err.fullMsg)
               case Right(()) => filterChain.doFilter(request, response)
             }
@@ -178,6 +146,49 @@ class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailLi
     */
   def updateUser(user: RudderUserDetail): UIO[Unit] = {
     userCache.update(_ + (user.getUsername -> hashRudderUserDetail(user)))
+  }
+
+  private def checkUser(
+      user: RudderUserDetail
+  )(session: HttpSession, request: HttpServletRequest, response: HttpServletResponse): IOResult[Unit] = {
+    val username = user.getUsername
+    implicit val userDetail: RudderUserDetail = user
+    // we need to NOT put doFilter into ZIO effect, so we exec immediately, see https://issues.rudder.io/issues/29034
+    userCache.get
+      .map(_.get(username))
+      .flatMap {
+        case checkUser(reason) =>
+          val endSessionReason = s"Session invalidated because ${reason}"
+          IOResult.attempt {
+            session.invalidate()
+            response.sendRedirect(request.getContextPath)
+          }
+            .foldZIO(
+              {
+                case SystemError(_, _: IllegalStateException) =>
+                  ApplicationLoggerPure.info(
+                    s"User session for user '${username}' is already invalidated because : ${reason}"
+                  )
+                case err                                      =>
+                  err
+                    .copy(msg = {
+                      s"User session for user '${username}' could not be invalidated for reason : ${reason}. " +
+                      s"Please contact Rudder developers with the following explanation : ${err.fullMsg}"
+                    })
+                    .fail
+              },
+              _ => {
+                for {
+                  now <- currentOffsetDateTimeUTC
+                  _   <- userRepository.logCloseSession(user.getUsername, now, endSessionReason)
+                  _   <-
+                    ApplicationLoggerPure.info(s"User session for user '${username}' is invalidated because : ${reason}")
+                } yield ()
+              }
+            )
+        case _                 =>
+          ZIO.unit
+      }
   }
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CreateTableUsersTotp.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CreateTableUsersTotp.scala
@@ -1,0 +1,86 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.checks.earlyconfig.db
+
+import bootstrap.liftweb.BootstrapChecks
+import bootstrap.liftweb.BootstrapLogger
+import com.normation.errors.IOResult
+import com.normation.rudder.db.Doobie
+import com.normation.zio.*
+import doobie.implicits.*
+import zio.interop.catz.*
+
+/*
+ * Creates the 'userstotp' table for storing TOTP
+ * secrets and their creation timestamps.
+ */
+class CreateTableUsersTotp(
+    doobie: Doobie
+) extends BootstrapChecks {
+
+  import doobie.*
+
+  override def description: String =
+    "Check if table 'userstotp' exists or create it"
+
+  def createTableStatement: IOResult[Unit] = {
+    val sql = {
+      sql"""CREATE TABLE IF NOT EXISTS userstotp (
+        user_id    TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE
+      , secret     TEXT NOT NULL
+      , created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );"""
+    }
+
+    transactIOResult(s"Error with 'userstotp' table creation")(xa => sql.update.run.transact(xa)).unit
+  }
+
+  override def checks(): Unit = {
+    val prog = {
+      for {
+        _ <- createTableStatement
+      } yield ()
+    }
+
+    // Actually run the migration async to avoid blocking boot
+    prog
+      .catchAll(err => BootstrapLogger.Early.DB.error(s"Error when trying to create table userstotp: ${err.fullMsg}"))
+      .forkDaemon
+      .runNow
+  }
+
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -54,7 +54,7 @@ import com.normation.rudder.facts.nodes.MinimalNodeFactInterface
 import com.normation.rudder.ncf.EditorTechniqueError
 import com.normation.rudder.ncf.EditorTechniqueStatus
 import com.normation.rudder.tenants.QueryContext
-import com.normation.rudder.users.RudderUserDetail
+import com.normation.rudder.users.AuthenticatedUser
 import com.normation.utils.DateFormaterService
 import com.normation.zio.UnsafeRun
 import net.liftweb.common.*
@@ -91,7 +91,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
   }
   // we need to get current user from SpringSecurity because it is not set in session anymore,
   // and comet doesn't know about requests
-  private val currentUser:                                               Option[RudderUserDetail]                        = FindCurrentUser.get()
+  private val currentUser:                                               Option[AuthenticatedUser]                       = FindCurrentUser.get()
   private def havePerm[A](perm: AuthorizationType)(a: EventActor ?=> A): Option[A]                                       = {
     currentUser match {
       case None    => Option.empty

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
@@ -42,7 +42,7 @@ import bootstrap.liftweb.UserLogout
 import com.normation.plugins.DefaultExtendableSnippet
 import com.normation.rudder.Role
 import com.normation.rudder.domain.logger.ApplicationLogger
-import com.normation.rudder.users.CurrentUser
+import com.normation.rudder.users.*
 import com.normation.utils.DateFormaterService
 import com.normation.utils.DateFormaterService.toJodaDateTime
 import com.normation.zio.*

--- a/webapp/sources/rudder/rudder-web/src/main/style/login.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/login.css
@@ -2,7 +2,7 @@ html,body{
   padding: 0;
   margin : 0;
   height : 100%;
-  background-color : #F8F9FC;
+  background-color : #F8F9FC !important;
   color: #041922;
   font-size   : 18px;
   font-family : system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
@@ -26,8 +26,8 @@ html,body{
   display: block;
   width: 100%;
 }
-/* === FORM === */
-.flex-container form{
+/* === FORM, OTP === */
+.flex-container form, .flex-container .otp-container{
   background-color : #fff;
   border-radius    : 20px;
   padding    : 46px 60px 16px 60px;
@@ -37,8 +37,8 @@ html,body{
   color : #6d7c83;
   font-weight : normal;
 }
-.flex-container form .btn.btn-primary,
-.flex-container form .form-control {
+.flex-container form#login-form .btn.btn-primary,
+.flex-container form#login-form .form-control {
   font-size : 18px;
   padding   : 12px 6px;
   height    : auto;
@@ -48,17 +48,17 @@ html,body{
   box-shadow : none !important;
   transition-duration: .2s;
 }
-.flex-container form .btn.btn-primary.signing{
+.flex-container form#login-form .btn.btn-primary.signing{
   cursor: not-allowed;
   opacity : .4;
 }
-.flex-container form .form-control:focus {
+.flex-container form#login-form .form-control:focus {
   border-color: #13beb7;
 }
-.flex-container form .btn.btn-primary:hover{
+.flex-container form#login-form .btn.btn-primary:hover{
   background-color: #10aca6;
 }
-.flex-container form .btn.btn-primary {
+.flex-container form#login-form .btn.btn-primary {
   background-color : #13beb7;
   color  : #fff;
   border : none;

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/otp.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/otp.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:lift="http://liftweb.net/">
+  <head>
+    <title>Rudder - MFA</title>
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/libs/bootstrap.min.css">
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/fontawesome-5-15-1/css/all.min.css"/>
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/fontawesome-5-15-1/css/v4-shims.min.css"/>
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/ionicons-2.0.1/css/ionicons.min.css">
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/login.css">
+
+    <link type="image/x-icon" rel="icon" data-lift="with-cached-resource" href="/images/rudder-favicon.ico" />
+
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-bootstrap.css">
+
+    <script data-lift="baseUrl.display" ></script>
+
+    <!-- ELM -->
+    <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/jquery.min.js"></script>
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-notifications.css" />
+    <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-notifications.js"></script>
+    <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-otp.js"></script>
+    <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/rudder-elm.js"></script>
+  </head>
+
+  <body>
+    <div class="flex-container">
+      <div class="col-xxl-3 col-xl-4 col-lg-6 col-sm-8 col-12 px-3 px-md-0">
+
+        <div data-lift="Login.display">
+
+          <div class="logo-container">
+            <img src="/images/logo/rudder-logo-rect-black.svg" data-lift="with-cached-resource" alt="Rudder"/>
+          </div>
+
+          <div class="content-wrapper">
+            <div class="rudder_col">
+              <rudder-notifications></rudder-notifications>
+              <div id="content">
+                <div id="otp-app"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="links">
+            <a href="/rudder-doc" target="_blank">
+              <span>Documentation</span>
+            </a>
+            <a href="https://www.rudder.io/pricing/subscription/" target="_blank">
+              <span>Support</span>
+            </a>
+            <a href="https://www.rudder.io/open-source/community/" target="_blank">
+              <span>Community</span>
+            </a>
+            <a href="https://issues.rudder.io/" target="_blank">
+              <span>Bug tracker</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script data-lift="with-nonce">
+      $(document).ready(function () {
+        const main = document.getElementById("otp-app")
+        const initValues = {
+            contextPath: contextPath
+        };
+
+        const app = Elm.Otp.init({node: main, flags: initValues});
+
+        app.ports.errorNotification.subscribe(function (str) {
+          createErrorNotification(str)
+        });
+
+        app.ports.pushUrl.subscribe(function (url) {
+          window.location.href = url;
+        });
+
+        app.ports.readUrl.send(window.location.href);
+      });
+    </script>
+
+  </body>
+  <div data-lift="CustomPageJs.pageScript"></div>
+</html>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -66,6 +66,19 @@
       <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-notifications.js"></script>
       <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-quicksearch.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/rudder-elm.js"></script>
+    <script type="text/javascript" data-lift="with-nonce">
+      $(document).ready(function(){
+        const flags = { contextPath }
+        const appNode  = document.querySelector("rudder-quicksearch")
+        const appQuicksearch = Elm.QuickSearch.init({
+          node  : appNode,
+          flags
+        })
+        appQuicksearch.ports.errorNotification.subscribe(function (str) {
+          createErrorNotification(str)
+        })
+      })
+    </script>
     <script data-lift="with-nonce">
     (function($) {
        $.fn.hasScrollBar = function() {


### PR DESCRIPTION
https://issues.rudder.io/issues/29025

OTP implementation:
* add the config `rudder.auth.otp.enforce=false` by default
* adding new `userstotp` table with its migration
* create a new `/secure/otp.html` Elm page (inspired from login page, which needed some restructuration) and:
  * a dedicated API to get the OTP status (if enrollement is needed)
  * a dedicated Spring filter `OtpAuthenticationFilter` for processing the verification request
  * all that is handled with a new special Spring role: `ROLE_PRE_AUTH`, intercepting the authentication until the code is verified (in which case `ROLE_USER` is put back in authenticated principal)  
* add the OTP status into user management page, and allow to reset a user's OTP from there

Some screens:
* Enrollement + login:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2e7300a2-81ba-412c-a01d-0f96ad7633d2" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/23faca57-9da8-446c-9916-ddb7e9a01d81" />

* OTP login:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4294234c-b8a5-41b9-855c-f8250486a165" />

* User management:
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/126deef6-6896-45f3-966c-8b81059d812b" />
<img width="100%" height="500" alt="image" src="https://github.com/user-attachments/assets/9a06c8fe-15f9-4442-9657-eea1e24b32d9" />
<img width="100%" height="582" alt="image" src="https://github.com/user-attachments/assets/4e014a76-a511-4605-8ba8-6a5bc63a8e4c" />

---
Next steps:
* add unit tests
* some other security enforcement, like "rejecting 3 bad OTP code", add a timeout for filling the OTP page, especially during enrollement where secret is displayed 