### PR TITLE
Fixes #29106: Move technique link from directive hidden details to next to title

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -273,6 +273,26 @@ class DirectiveEditForm(
       case (true, true)   =>
         ("", NodeSeq.Empty)
     }
+
+    val techniqueNameLink = if (isNcfTechnique(technique.id)) {
+      <a href={
+        "/secure/configurationManager/techniqueEditor/technique/" +
+        technique.id.name.value
+      }>
+              {technique.name}
+              version
+              {technique.id.version}
+            </a>
+    } else {
+      <a href={
+        "/secure/administration/maintenance#techniqueTree"
+      }>
+              {technique.name}
+              version
+              {technique.id.version}
+            </a>
+    }
+
     (
       "#editForm" #> { (n: NodeSeq) => SHtml.ajaxForm(n) } andThen
       // don't show the action button when we are creating a popup
@@ -292,6 +312,7 @@ class DirectiveEditForm(
       }</span> &
       "#shortDescription" #> (if (directive.shortDescription.isEmpty) NodeSeq.Empty
                               else <div class="header-description"><p>{directive.shortDescription}</p></div>) &
+      "#techniqueLink" #> techniqueNameLink &
       "#disactivateButtonLabel" #> {
         if (directive.isEnabled) "Disable" else "Enable"
       } &
@@ -309,29 +330,15 @@ class DirectiveEditForm(
         ("type", "button")
       ) &
       // form and form fields
-      "#techniqueName *" #> {
-        if (isNcfTechnique(technique.id)) {
-          <a href={
-            "/secure/configurationManager/techniqueEditor/technique/" +
-            technique.id.name.value
-          }>
-              {technique.name}
-              version
-              {technique.id.version}
-            </a>
-        } else {
-          <a href={
-            "/secure/administration/maintenance#techniqueTree"
-          }>
-              {technique.name}
-              version
-              {technique.id.version}
-            </a>
-        }
-      } &
+      "#techniqueName *" #> techniqueNameLink &
       "#techniqueID *" #> technique.id.name.value &
-      "#showTechniqueDescription *" #> <button type="button" class="btn btn-technical-details btn-default" onclick="$('#techniqueDescriptionPanel').toggle(400);$(this).toggleClass('opened');">technique description</button> &
-      "#techniqueDescription *" #> technique.description &
+      (if (technique.description.isEmpty) {
+         "#showTechniqueDescription *" #> NodeSeq.Empty &
+         "#techniqueDescription" #> NodeSeq.Empty
+       } else {
+         "#showTechniqueDescription *" #> <button type="button" class="btn btn-technical-details btn-default" onclick="$('#techniqueDescriptionPanel').toggle(400);$(this).toggleClass('opened');">technique description</button> &
+         "#techniqueDescription" #> technique.description
+       }) &
       "#isDisabled" #> {
         if (!activeTechnique.isEnabled || !directive.isEnabled) {
           <div class="main-alert alert alert-warning">

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
@@ -31,6 +31,7 @@
           </div>
         </lift:authz>
       </div>
+      <div class="header-description">Based on technique <span id="techniqueLink">techniqueLink</span></div>
       <div class="header-description" id="shortDescription">
       </div>
     </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/29106

Add a small link to the directive's technique near the title. 

Also correct the technique description that was always empty (and hide it if it is empty for real)

<img width="1324" height="1311" alt="image" src="https://github.com/user-attachments/assets/fb222cc4-3743-4a18-99d3-55e3a6aafac6" />
