### PR TITLE
Fixes #29092: Fix tests on java time

### DIFF
--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/GeneralizedTimeTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/GeneralizedTimeTest.scala
@@ -17,7 +17,7 @@ import zio.test.Assertion.*
 import zio.test.junit.ZTestJUnitRunner
 
 @RunWith(classOf[ZTestJUnitRunner])
-class GeneralizedTimeSpec extends ZIOSpecDefault {
+class GeneralizedTimeTest extends ZIOSpecDefault {
 
   def toGeneralizedTimeString(instant: Instant) = {
     val date = new DateTimeFormatterBuilder()

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -65,11 +65,26 @@ object DateFormaterService {
 
     // see https://stackoverflow.com/a/47753227 - read other solution and the comment in them, too
     def toZonedDateTime: ZonedDateTime = self.toJavaInstant.atZone(ZoneId.of(self.getZone.getID, ZoneId.SHORT_IDS))
+
+    def toOffsetDateTime: OffsetDateTime = {
+      OffsetDateTime.ofInstant(
+        self.toJavaInstant,
+        ZoneOffset.ofTotalSeconds(self.getZone.getOffset(self) / 1000)
+      )
+    }
   }
 
   extension (self: Instant) {
     def toJodaDateTime: DateTime = new DateTime(self.toEpochMilli, DateTimeZone.UTC)
   }
+
+  extension (self: OffsetDateTime)
+    def toJodaDateTime: DateTime = {
+      new DateTime(
+        self.toInstant.toEpochMilli,
+        DateTimeZone.forOffsetMillis(self.getOffset.getTotalSeconds * 1000)
+      )
+    }
 
   implicit class JavaTimeToJoda(x: ZonedDateTime) {
     // see https://stackoverflow.com/a/37335420 - read other solution and the comment in them, too

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/DateFormaterServiceTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/DateFormaterServiceTest.scala
@@ -18,7 +18,7 @@ import zio.test.Assertion.*
 import zio.test.junit.ZTestJUnitRunner
 
 @RunWith(classOf[ZTestJUnitRunner])
-class DateFormaterServiceSpec extends ZIOSpecDefault {
+class DateFormaterServiceTest extends ZIOSpecDefault {
 
   val legacyGitTagFormat = new org.joda.time.format.DateTimeFormatterBuilder()
     .appendYear(4, 4)


### PR DESCRIPTION
https://issues.rudder.io/issues/29092

See https://github.com/Normation/rudder/pull/7135
* Rename the files so that they are executed
* Some extension methods and tests were added in 9.2, they need a fix, so it's just backported along with the fix: millis to seconds is `/ 1000` instead of `/ 2000` :sweat_smile: 