### PR TITLE
Fixes #29127: PreparingEOL nodes don't have compliance

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -614,12 +614,15 @@ object JsonResponseObjects {
         )
         .withFieldConst(_.compliance, compliance)
         .withFieldConst(_.runAnalysisKind, runAnalysisKind)
-        .withFieldConst(
+        .withFieldComputed(
           _.systemError,
-          systemCompliance
-            .map(_.compliance.computePercent().compliance < 100)
-            .getOrElse(false)
-        ) // do not display error if no sys compliance
+          // do not display error if no sys compliance or node is in a disabled state
+          n => {
+            n.rudderSettings.state.isEnabled && systemCompliance
+              .map(_.compliance.computePercent().compliance < 100)
+              .getOrElse(false)
+          }
+        )
         .withFieldConst(
           _.software,
           softs.map(s => (s.name.getOrElse(""), s.version.map(_.value).getOrElse("N/A"))).toMap

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -103,7 +103,7 @@ object NodeState extends Enum[NodeState] {
   case object Enabled       extends NodeState("enabled", true)
   case object EmptyPolicies extends NodeState("empty-policies", true)
   case object Ignored       extends NodeState("ignored", false)
-  case object PreparingEOL  extends NodeState("preparing-eol", false)
+  case object PreparingEOL  extends NodeState("preparing-eol", true)
 
   def values: IndexedSeq[NodeState] = findValues
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
@@ -157,12 +157,21 @@ class ScoreUpdateOnNodeFactChange(scoreServiceManager: ScoreServiceManager, scor
 
   def run(change: NodeFactChangeEventCC): IOResult[Unit] = {
     change.event match {
-      case NodeFactChangeEvent.Accepted(node, _)      =>
+      case NodeFactChangeEvent.Accepted(node, _) =>
         scoreServiceManager.handleEvent(SystemUpdateScoreEvent(node.id, node.softwareUpdate.toList))
-      case NodeFactChangeEvent.Updated(_, newNode, _) =>
-        scoreServiceManager.handleEvent(SystemUpdateScoreEvent(newNode.id, newNode.softwareUpdate.toList))
-      case NodeFactChangeEvent.Deleted(node, _)       => scoreService.deleteNodeScore(node.id)(using change.cc.toQuery)
-      case _                                          => ZIO.unit
+
+      case NodeFactChangeEvent.Updated(oldNode, newNode, _) =>
+        if (newNode.rudderSettings.state.isEnabled) { // if enabled and update, get the software
+          scoreServiceManager.handleEvent(SystemUpdateScoreEvent(newNode.id, newNode.softwareUpdate.toList))
+        } else {
+          if (oldNode.rudderSettings.state.isEnabled) { // we are disabling the node: delete its scores
+            scoreService.deleteNodeScore(newNode.id)(using change.cc.toQuery)
+          } else ZIO.unit // the node was already disabled
+        }
+
+      case NodeFactChangeEvent.Deleted(node, _) => scoreService.deleteNodeScore(node.id)(using change.cc.toQuery)
+
+      case _ => ZIO.unit
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -749,6 +749,7 @@ class CoreNodeFactRepository(
           state match {
             // ignored by-pass consistency check so that we can remove a node form policy generation without deleting it,
             // even if the node is in some inconsistent state. It was already there so that ok.
+            // We only authorize that for `Ignored`, not for all `NodeState.isEnabled == false`
             case NodeState.Ignored => internalSave(Left(NodeFact.fromMinimal(updated)))(using cc, SelectFacts.none)
             case _                 => save(updated)
           }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
@@ -40,7 +40,6 @@ package com.normation.rudder.metrics
 import better.files.*
 import com.normation.errors.*
 import com.normation.rudder.domain.logger.ScheduledJobLoggerPure
-import com.normation.rudder.domain.nodes.NodeState.Ignored
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext
@@ -164,7 +163,7 @@ class FetchDataServiceImpl(nodeFactRepo: NodeFactRepository, reportingService: R
         modes.getOrElse(Mode.Audit, 0),
         modes.getOrElse(Mode.Enforce, 0),
         modes.getOrElse(Mode.Mixed, 0),
-        accepted.count { case (_, n) => n.rudderSettings.state == Ignored }
+        accepted.count { case (_, n) => !n.rudderSettings.state.isEnabled }
       )
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreService.scala
@@ -124,12 +124,14 @@ class ScoreServiceImpl(
   def getGlobalScore(nodeId: NodeId)(implicit qc: QueryContext): IOResult[GlobalScore] = {
 
     for {
-      _           <- nodeFactRepo.get(nodeId).notOptional(s"Cannot access score for node '${nodeId.value}'")
+      n           <- nodeFactRepo.get(nodeId).notOptional(s"Cannot access score for node '${nodeId.value}'")
       c           <- cache.get
       res         <-
         c.get(nodeId) match {
           case Some(g) => g.succeed
-          case None    => Inconsistency(s"No global score for node ${nodeId.value}").fail
+          case None    =>
+            if (n.rudderSettings.state.isEnabled) Inconsistency(s"No global score for node ${nodeId.value}").fail
+            else GlobalScore(ScoreValue.NoScore, "Node is disabled", Nil).succeed
         }
       withNoScore <- fillWithNoScore(res)
     } yield {
@@ -139,12 +141,14 @@ class ScoreServiceImpl(
 
   def getScoreDetails(nodeId: NodeId)(implicit qc: QueryContext): IOResult[List[Score]] = {
     for {
-      _   <- nodeFactRepo.get(nodeId).notOptional(s"Cannot access score details for node '${nodeId.value}'")
+      n   <- nodeFactRepo.get(nodeId).notOptional(s"Cannot access score details for node '${nodeId.value}'")
       c   <- scoreCache.get
       res <-
         c.get(nodeId) match {
           case Some(g) => g.succeed
-          case None    => Inconsistency(s"No score for node ${nodeId.value}").fail
+          case None    =>
+            if (n.rudderSettings.state.isEnabled) Inconsistency(s"No score for node ${nodeId.value}").fail
+            else Nil.succeed
         }
     } yield {
       res

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -900,7 +900,7 @@ object GetConsistentNodesAndGroups {
     }
 
     // now, filter out all nodes in groups that are not in the accepted list of nodes
-    val (okNodes, others) = nodeFacts.toMap.partition { case (_, n) => n.rudderSettings.state != NodeState.Ignored }
+    val (okNodes, others) = nodeFacts.toMap.partition { case (_, n) => n.rudderSettings.state.isEnabled }
 
     for {
       _   <- ZIO.foreachDiscard(others.values) { n =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -42,7 +42,6 @@ import com.normation.box.*
 import com.normation.inventory.domain.AgentType
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.AuthorizationType
-import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.PolicyTypeName
 import com.normation.rudder.domain.reports.{RunAnalysisKind as R, *}
@@ -393,9 +392,9 @@ class ReportDisplayer(
       onlySystem:         Boolean,
       defaultRunInterval: Int
   )(implicit qc: QueryContext): NodeSeq = {
-    val boxXml = (if (node.rudderSettings.state == NodeState.Ignored) {
+    val boxXml = (if (!node.rudderSettings.state.isEnabled) {
                     Full(
-                      <div><div class="col-md-3"><p class="center alert alert-info" style="padding: 25px; margin:5px;">This node is disabled.</p></div></div>
+                      <div><div class="col-md-3"><p class="center alert alert-info" style="padding: 25px; margin:5px;">This node is in a disabled state.</p></div></div>
                     )
                   } else {
                     for {
@@ -444,9 +443,9 @@ class ReportDisplayer(
                           <div id={"triggerAgent" + defaultOrInventory} class="mb-3">
             <button id={
                             "triggerBtn" + defaultOrInventory
-                          } class="btn btn-primary btn-trigger pe-auto" 
-                            data-bs-toggle="tooltip" 
-                            title="This action is not supported for Windows nodes" 
+                          } class="btn btn-primary btn-trigger pe-auto"
+                            data-bs-toggle="tooltip"
+                            title="This action is not supported for Windows nodes"
                             disabled="disabled">
                               <span>Trigger agent {defaultOrInventory.toLowerCase()}</span>
                               &nbsp;

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -53,7 +53,6 @@ import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.logger.ComplianceLogger
 import com.normation.rudder.domain.logger.TimingDebugLogger
-import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.QueryContext
@@ -183,7 +182,7 @@ class HomePage extends StatefulSnippet {
 
   def getAllCompliance(allNodes: Map[NodeId, CoreNodeFact])(implicit qc: QueryContext): NodeSeq = {
     // this needs to be outside of the zio for-comprehension context to see the right node facts
-    val nodes = allNodes.filterNot(_._2.rudderSettings.state == NodeState.Ignored).keys.toSet
+    val nodes = allNodes.filter(_._2.rudderSettings.state.isEnabled).keys.toSet
     (for {
       n2                <- currentTimeMillis
       userRules         <- roRuleRepo.getIds()


### PR DESCRIPTION
https://issues.rudder.io/issues/29127

Revert change from https://github.com/Normation/rudder/pull/7052 setting `PrepareEOL` as disable

The fixe correct the little red triangle (we see that enabled state has one here) : 

<img width="689" height="192" alt="image" src="https://github.com/user-attachments/assets/cca78467-2347-49f2-b663-993852103e0d" />


It also remove score when a node is disabled: 

<img width="1068" height="451" alt="image" src="https://github.com/user-attachments/assets/685f6d70-fc2c-4180-9b28-8f06c00d04c3" />

