### PR TITLE
Fixes #29148: Correct directive tab import which changed in upper version

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/MethodElemUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/MethodElemUtils.elm
@@ -193,6 +193,22 @@ checkBlockConstraint block =
     List.foldl fold checkEmptyComponent [ checkFocusNotSet, checkCondition ]
 
 
+policyModeValue : Maybe PolicyMode -> String
+policyModeValue pm =
+    case pm of
+        Nothing ->
+            "default"
+
+        Just Audit ->
+            "audit"
+
+        Just Enforce ->
+            "enforce"
+
+        Just Default ->
+            "default"
+
+
 defaultNewForeach : Maybe String -> Maybe (List (Dict String String)) -> NewForeach
 defaultNewForeach foreachName foreach =
     let


### PR DESCRIPTION
https://issues.rudder.io/issues/29148

The method was removed here: https://github.com/Normation/rudder/commit/cc15ebe870cb0bff46a9b59a21edd0abc56dcd58#diff-8cd31dd3d374d7439d3f0ee98f746874c6c5b84063d102bb2e82581b8a44d805L118-L125 because it wasn't used anymore. 