### PR TITLE
Fixes #29098: Still some random test failures for joda and java-time 

### DIFF
--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/GeneralizedTimeTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/GeneralizedTimeTest.scala
@@ -32,7 +32,7 @@ class GeneralizedTimeTest extends ZIOSpecDefault {
       .optionalStart
       .appendValue(SECOND_OF_MINUTE, 2)
       .optionalStart
-      .appendFraction(NANO_OF_SECOND, 0, 3, true)
+      .appendFraction(NANO_OF_SECOND, 3, 3, true)
       .appendOffsetId()
       .toFormatter()
 

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -246,7 +246,7 @@ object DateFormaterService {
       .optionalStart
       .appendValue(SECOND_OF_MINUTE, 2)
       .optionalStart
-      .appendFraction(NANO_OF_SECOND, 0, 3, true)
+      .appendFraction(NANO_OF_SECOND, 3, 3, true)
       .appendOffsetId()
       .toFormatter()
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29098

Joda basic formater had at least 3 digits for nanos, and [DateTime](https://www.joda.org/joda-time/apidocs/org/joda/time/DateTime.html)'s precision is millis, so cannot be up to 9 digits

:arrow_right: so just apply fixed 3 digits to java-time basic formater