### PR TITLE
Fixes #29107: Add a tab for directives using the technique in editor

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -144,9 +144,9 @@ mainInit : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 mainInit initValues =
     let
         model =
-            Model [] [] Dict.empty (TechniqueCategory "" "" "" (SubCategories [])) Dict.empty [] Introduction initValues.contextPath (TreeFilters "" []) (MethodListUI (MethodFilter "" False Nothing FilterClosed) []) False DragDrop.initialState Nothing initValues.hasWriteRights Nothing Nothing True []
+            Model [] [] Dict.empty (TechniqueCategory "" "" "" (SubCategories [])) Dict.empty [] Introduction initValues.contextPath (TreeFilters "" []) (MethodListUI (MethodFilter "" False Nothing FilterClosed) []) False DragDrop.initialState Nothing initValues.hasWriteRights Nothing Nothing True [] "default"
     in
-    ( model, Cmd.batch [ getDrafts (), getMethods model, getTechniquesCategories model, getDirectives model ] )
+    ( model, Cmd.batch [ getDrafts (), getMethods model, getTechniquesCategories model, getDirectives model, getPolicyMode model ] )
 
 
 updatedStoreTechnique : Model -> ( Model, Cmd Msg )
@@ -357,6 +357,12 @@ update msg model =
         GetDirectives (Err err) ->
             ( { model | loadingTechniques = False }, errorNotification ("Error when getting directives: " ++ debugHttpErr err) )
 
+        GetPolicyMode (Ok ( _, policyMode )) ->
+            ( { model | policyMode = policyMode }, Cmd.none )
+
+        GetPolicyMode (Err err) ->
+            ( model, errorNotification ("Error when getting global policy mode: " ++ debugHttpErr err) )
+
         OpenTechniques ->
             ( { model | genericMethodsOpen = False }, Cmd.none )
 
@@ -477,7 +483,9 @@ update msg model =
                         m ->
                             m
             in
-            ( { model | mode = newMode }, Cmd.none )
+            -- (re)initialize Bootstrap tooltips so badges rendered in the newly displayed tab
+            -- (eg. the policy mode badges of the Directives tab) get their HTML tooltip wired up
+            ( { model | mode = newMode }, initTooltips () )
 
         UpdateTechnique technique ->
             let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ApiCalls.elm
@@ -269,6 +269,23 @@ getDirectives model =
     req
 
 
+getPolicyMode : Model -> Cmd Msg
+getPolicyMode model =
+    let
+        req =
+            request
+                { method = "GET"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model "settings/global_policy_mode"
+                , body = emptyBody
+                , expect = Detailed.expectJson GetPolicyMode decodeGetPolicyMode
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
+    req
+
+
 ignoreMetadata : Result (Detailed.Error String) ( Http.Metadata, a ) -> Result (Detailed.Error String) a
 ignoreMetadata =
     Result.map Tuple.second

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -334,6 +334,7 @@ type alias Model =
     , isMethodHovered : Maybe MethodId
     , loadingTechniques : Bool
     , recClone : List Msg
+    , policyMode : String
     }
 
 
@@ -478,6 +479,7 @@ type Tab
     = General
     | Parameters
     | Resources
+    | Directives
     | Output
     | None
 
@@ -504,6 +506,7 @@ type Msg
     | SelectDraft DraftId
     | GetTechniques (Result (Http.Detailed.Error String) ( Http.Metadata, List (Either TechniqueError Technique) ))
     | GetDirectives (Result (Http.Detailed.Error String) ( Http.Metadata, List Directive ))
+    | GetPolicyMode (Result (Http.Detailed.Error String) ( Http.Metadata, String ))
     | GetYaml (Result (Http.Detailed.Error String) ( Http.Metadata, String ))
     | SaveTechnique (Result (Http.Detailed.Error String) ( Http.Metadata, Technique ))
     | UpdateTechnique Technique

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
@@ -135,6 +135,11 @@ decodePolicyMode =
         string
 
 
+decodeGetPolicyMode : Decoder String
+decodeGetPolicyMode =
+    at [ "data", "settings", "global_policy_mode" ] string
+
+
 decodeBlock : Decoder MethodBlock
 decodeBlock =
     succeed MethodBlock

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -731,6 +731,25 @@ showTechnique model technique origin ui editInfo =
                             ]
                         ]
                     ]
+                , li [ class "nav-item" ]
+                    [ button
+                        [ attribute "role" "tab", type_ "button", class ("nav-link " ++ activeTabClass Directives), onClick (SwitchTab Directives) ]
+                        [ text "Directives "
+                        , span
+                            [ class
+                                ("badge badge-secondary badge-resources "
+                                    ++ (if List.isEmpty (getDirectivesBaseOnTechnique technique.id model.directives) then
+                                            "empty"
+
+                                        else
+                                            ""
+                                       )
+                                )
+                            ]
+                            [ span [] [ text (String.fromInt (List.length (getDirectivesBaseOnTechnique technique.id model.directives))) ]
+                            ]
+                        ]
+                    ]
                 , if Maybe.Extra.isJust technique.output then
                     li [ class "nav-item" ]
                         [ button
@@ -747,29 +766,33 @@ showTechnique model technique origin ui editInfo =
         , div [ class "main-details", id "details" ]
             [ div [ class "editForm", name "ui.editForm" ]
                 [ techniqueTab model technique creation ui
-                , div [ class "row" ]
-                    [ h5 []
-                        [ text "Methods"
-                        , span [ class "badge badge-secondary" ]
-                            [ span [] [ text (String.fromInt (List.length technique.elems)) ]
+                , if ui.tab == Directives then
+                    text ""
+
+                  else
+                    div [ class "row" ]
+                        [ h5 []
+                            [ text "Methods"
+                            , span [ class "badge badge-secondary" ]
+                                [ span [] [ text (String.fromInt (List.length technique.elems)) ]
+                                ]
+                            , if model.genericMethodsOpen || not model.hasWriteRights then
+                                text ""
+
+                              else
+                                button [ class "btn-sm btn btn-success", type_ "button", onClick OpenMethods ]
+                                    [ text "Add "
+                                    , i [ class "fa fa-plus-circle" ] []
+                                    ]
                             ]
-                        , if model.genericMethodsOpen || not model.hasWriteRights then
-                            text ""
+                        , if editInfo.open then
+                            div [ class "col-sm-12" ]
+                                [ viewYamlEdit editInfo.value
+                                ]
 
                           else
-                            button [ class "btn-sm btn btn-success", type_ "button", onClick OpenMethods ]
-                                [ text "Add "
-                                , i [ class "fa fa-plus-circle" ] []
-                                ]
+                            render methodsList
                         ]
-                    , if editInfo.open then
-                        div [ class "col-sm-12" ]
-                            [ viewYamlEdit editInfo.value
-                            ]
-
-                      else
-                        render methodsList
-                    ]
                 ]
             ]
         ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
@@ -1,7 +1,9 @@
 module Editor.ViewTechniqueTabs exposing (..)
 
+import Compliance.Utils exposing (badgePolicyMode)
 import Editor.AgentValueParser exposing (..)
 import Editor.DataTypes exposing (..)
+import Editor.MethodElemUtils exposing (policyModeValue)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -44,6 +46,56 @@ techniqueResource resource =
                 [ i [ class "ion ion-clipboard" ] []
                 ]
             ]
+        ]
+
+
+techniqueDirectives : Model -> Technique -> Html Msg
+techniqueDirectives model technique =
+    let
+        directives =
+            getDirectivesBaseOnTechnique technique.id model.directives
+
+        directiveRow directive =
+            let
+                directiveLink =
+                    model.contextPath ++ "/secure/configurationManager/directiveManagement#{\"directiveId\":\"" ++ directive.id.value ++ "\"}"
+            in
+            tr []
+                [ td [] [ a [ href directiveLink ] [ text directive.displayName ] ]
+                , td [] [ text directive.shortDescription ]
+                , td [] [ badgePolicyMode model.policyMode (policyModeValue (Just directive.policyMode)) ]
+                , td []
+                    [ text
+                        (if directive.enabled then
+                            "Enabled"
+
+                         else
+                            "Disabled"
+                        )
+                    ]
+                ]
+    in
+    div [ class "tab tab-directives" ]
+        [ if List.isEmpty directives then
+            ul [ class "files-list" ]
+                [ li [ class "empty" ]
+                    [ span [] [ text "There is no directive based on this technique." ]
+                    , span [ class "warning-sign" ] [ i [ class "fa fa-info-circle" ] [] ]
+                    ]
+                ]
+
+          else
+            table [ class "table" ]
+                [ thead []
+                    [ tr []
+                        [ th [] [ text "Name" ]
+                        , th [] [ text "Description" ]
+                        , th [] [ text "Policy Mode" ]
+                        , th [] [ text "Status" ]
+                        ]
+                    ]
+                , tbody [] (List.map directiveRow directives)
+                ]
         ]
 
 
@@ -689,6 +741,9 @@ techniqueTab model technique creation ui =
                         ]
                     ]
                 ]
+
+        Directives ->
+            techniqueDirectives model technique
 
         Output ->
             case technique.output of


### PR DESCRIPTION
https://issues.rudder.io/issues/29107

Add a directive tab for techniques: 

<img width="2581" height="571" alt="image" src="https://github.com/user-attachments/assets/12417da9-c711-480a-8508-2c901e7c8fd9" />

Most of the business code was already present, because we use the list of directive to add a little tag with directives used... But with no link toward the directives, which is a bit sad. 

And most of the change are just about getting the global policy mode (copied from rule elm app). 

The directive tab is minimalist with just the list of directives (clickable name, short description, policy mode, enabled). 

AI disclosure: added with the help of Claude Code 2.0.1 - opus 4.8
