### PR TITLE
Fixes #29147: Elm format is not really checked upon build.sh

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/build.sh
+++ b/webapp/sources/rudder/rudder-web/src/main/build.sh
@@ -33,5 +33,15 @@ else
   npx gulp
 fi
 
+# elm-format check
 echo "> npm run elm-format-check"
-npm run elm-format-check | sed "s/\[\]/> All Elm files are formatted \\\\o\//"  
+fail="$(mktemp)"
+if npm run elm-format-check > "$fail" 2>&1
+then
+  rm "$fail"
+  echo "> All Elm files are formatted \o/"
+else
+  cat "$fail" >&2
+  rm "$fail"
+  exit 1
+fi


### PR DESCRIPTION
https://issues.rudder.io/issues/29147

the `npm run elm-format-check | sed ...` added in https://github.com/Normation/rudder/pull/7250 would succeed every time because of `sed`.

The script uses sh so `set -o pipefail` wouldn't work, we need more shell logic to output the success and error