### PR TITLE
Fixes #29030: Export Group compliance by Rule to CSV

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/groups/compliance.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/compliance.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/groups/compliance?groups=g1,g2,g3'

--- a/webapp/sources/api-doc/code_samples/curl/groups/global-compliance-by-rule-id.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/global-compliance-by-rule-id.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/global/byRule'

--- a/webapp/sources/api-doc/code_samples/curl/groups/global-compliance-id.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/global-compliance-id.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/global'

--- a/webapp/sources/api-doc/code_samples/curl/groups/targeted-compliance-by-rule-id.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/targeted-compliance-by-rule-id.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/targeted/byRule'

--- a/webapp/sources/api-doc/code_samples/curl/groups/targeted-compliance-id.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/targeted-compliance-id.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/targeted'

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -307,6 +307,16 @@ paths:
     $ref: paths/groups/categories.yml
   "/groups/tree":
     $ref: paths/groups/tree.yml
+  "/groups/compliance":
+    $ref: paths/groups/compliance.yml
+  "/groups/{targetOrNodeGroupId}/compliance/global":
+    $ref: paths/groups/global-compliance-id.yml
+  "/groups/{targetOrNodeGroupId}/compliance/targeted":
+    $ref: paths/groups/targeted-compliance-id.yml
+  "/groups/{targetOrNodeGroupId}/compliance/global/byRule":
+    $ref: paths/groups/global-compliance-by-rule-id.yml
+  "/groups/{targetOrNodeGroupId}/compliance/targeted/byRule":
+    $ref: paths/groups/targeted-compliance-by-rule-id.yml
   "/directives":
     $ref: paths/directives/all.yml
   "/directives/{directiveId}":

--- a/webapp/sources/api-doc/paths/groups/compliance.yml
+++ b/webapp/sources/api-doc/paths/groups/compliance.yml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2026 Normation SAS
+get:
+  summary: Get compliance for a given list of node groups
+  description: Get targeted and global compliance of all selected groups
+  operationId: getNodeGroupCompliance
+  parameters:
+    - in: query
+      name: groups
+      schema:
+        type: string
+      description: list of node group ids
+      example: g1,g2,g3
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getNodeGroupCompliance
+              data:
+                type: object
+                required:
+                  - groupCompliance
+                properties:
+                  groupCompliance:
+                    type: array
+                    items:
+                      type: object
+                      required: 
+                        - id
+                        - targeted
+                        - global
+                      properties: 
+                        id:
+                          type: string
+                          format: uuid
+                          description: id of the group
+                          example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+                        targeted:
+                          type: object
+                          required:
+                            - id
+                            - mode
+                            - compliance
+                            - complianceDetails
+                            - rules
+                            - nodes
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                              description: id of the group
+                              example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+                            mode:
+                              type: string
+                              enum:
+                                - full-compliance
+                                - changes-only
+                                - reports-disabled
+                            compliance:
+                              type: number
+                              format: float
+                              description: Group compliance level
+                              example: 57.43
+                            complianceDetails:
+                              $ref: ../../components/schemas/compliance-details.yml
+                            rules:
+                              type: array
+                              items:
+                                $ref: ../../components/schemas/group-rule-compliance.yml
+                            nodes:
+                              type: array
+                              items:
+                                $ref: ../../components/schemas/group-node-compliance.yml
+                        global:
+                          type: object
+                          required:
+                            - id
+                            - mode
+                            - compliance
+                            - complianceDetails
+                            - rules
+                            - nodes
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                              description: id of the group
+                              example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+                            mode:
+                              type: string
+                              enum:
+                                - full-compliance
+                                - changes-only
+                                - reports-disabled
+                            compliance:
+                              type: number
+                              format: float
+                              description: Group compliance level
+                              example: 57.43
+                            complianceDetails:
+                              $ref: ../../components/schemas/compliance-details.yml
+                            rules:
+                              type: array
+                              items:
+                                $ref: ../../components/schemas/group-rule-compliance.yml
+                            nodes:
+                              type: array
+                              items:
+                                $ref: ../../components/schemas/group-node-compliance.yml
+  tags:
+    - Groups
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/groups/compliance.sh
+
+

--- a/webapp/sources/api-doc/paths/groups/global-compliance-by-rule-id.yml
+++ b/webapp/sources/api-doc/paths/groups/global-compliance-by-rule-id.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2026 Normation SAS
+get:
+  summary: Global compliance details of a group by rule
+  description: Get global compliance of a group with all rules that apply to a node within the group, sorted by rule
+  operationId: getGlobalNodeGroupComplianceByRuleId
+  parameters:
+    - in: query
+      name: format
+      schema:
+        type: string
+        enum:
+          - csv
+          - json
+        default: json
+      description: format of export
+      style: form
+      explode: false
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getGlobalNodeGroupComplianceByRuleId
+              data:
+                type: object
+                required:
+                  - rules
+                properties:
+                  rules:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/group-rule-compliance.yml
+        text/plain:
+          schema:
+            type: string
+          example: |
+            "Rule","Directive","Block","Component","Node","Value","Status","Message"
+            "R1","25. Testing blocks","","directive-techniqueWithBlocks-component-r1-n1","node1.localhost","directive-techniqueWithBlocks-component-value-r1-n1","successAlreadyOK",""
+            "R2","directive 99f4ef91-537b-4e03-97bc-e65b447514cc","","99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1","node1.localhost","99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1","successRepaired",""
+            "R3","directive2","","directive2-component-r3-n1","node1.localhost","directive2-component-value-r3-n1","error",""
+  tags:
+    - Groups
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/groups/global-compliance-by-rule-id.sh
+
+

--- a/webapp/sources/api-doc/paths/groups/global-compliance-id.yml
+++ b/webapp/sources/api-doc/paths/groups/global-compliance-id.yml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2026 Normation SAS
+get:
+  summary: Global compliance details of a group
+  description: Get global compliance of a group with all rules that apply to a node within the group.
+  operationId: getGlobalNodeGroupComplianceId
+  parameters:
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getGlobalNodeGroupComplianceId
+              data:
+                type: object
+                required:
+                  - groupCompliance
+                properties:
+                  groupCompliance:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - mode
+                        - compliance
+                        - complianceDetails
+                        - rules
+                        - nodes
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: id of the group
+                          example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+                        mode:
+                          type: string
+                          enum:
+                            - full-compliance
+                            - changes-only
+                            - reports-disabled
+                        compliance:
+                          type: number
+                          format: float
+                          description: Group compliance level
+                          example: 57.43
+                        complianceDetails:
+                          $ref: ../../components/schemas/compliance-details.yml
+                        rules:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-rule-compliance.yml
+                        nodes:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-node-compliance.yml
+  tags:
+    - Groups
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/groups/global-compliance-id.sh
+
+

--- a/webapp/sources/api-doc/paths/groups/targeted-compliance-by-rule-id.yml
+++ b/webapp/sources/api-doc/paths/groups/targeted-compliance-by-rule-id.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2026 Normation SAS
+get:
+  summary: Targeted compliance details of a group by rule
+  description: Get targeted compliance of a group with only rules that explicitly include the group, sorted by rule
+  operationId: getTargetedNodeGroupComplianceByRuleId
+  parameters:
+    - in: query
+      name: format
+      schema:
+        type: string
+        enum:
+          - csv
+          - json
+        default: json
+      description: format of export
+      style: form
+      explode: false
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getTargetedNodeGroupComplianceByRuleId
+              data:
+                type: object
+                required:
+                  - rules
+                properties:
+                  rules:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/group-rule-compliance.yml
+        text/plain:
+          schema:
+            type: string
+          example: |
+            "Rule","Directive","Block","Component","Node","Value","Status","Message"
+            "R3","directive2","","directive2-component-r3-n1","node1.localhost","directive2-component-value-r3-n1","error",""
+  tags:
+    - Groups
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/groups/targeted-compliance-by-rule-id.sh
+
+

--- a/webapp/sources/api-doc/paths/groups/targeted-compliance-id.yml
+++ b/webapp/sources/api-doc/paths/groups/targeted-compliance-id.yml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2026 Normation SAS
+get:
+  summary: Targeted compliance details of a group
+  description: Get targeted compliance of a group with only rules that explicitly include the group.
+  operationId: getTargetedNodeGroupComplianceId
+  parameters:
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getTargetedNodeGroupComplianceId
+              data:
+                type: object
+                required:
+                  - groupCompliance
+                properties:
+                  groupCompliance:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - mode
+                        - compliance
+                        - complianceDetails
+                        - rules
+                        - nodes
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: id of the group
+                          example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+                        mode:
+                          type: string
+                          enum:
+                            - full-compliance
+                            - changes-only
+                            - reports-disabled
+                        compliance:
+                          type: number
+                          format: float
+                          description: Group compliance level
+                          example: 57.43
+                        complianceDetails:
+                          $ref: ../../components/schemas/compliance-details.yml
+                        rules:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-rule-compliance.yml
+                        nodes:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-node-compliance.yml
+  tags:
+    - Groups
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/groups/targeted-compliance-id.sh
+
+

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -275,50 +275,57 @@ sealed trait GroupApi extends EnumEntry with EndpointSchema with SortIndex    {
 }
 object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
   // API v2
-  case object ListGroups               extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object ListGroups               extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "List all groups with their information"
     val (action, path) = GET / "groups"
     val authz: List[AuthorizationType] = AuthorizationType.Group.Read :: Nil
   }
-  case object CreateGroup              extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object CreateGroup              extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Create a new group"
     val (action, path) = PUT / "groups"
     val authz: List[AuthorizationType] = AuthorizationType.Group.Write :: Nil
   }
-  case object GetGroupTree             extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion6 with SortIndex {
+  case object GetGroupTree             extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "List all group categories and group in a tree format"
     val (action, path) = GET / "groups" / "tree"
     val authz:                  List[AuthorizationType] = AuthorizationType.Group.Read :: Nil
     override def dataContainer: None.type               = None
   }
-  case object GroupDetails             extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object GetNodeGroupCompliance   extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get compliance for a given list of node groups"
+    val (action, path) = GET / "groups" / "compliance"
+    override def dataContainer: Option[String]          = Some("groupCompliance")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GroupDetails             extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Get information about the given group"
     val (action, path) = GET / "groups" / "{id}"
     val authz: List[AuthorizationType] = AuthorizationType.Group.Read :: Nil
   }
-  case object DeleteGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object DeleteGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Delete given group"
     val (action, path) = DELETE / "groups" / "{id}"
     val authz: List[AuthorizationType] = AuthorizationType.Group.Write :: Nil
   }
-  case object UpdateGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object UpdateGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Update given group"
     val (action, path) = POST / "groups" / "{id}"
     val authz: List[AuthorizationType] = AuthorizationType.Group.Write :: Nil
   }
-  case object ReloadGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object ReloadGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Update given dynamic group node list"
     val (action, path) = GET / "groups" / "{id}" / "reload"
     val authz: List[AuthorizationType] = AuthorizationType.Group.Write :: Nil
   }
-  case object GroupInheritedProperties extends GroupApi with GeneralApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object GroupInheritedProperties extends GroupApi with GeneralApi with OneParam with StartsAtVersion11 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get all proporeties for that group, included inherited ones"
     val (action, path) = GET / "groups" / "{id}" / "inheritedProperties"
@@ -362,6 +369,39 @@ object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
     val (action, path) = PUT / "groups" / "categories"
     override def dataContainer: None.type               = None
     val authz:                  List[AuthorizationType] = AuthorizationType.Group.Write :: Nil
+  }
+  // API v24
+  case object GetGlobalNodeGroupComplianceId
+      extends GroupApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Get a node group's global compliance"
+    val (action, path) = GET / "groups" / "{id}" / "compliance" / "global"
+    override def dataContainer: Option[String]          = Some("groupCompliance")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GetTargetedNodeGroupComplianceId
+      extends GroupApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Get a node group's targeted compliance"
+    val (action, path) = GET / "groups" / "{id}" / "compliance" / "targeted"
+    override def dataContainer: Option[String]          = Some("groupCompliance")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GetGlobalNodeGroupComplianceByRuleId
+      extends GroupApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Get a node group's global compliance by rule"
+    val (action, path) = GET / "groups" / "{id}" / "compliance" / "global" / "byRule"
+    override def dataContainer: Option[String]          = Some("rules")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GetTargetedNodeGroupComplianceByRuleId
+      extends GroupApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Get a node group's targeted compliance by rule"
+    val (action, path) = GET / "groups" / "{id}" / "compliance" / "targeted" / "byRule"
+    override def dataContainer: Option[String]          = Some("rules")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
   }
 
   def endpoints: List[GroupApi] = values.toList.sortBy(_.z)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -43,9 +43,14 @@ import cats.syntax.list.*
 import com.normation.cfclerk.domain.ReportingLogic
 import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
+import com.normation.errors.PureResult
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.SimpleTarget
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.ReportType.*
 import com.normation.rudder.reports.ComplianceModeName
@@ -453,6 +458,8 @@ final case class ByNodeDirectiveCompliance(
  */
 object CsvCompliance {
 
+  import CsvComplianceTypes.*
+
   // use "," , quote everything with ", line separator is \n
   val csvFormat: CSVFormat = CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).setRecordSeparator("\n").get()
 
@@ -500,48 +507,57 @@ object CsvCompliance {
     }
   }
 
-  /** Trait that contains Csv[A] and Csv.Header.One[A] instances 
-   * that are common to all values that can be converted to CSV */
-  trait CsvField[A <: String] {
-    given Csv[A] = Csv.instance(a => a)
-    given Csv.Header.One[A] with {}
-  }
+  object CsvComplianceTypes {
 
-  opaque type DirectiveField = String
-  object DirectiveField extends CsvField[DirectiveField] {
-    def apply(directive: ByRuleDirectiveCompliance) = directive.name
-  }
+    /** Trait that contains Csv[A] and Csv.Header.One[A] instances 
+     * that are common to all values that can be converted to CSV */
+    trait CsvField[A <: String] {
+      given Csv[A] = Csv.instance(a => a)
+      given Csv.Header.One[A] with {}
+    }
 
-  opaque type BlockField = String
-  object BlockField extends CsvField[BlockField] {
-    def apply(block: List[ComponentField]) = block.mkString(",")
-  }
+    opaque type DirectiveField = String
+    object DirectiveField extends CsvField[DirectiveField] {
+      def apply(directive: ByRuleDirectiveCompliance): DirectiveField = directive.name
+      def apply(directive: String):                    DirectiveField = directive
+    }
 
-  opaque type ComponentField = String
-  object ComponentField extends CsvField[ComponentField] {
-    def apply(value: ByRuleValueCompliance) = value.name
-    def apply(block: ByRuleBlockCompliance) = block.name
-  }
+    opaque type BlockField = String
+    object BlockField extends CsvField[BlockField] {
+      def apply(block: List[ComponentField]): BlockField = block.mkString(",")
+    }
 
-  opaque type NodeField = String
-  object NodeField extends CsvField[NodeField] {
-    def apply(node: ByRuleNodeCompliance) = node.name
-  }
+    opaque type ComponentField = String
+    object ComponentField extends CsvField[ComponentField] {
+      def apply(value: ByRuleValueCompliance): ComponentField = value.name
+      def apply(block: ByRuleBlockCompliance): ComponentField = block.name
+    }
 
-  opaque type ValueField = String
-  object ValueField extends CsvField[ValueField] {
-    def apply(value: ComponentValueStatusReport) = value.componentValue
-  }
+    opaque type NodeField = String
+    object NodeField extends CsvField[NodeField] {
+      def apply(node: ByRuleNodeCompliance): NodeField = node.name
+    }
 
-  opaque type StatusField = String
-  object StatusField extends CsvField[StatusField] {
-    import com.normation.rudder.rest.data.ComplianceApiData.serialize
-    def apply(report: MessageStatusReport) = report.reportType.serialize
-  }
+    opaque type ValueField = String
+    object ValueField extends CsvField[ValueField] {
+      def apply(value: ComponentValueStatusReport): ValueField = value.componentValue
+    }
 
-  opaque type MessageField = String
-  object MessageField extends CsvField[MessageField] {
-    def apply(report: MessageStatusReport) = report.message.getOrElse("")
+    opaque type StatusField = String
+    object StatusField extends CsvField[StatusField] {
+      import com.normation.rudder.rest.data.ComplianceApiData.serialize
+      def apply(report: MessageStatusReport): StatusField = report.reportType.serialize
+    }
+
+    opaque type MessageField = String
+    object MessageField extends CsvField[MessageField] {
+      def apply(report: MessageStatusReport): MessageField = report.message.getOrElse("")
+    }
+
+    opaque type RuleField = String
+    object RuleField extends CsvField[RuleField] {
+      def apply(ruleName: String): RuleField = ruleName
+    }
   }
 
   type RuleComponentResult =
@@ -613,6 +629,46 @@ object CsvCompliance {
           res.transformInto[RuleComplianceByNodeCsv]
         }
       })
+    }
+  }
+
+  case class NodeGroupComplianceByRuleCsv(
+      rule:      RuleField,
+      directive: DirectiveField,
+      block:     BlockField,
+      component: ComponentField,
+      node:      NodeField,
+      value:     ValueField,
+      status:    StatusField,
+      message:   MessageField
+  ) derives Csv
+
+  object NodeGroupComplianceByRuleCsv {
+
+    given (using
+        rule:      RuleField,
+        directive: DirectiveField
+    ): Transformer[RuleComponentResult, NodeGroupComplianceByRuleCsv] = {
+      Transformer
+        .define[RuleComponentResult, NodeGroupComplianceByRuleCsv]
+        .withFieldConst(_.rule, rule)
+        .withFieldConst(_.directive, directive)
+        .buildTransformer
+    }
+
+    given Transformer[Seq[ByNodeGroupRuleCompliance], Seq[NodeGroupComplianceByRuleCsv]] = {
+      (rules: Seq[ByNodeGroupRuleCompliance]) =>
+        rules.flatMap(rule => {
+          rule.directives.flatMap(directive => {
+            directive.components.flatMap(component => {
+              given RuleField      = RuleField(rule.name)
+              given DirectiveField = DirectiveField(directive.name)
+              val components       = recurseComponent(component, Nil)
+
+              components.map(_.transformInto[NodeGroupComplianceByRuleCsv])
+            })
+          })
+        })
     }
   }
 }
@@ -1378,5 +1434,13 @@ object ComplianceUtils {
       case Some(format :: _)                  =>
         ComplianceFormat.fromValue(format).left.map(Inconsistency.apply).toIO
     }
+  }
+
+  def parseSimpleTargetOrNodeGroupId(str: String): PureResult[SimpleTarget] = {
+    // attempt to parse a "target" first because format is more specific
+    RuleTarget
+      .unserOne(str)
+      .orElse(NodeGroupId.parse(str).map(GroupTarget(_)).left.map(Inconsistency(_)))
+      .chainError("Could not parse the node group id or group target")
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -42,7 +42,6 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
-import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies.AllPolicyServers
 import com.normation.rudder.domain.policies.AllTarget
 import com.normation.rudder.domain.policies.AllTargetExceptPolicyServers
@@ -295,7 +294,7 @@ class ComplianceApi(
       (for {
         precision <- ComplianceUtils.extractPercentPrecision(req.params)
         targets    = req.params.getOrElse("groups", List.empty).flatMap { nodeGroups =>
-                       nodeGroups.split(",").toList.flatMap(parseSimpleTargetOrNodeGroupId(_).toOption)
+                       nodeGroups.split(",").toList.flatMap(ComplianceUtils.parseSimpleTargetOrNodeGroupId(_).toOption)
                      }
 
         group <- complianceService.getNodeGroupComplianceSummary(targets, precision)
@@ -335,7 +334,9 @@ class ComplianceApi(
       (for {
         level     <- ComplianceUtils.extractComplianceLevel(req.params)
         precision <- ComplianceUtils.extractPercentPrecision(req.params)
-        target    <- parseSimpleTargetOrNodeGroupId(groupId).chainError("Could not parse the node group id or group target").toIO
+        target    <- ComplianceUtils
+                       .parseSimpleTargetOrNodeGroupId(groupId)
+                       .toIO
         group     <- complianceService.getNodeGroupCompliance(target, level)
       } yield {
         given l: Int                 = level.getOrElse(10)
@@ -366,7 +367,9 @@ class ComplianceApi(
       (for {
         level     <- ComplianceUtils.extractComplianceLevel(req.params)
         precision <- ComplianceUtils.extractPercentPrecision(req.params)
-        target    <- parseSimpleTargetOrNodeGroupId(groupId).chainError("Could not parse the node group id or group target").toIO
+        target    <- ComplianceUtils
+                       .parseSimpleTargetOrNodeGroupId(groupId)
+                       .toIO
         group     <- complianceService.getNodeGroupCompliance(target, level, isGlobalCompliance = false)
       } yield {
         given l: Int                 = level.getOrElse(10)
@@ -478,11 +481,6 @@ class ComplianceApi(
         optCompliance.transformInto[ComplianceApiData.JsonGlobalCompliance.GlobalComplianceApi].withContainer
       }).chainError("Could not get global compliance (for non system rules)").toLiftResponseOne(params, schema, None)
     }
-  }
-
-  private def parseSimpleTargetOrNodeGroupId(str: String): PureResult[SimpleTarget] = {
-    // attempt to parse a "target" first because format is more specific
-    RuleTarget.unserOne(str).orElse(NodeGroupId.parse(str).map(GroupTarget(_)).left.map(Inconsistency(_)))
   }
 
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.properties.FailedNodePropertyHierarchy
 import com.normation.rudder.domain.properties.SuccessNodePropertyHierarchy
 import com.normation.rudder.domain.properties.Visibility.Displayed
+import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.properties.NodePropertiesService
 import com.normation.rudder.properties.PropertiesRepository
@@ -60,15 +61,21 @@ import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.rest.{GroupApi as API, *}
 import com.normation.rudder.rest.RudderJsonRequest.*
+import com.normation.rudder.rest.data.ComplianceApiData
+import com.normation.rudder.rest.data.ComplianceFormat
+import com.normation.rudder.rest.data.ComplianceUtils
+import com.normation.rudder.rest.data.CsvCompliance.NodeGroupComplianceByRuleCsv
 import com.normation.rudder.rest.syntax.*
 import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.rudder.services.queries.QueryProcessor
 import com.normation.rudder.services.workflows.*
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
+import com.normation.utils.Csv.toCsv
 import com.normation.utils.StringUuidGenerator
 import io.scalaland.chimney.syntax.*
 import net.liftweb.http.LiftResponse
+import net.liftweb.http.PlainTextResponse
 import net.liftweb.http.Req
 import zio.Chunk
 import zio.ZIO
@@ -79,7 +86,8 @@ class GroupsApi(
     zioJsonExtractor:    ZioJsonExtractor,
     uuidGen:             StringUuidGenerator,
     userPropertyService: UserPropertyService,
-    service:             GroupApiService14
+    service:             GroupApiService14,
+    complianceService:   ComplianceAPIService
 ) extends LiftApiModuleProvider[API] {
 
   implicit def reasonBehavior: ReasonBehavior = userPropertyService.reasonsFieldBehavior
@@ -92,19 +100,24 @@ class GroupsApi(
    */
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map {
-      case API.ListGroups                      => List
-      case API.GetGroupTree                    => GetTree
-      case API.GroupDetails                    => Get
-      case API.GroupInheritedProperties        => GroupInheritedProperties
-      case API.GroupDisplayInheritedProperties => GroupDisplayInheritedProperties
-      case API.DeleteGroup                     => Delete
-      case API.CreateGroup                     => Create
-      case API.UpdateGroup                     => Update
-      case API.DeleteGroupCategory             => DeleteCategory
-      case API.CreateGroupCategory             => CreateCategory
-      case API.GetGroupCategoryDetails         => GetCategory
-      case API.UpdateGroupCategory             => UpdateCategory
-      case API.ReloadGroup                     => Reload
+      case API.ListGroups                             => List
+      case API.GetGroupTree                           => GetTree
+      case API.GroupDetails                           => Get
+      case API.GroupInheritedProperties               => GroupInheritedProperties
+      case API.GroupDisplayInheritedProperties        => GroupDisplayInheritedProperties
+      case API.DeleteGroup                            => Delete
+      case API.CreateGroup                            => Create
+      case API.UpdateGroup                            => Update
+      case API.DeleteGroupCategory                    => DeleteCategory
+      case API.CreateGroupCategory                    => CreateCategory
+      case API.GetGroupCategoryDetails                => GetCategory
+      case API.UpdateGroupCategory                    => UpdateCategory
+      case API.ReloadGroup                            => Reload
+      case API.GetNodeGroupCompliance                 => GetNodeGroupCompliance
+      case API.GetGlobalNodeGroupComplianceId         => GetGlobalNodeGroupComplianceId
+      case API.GetTargetedNodeGroupComplianceId       => GetTargetedNodeGroupComplianceId
+      case API.GetGlobalNodeGroupComplianceByRuleId   => GetGlobalNodeGroupComplianceByRuleId
+      case API.GetTargetedNodeGroupComplianceByRuleId => GetTargetedNodeGroupComplianceByRuleId
     }
   }
 
@@ -415,6 +428,184 @@ class GroupsApi(
         None
       )
     }
+  }
+
+  object GetNodeGroupCompliance extends LiftApiModule0 {
+    override val schema: API.GetNodeGroupCompliance.type = API.GetNodeGroupCompliance
+
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      (for {
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        targets    = req.params.getOrElse("groups", scala.List.empty).flatMap { nodeGroups =>
+                       nodeGroups.split(",").toList.flatMap(ComplianceUtils.parseSimpleTargetOrNodeGroupId(_).toOption)
+                     }
+
+        group <- complianceService.getNodeGroupComplianceSummary(targets, precision)
+      } yield {
+        given l: Int = 1 // it's a summary
+
+        given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+
+        group.toList.map {
+          case (id, (global, targeted)) =>
+            ComplianceApiData.JsonByNodeGroupCompliance.ByNodeGroupSummaryApi(
+              id,
+              targeted.transformInto[ComplianceApiData.JsonByNodeGroupCompliance.ByNodeGroupComplianceApi],
+              global.transformInto[ComplianceApiData.JsonByNodeGroupCompliance.ByNodeGroupComplianceApi]
+            )
+        }
+      }).toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { x =>
+        given f: Boolean = params.prettify
+
+        RudderJsonResponse.successList(RudderJsonResponse.toResponseSchema(schema), x)
+      }
+    }
+  }
+
+  object GetGlobalNodeGroupComplianceId extends LiftApiModule {
+    override val schema: OneParam = API.GetGlobalNodeGroupComplianceId
+
+    override def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        groupId:    String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      (for {
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        target    <- ComplianceUtils
+                       .parseSimpleTargetOrNodeGroupId(groupId)
+                       .toIO
+        group     <- complianceService.getNodeGroupCompliance(target, level)
+      } yield {
+        given l: Int = level.getOrElse(10)
+
+        given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+
+        group.transformInto[ComplianceApiData.JsonByNodeGroupCompliance.ByNodeGroupComplianceApi]
+      }).toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { x =>
+        given f: Boolean = params.prettify
+
+        RudderJsonResponse.successOne(RudderJsonResponse.toResponseSchema(schema), x, None)
+      }
+    }
+  }
+
+  object GetTargetedNodeGroupComplianceId extends LiftApiModule {
+    override val schema: OneParam = API.GetTargetedNodeGroupComplianceId
+
+    override def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        groupId:    String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      (for {
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        target    <- ComplianceUtils
+                       .parseSimpleTargetOrNodeGroupId(groupId)
+                       .toIO
+        group     <- complianceService.getNodeGroupCompliance(target, level, isGlobalCompliance = false)
+      } yield {
+        given l: Int = level.getOrElse(10)
+
+        given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+
+        group.transformInto[ComplianceApiData.JsonByNodeGroupCompliance.ByNodeGroupComplianceApi]
+      }).toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { x =>
+        given f: Boolean = params.prettify
+
+        RudderJsonResponse.successOne(RudderJsonResponse.toResponseSchema(schema), x, None)
+      }
+    }
+  }
+
+  private def getNodeGroupComplianceByRuleId(groupId: String, req: Req, params: DefaultParams, isGlobalCompliance: Boolean)(using
+      qc:     QueryContext,
+      schema: OneParam
+  ): LiftResponse = {
+    (for {
+      level     <- ComplianceUtils.extractComplianceLevel(req.params)
+      precision <- ComplianceUtils.extractPercentPrecision(req.params)
+      format    <- ComplianceUtils.extractComplianceFormat(req.params)
+      target    <- ComplianceUtils
+                     .parseSimpleTargetOrNodeGroupId(groupId)
+                     .toIO
+      group     <- complianceService.getNodeGroupCompliance(target, level, isGlobalCompliance)
+    } yield (level, precision, format, group)).toLiftResponseGeneric(params, schema, IdTrace.Const(None)) {
+      (level, precision, format, group) =>
+        format match {
+          case ComplianceFormat.CSV  =>
+            PlainTextResponse(group.rules.transformInto[Seq[NodeGroupComplianceByRuleCsv]].toCsv)
+          case ComplianceFormat.JSON =>
+            given l: Int                 = level.getOrElse(10)
+            given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+            given f: Boolean             = params.prettify
+
+            val complianceJson = group
+              .transformInto[ComplianceApiData.JsonByNodeGroupCompliance.ByNodeGroupComplianceApi]
+              .rules
+              .getOrElse(Seq.empty)
+              .toList
+            RudderJsonResponse.successList(RudderJsonResponse.toResponseSchema(schema), complianceJson)
+        }
+    }
+  }
+
+  object GetGlobalNodeGroupComplianceByRuleId extends LiftApiModule {
+    override val schema: OneParam = API.GetGlobalNodeGroupComplianceByRuleId
+
+    override def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        groupId:    String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+      given OneParam = schema
+
+      getNodeGroupComplianceByRuleId(groupId, req, params, isGlobalCompliance = true)
+    }
+
+  }
+
+  object GetTargetedNodeGroupComplianceByRuleId extends LiftApiModule {
+    override val schema: OneParam = API.GetTargetedNodeGroupComplianceByRuleId
+
+    override def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        groupId:    String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+      given OneParam = schema
+
+      getNodeGroupComplianceByRuleId(groupId, req, params, isGlobalCompliance = false)
+    }
+
   }
 
   // Extracts reason from the request and provide an (implicit ChangeContext)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -3225,8 +3225,785 @@ response:
         }
       }
     }
-
-
+---
+description: Get compliance for all node groups
+method: GET
+url: /api/latest/groups/compliance?groups=g1,g2,g3
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupCompliance",
+      "result" : "success",
+      "data" : {
+        "groupCompliance" : [
+          {
+            "id" : "g1",
+            "targeted" : {
+              "id" : "g1",
+              "name" : "G1",
+              "compliance" : 60.0,
+              "mode" : "full-compliance",
+              "complianceDetails" : {
+                "successAlreadyOK" : 40.0,
+                "successRepaired" : 20.0,
+                "error" : 40.0
+              }
+            },
+            "global" : {
+              "id" : "g1",
+              "name" : "G1",
+              "compliance" : 60.0,
+              "mode" : "full-compliance",
+              "complianceDetails" : {
+                "successAlreadyOK" : 40.0,
+                "successRepaired" : 20.0,
+                "error" : 40.0
+              }
+            }
+          },
+          {
+            "id" : "g2",
+            "targeted" : {
+              "id" : "g2",
+              "name" : "G2",
+              "compliance" : 0.0,
+              "mode" : "full-compliance",
+              "complianceDetails" : {}
+            },
+            "global" : {
+              "id" : "g2",
+              "name" : "G2",
+              "compliance" : 50.0,
+              "mode" : "full-compliance",
+              "complianceDetails" : {
+                "successAlreadyOK" : 50.0,
+                "error" : 50.0
+              }
+            }
+          },
+          {
+            "id" : "g3",
+            "targeted" : {
+              "id" : "g3",
+              "name" : "G3",
+              "compliance" : 0.0,
+              "mode" : "full-compliance",
+              "complianceDetails" : {
+                "error" : 100.0
+              }
+            },
+            "global" : {
+              "id" : "g3",
+              "name" : "G3",
+              "compliance" : 66.66,
+              "mode" : "full-compliance",
+              "complianceDetails" : {
+                "successAlreadyOK" : 33.33,
+                "successRepaired" : 33.33,
+                "error" : 33.34
+              }
+            }
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's global compliance
+method: GET
+url: /api/latest/groups/g3/compliance/global
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGlobalNodeGroupComplianceId",
+      "result" : "success",
+      "data" : {
+        "groupCompliance" : [
+          {
+            "id" : "g3",
+            "name" : "G3",
+            "compliance" : 66.66,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "successAlreadyOK" : 33.33,
+              "successRepaired" : 33.33,
+              "error" : 33.34
+            },
+            "rules" : [
+              {
+                "id" : "r1",
+                "name" : "R1",
+                "compliance" : 100.0,
+                "policyMode" : "mixed",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive-techniqueWithBlocks",
+                    "name" : "25. Testing blocks",
+                    "compliance" : 100.0,
+                    "policyMode" : "audit",
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive-techniqueWithBlocks-component-r1-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r2",
+                "name" : "R2",
+                "compliance" : 100.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "name" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "compliance" : 100.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }    
+            ],
+            "nodes" : [
+              {
+                "id" : "n1",
+                "name" : "node1.localhost",
+                "mode" : "full-compliance",
+                "compliance" : 66.66,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 33.33,
+                  "successRepaired" : 33.33,
+                  "error" : 33.34
+                },
+                "rules" : [
+                  {
+                    "id" : "r1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "policyMode" : "audit",
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive-techniqueWithBlocks",
+                        "name" : "25. Testing blocks",
+                        "compliance" : 100.0,
+                        "policyMode" : "audit",
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive-techniqueWithBlocks-component-r1-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r2",
+                    "name" : "R2",
+                    "compliance" : 100.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "name" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "compliance" : 100.0,
+                        "policyMode" : "enforce",
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "policyMode" : "enforce",
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n1",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's targeted compliance
+method: GET
+url: /api/latest/groups/g3/compliance/targeted
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getTargetedNodeGroupComplianceId",
+      "result" : "success",
+      "data" : {
+        "groupCompliance" : [
+          {
+            "id" : "g3",
+            "name" : "G3",
+            "compliance" : 0.0,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "n1",
+                "name" : "node1.localhost",
+                "mode" : "full-compliance",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "rules" : [
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "policyMode" : "enforce",
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n1",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's global compliance by rule in JSON format
+method: GET
+url: /api/latest/groups/g3/compliance/global/byRule
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGlobalNodeGroupComplianceByRuleId",
+      "result" : "success",
+      "data" : {
+        "rules" : [
+          {
+            "id" : "r1",
+            "name" : "R1",
+            "compliance" : 100.0,
+            "policyMode" : "mixed",
+            "complianceDetails" : {
+              "successAlreadyOK" : 100.0
+            },
+            "directives" : [
+              {
+                "id" : "directive-techniqueWithBlocks",
+                "name" : "25. Testing blocks",
+                "compliance" : 100.0,
+                "policyMode" : "audit",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "directive-techniqueWithBlocks-component-r1-n1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "nodes" : [
+                      {
+                        "id" : "n1",
+                        "name" : "node1.localhost",
+                        "compliance" : 100.0,
+                        "policyMode" : "enforce",
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
+                            "reports" : [
+                              {
+                                "status" : "successAlreadyOK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id" : "r2",
+            "name" : "R2",
+            "compliance" : 100.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "successRepaired" : 100.0
+            },
+            "directives" : [
+              {
+                "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                "name" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+                "compliance" : 100.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "nodes" : [
+                      {
+                        "id" : "n1",
+                        "name" : "node1.localhost",
+                        "compliance" : 100.0,
+                        "policyMode" : "enforce",
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                            "reports" : [
+                              {
+                                "status" : "successRepaired"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id" : "r3",
+            "name" : "R3",
+            "compliance" : 0.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "directives" : [
+              {
+                "id" : "directive2",
+                "name" : "directive2",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "directive2-component-r3-n1",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "nodes" : [
+                      {
+                        "id" : "n1",
+                        "name" : "node1.localhost",
+                        "compliance" : 0.0,
+                        "policyMode" : "enforce",
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "directive2-component-value-r3-n1",
+                            "reports" : [
+                              {
+                                "status" : "error"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's targeted compliance by rule in JSON format
+method: GET
+url: /api/latest/groups/g3/compliance/targeted/byRule
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getTargetedNodeGroupComplianceByRuleId",
+      "result" : "success",
+      "data" : {
+        "rules" : [
+          {
+            "id" : "r3",
+            "name" : "R3",
+            "compliance" : 0.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "directives" : [
+              {
+                "id" : "directive2",
+                "name" : "directive2",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "directive2-component-r3-n1",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "nodes" : [
+                      {
+                        "id" : "n1",
+                        "name" : "node1.localhost",
+                        "compliance" : 0.0,
+                        "policyMode" : "enforce",
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "directive2-component-value-r3-n1",
+                            "reports" : [
+                              {
+                                "status" : "error"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's global compliance by rule in CSV format
+method: GET
+url: /api/latest/groups/g3/compliance/global/byRule
+params:
+  format: csv
+response:
+  code: 200
+  type: text
+  content: |
+    "Rule","Directive","Block","Component","Node","Value","Status","Message"
+    "R1","25. Testing blocks","","directive-techniqueWithBlocks-component-r1-n1","node1.localhost","directive-techniqueWithBlocks-component-value-r1-n1","successAlreadyOK",""
+    "R2","directive 99f4ef91-537b-4e03-97bc-e65b447514cc","","99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1","node1.localhost","99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1","successRepaired",""
+    "R3","directive2","","directive2-component-r3-n1","node1.localhost","directive2-component-value-r3-n1","error",""
+---
+description: Get a node group's targeted compliance by rule in CSV format
+method: GET
+url: /api/latest/groups/g3/compliance/targeted/byRule
+params:
+  format: csv
+response:
+  code: 200
+  type: text
+  content: |
+    "Rule","Directive","Block","Component","Node","Value","Status","Message"
+    "R3","directive2","","directive2-component-r3-n1","node1.localhost","directive2-component-value-r3-n1","error",""
 
 #
 # API GROUPSINTERNAL

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -1051,7 +1051,8 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       zioJsonExtractor,
       uuidGen,
       userPropertyService,
-      groupService14
+      groupService14,
+      mockCompliance.complianceAPIService
     ),
     new SettingsApi(
       settingsService.configService,

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ApiCalls.elm
@@ -66,3 +66,29 @@ getTargetedGroupCompliance model =
                 }
     in
     req
+
+
+getGlobalGroupComplianceByRuleCSV : String -> Model -> Cmd Msg
+getGlobalGroupComplianceByRuleCSV filename model =
+    request
+        { method = "GET"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = getUrl model [ "groups", model.groupId.value, "compliance", "global", "byRule" ] [ Url.Builder.string "format" "csv" ]
+        , body = emptyBody
+        , expect = expectString (RuleComplianceCsvExported filename)
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+getTargetedGroupComplianceByRuleCSV : String -> Model -> Cmd Msg
+getTargetedGroupComplianceByRuleCSV filename model =
+    request
+        { method = "GET"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = getUrl model [ "groups", model.groupId.value, "compliance", "targeted", "byRule" ] [ Url.Builder.string "format" "csv" ]
+        , body = emptyBody
+        , expect = expectString (RuleComplianceCsvExported filename)
+        , timeout = Nothing
+        , tracker = Nothing
+        }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
@@ -1,6 +1,7 @@
 module GroupCompliance.DataTypes exposing (..)
 
 import Compliance.DataTypes exposing (..)
+import Date
 import Http exposing (Error)
 import Rules.DataTypes exposing (RuleCompliance)
 import Ui.Datatable exposing (SortOrder, TableFilters)
@@ -121,7 +122,9 @@ type Msg
     | ToggleRowSort String String SortOrder
     | GetPolicyModeResult (Result Error String)
     | GetGroupComplianceResult (Result Error GroupCompliance)
-      --| Export (Result Error String) --TODO: later
     | RefreshCompliance ComplianceScope
     | CallApi (Model -> Cmd Msg)
     | LoadCompliance ComplianceScope
+    | ExportCsv (Cmd Msg)
+    | ExportGroupComplianceByRule GroupId ComplianceScope Date.Date
+    | RuleComplianceCsvExported String (Result Error String)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
@@ -3,6 +3,7 @@ module GroupCompliance.ViewUtils exposing (..)
 import Compliance.DataTypes exposing (..)
 import Compliance.Html exposing (buildComplianceBar)
 import Compliance.Utils exposing (..)
+import Date
 import Dict exposing (Dict)
 import Either exposing (Either(..))
 import GroupCompliance.DataTypes exposing (..)
@@ -15,8 +16,10 @@ import List.Extra
 import Maybe.Extra
 import NaturalOrdering as N
 import String
+import Task
 import Tuple3
 import Ui.Datatable exposing (SortOrder(..))
+import Utils.CsvExportUtils exposing (exportToCsvButton)
 import Utils.TooltipUtils exposing (buildTooltipContent)
 
 
@@ -477,6 +480,14 @@ filtersView model =
 
         isGlobalMode =
             isGlobalCompliance model
+
+        exportCsv =
+            case model.ui.viewMode of
+                RulesView ->
+                    ExportGroupComplianceByRule model.groupId complianceScope
+
+                NodesView ->
+                    \_ -> Ignore
     in
     div [ class "table-header extra-filters" ]
         [ div [ class "d-inline-flex align-items-baseline pb-3 w-25" ]
@@ -551,8 +562,12 @@ filtersView model =
                     ]
                     []
                 ]
-            , button [ class "btn btn-default btn-sm btn-refresh", onClick (RefreshCompliance complianceScope) ]
-                [ i [ class "fa fa-refresh" ] [] ]
+            , div
+                [ class "ms-auto my-auto" ]
+                [ exportToCsvButton (ExportCsv (Task.perform exportCsv Date.today))
+                , button [ class "btn btn-default btn-sm btn-refresh", onClick (RefreshCompliance complianceScope) ]
+                    [ i [ class "fa fa-refresh" ] [] ]
+                ]
             ]
         , displayComplianceFilters complianceFilters UpdateComplianceFilters
         ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
@@ -2,7 +2,9 @@ port module Groupcompliance exposing (..)
 
 import Browser
 import Browser.Navigation as Nav
+import Date
 import Dict
+import File.Download
 import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.DataTypes exposing (..)
 import GroupCompliance.Init exposing (init)
@@ -187,13 +189,6 @@ update msg model =
                 Err err ->
                     processApiError "Getting group compliance" err newModel
 
-        --TODO later
-        --Export res ->
-        --  case res of
-        --    Ok content ->
-        --      (model, File.Download.string (model.directiveId.value ++ ".csv") "text/csv" content)
-        --    Err err ->
-        --      processApiError "Export directive compliance" err model
         RefreshCompliance complianceScope ->
             let
                 getCompliance =
@@ -235,6 +230,43 @@ update msg model =
             ( newModel
             , actions
             )
+
+        ExportCsv cmd ->
+            ( model, cmd )
+
+        ExportGroupComplianceByRule groupId complianceScope date ->
+            let
+                timeStr =
+                    date |> Date.format "yyyy-MM-dd"
+
+                scope =
+                    case complianceScope of
+                        GlobalCompliance ->
+                            "global"
+
+                        TargetedCompliance ->
+                            "targeted"
+
+                filename =
+                    "rudder_group_" ++ groupId.value ++ "_" ++ scope ++ "_compliance_by_rule" ++ timeStr ++ ".csv"
+
+                cmd =
+                    case complianceScope of
+                        GlobalCompliance ->
+                            getGlobalGroupComplianceByRuleCSV filename model
+
+                        TargetedCompliance ->
+                            getTargetedGroupComplianceByRuleCSV filename model
+            in
+            ( model, cmd )
+
+        RuleComplianceCsvExported filename result ->
+            case result of
+                Ok content ->
+                    ( model, File.Download.string filename "text/csv" content )
+
+                Err error ->
+                    processApiError "Export group compliance" error model
 
 
 processApiError : String -> Error -> Model -> ( Model, Cmd Msg )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabDirectives.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabDirectives.elm
@@ -19,6 +19,7 @@ import Set
 import Task
 import Tuple3
 import Ui.Datatable exposing (Category, SortOrder(..), filterSearch, generateLoadingTable, getAllElems, getSubElems)
+import Utils.CsvExportUtils exposing (exportToCsvButton)
 import Utils.TooltipUtils exposing (buildTooltipContent)
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabNodes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabNodes.elm
@@ -15,7 +15,7 @@ import Rules.ViewUtils exposing (..)
 import Task
 import Tuple3
 import Ui.Datatable exposing (Category, SortOrder(..), generateLoadingTable, getAllElems)
-import Utils.TooltipUtils exposing (buildTooltipContent)
+import Utils.CsvExportUtils exposing (exportToCsvButton)
 
 
 nodesTab : Model -> RuleDetails -> Html Msg

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
@@ -1219,18 +1219,3 @@ viewModal { action, ruleName, crSettings, btnMsg, btnClass, btnIconClass } =
                 ]
             ]
         ]
-
-
-exportToCsvButton : Msg -> Html Msg
-exportToCsvButton onClickAction =
-    button
-        [ class "btn btn-sm btn-primary btn-export me-2"
-        , attribute "data-bs-toggle" "tooltip"
-        , title (buildTooltipContent "Export to CSV" "User-defined filters are not taken into account when exporting this table to CSV (the full compliance table will be exported).")
-        , onClick onClickAction
-        ]
-        [ span []
-            [ text "Export "
-            , i [ class "fa fa-download" ] []
-            ]
-        ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Utils/CsvExportUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Utils/CsvExportUtils.elm
@@ -1,0 +1,21 @@
+module Utils.CsvExportUtils exposing (exportToCsvButton)
+
+import Html exposing (Html, button, i, span, text)
+import Html.Attributes exposing (attribute, class, title)
+import Html.Events exposing (onClick)
+import Utils.TooltipUtils exposing (buildTooltipContent)
+
+
+exportToCsvButton : msg -> Html msg
+exportToCsvButton onClickAction =
+    button
+        [ class "btn btn-sm btn-primary btn-export me-2"
+        , attribute "data-bs-toggle" "tooltip"
+        , title (buildTooltipContent "Export to CSV" "User-defined filters are not taken into account when exporting this table to CSV (the full compliance table will be exported).")
+        , onClick onClickAction
+        ]
+        [ span []
+            [ text "Export "
+            , i [ class "fa fa-download" ] []
+            ]
+        ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2314,7 +2314,8 @@ object RudderConfigInit {
               workflowLevelService,
               queryParser,
               queryProcessor
-            )
+            ),
+            complianceAPIService
           ),
           new DirectiveApi(
             zioJsonExtractor,


### PR DESCRIPTION
https://issues.rudder.io/issues/29030

This PR aims to add an "Export to CSV" button to every group's compliance by rule tab. The export result also depends on whether the "global" or "targeted" scope is selected.

<img width="1128" height="457" alt="image" src="https://github.com/user-attachments/assets/fa5b7853-e381-474e-bcbd-ab7808252ac1" />

commit history : 
(1) adding the button on the elm side
(2) add new compliance endpoint definitions
(3) endpoint implementations ; add yml API test stubs
(4) make API tests pass
(5) API documentation for 4 of the new endpoints
(6)  and (7) : misc fixes
(8) API documentation for last new endpoint
(9) review
(10) review
