### PR TITLE
Fixes #29149: Improve the integration and appearance of the ‘Patches and vulnerabilities’ dashboard

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
@@ -76,12 +76,11 @@ const homePage = (
   doughnutChart('nodeCompliance', nodeCompliance, nodeCompliance.colors, nodeCompliance.colors.map(x => complianceHoverColors[x]), onClickDoughnuts);
 
   const complianceContainer = ".node-charts";
-  const patchVulnContainer = ".patch-vuln-charts";
+  const patchVulnContainer = ".patch-chart";
   const benchmarkContainer = ".security-benchmark-charts";
   const chartContainers = {
     'compliance': complianceContainer,
     'system-updates': patchVulnContainer,
-    'cve': patchVulnContainer,
   };
 
   scoreDetails.forEach(function(score) {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-dashboard.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-dashboard.scss
@@ -43,12 +43,10 @@ $doughnut-size : 160px;
   $doughnut-size : 300px;
 }
 
-.homePage > .container-fluid,
-.dashboard{
+.homePage > .container-fluid{
   height: calc(100vh - 50px);
 }
-#headerBar~.content-wrapper .rudder-template .homePage > .container-fluid,
-#headerBar~.content-wrapper .rudder-template .dashboard{
+#headerBar~.content-wrapper .rudder-template .homePage > .container-fluid{
   height: calc(100vh - 80px);
 }
 
@@ -108,7 +106,7 @@ $doughnut-size : 160px;
 .node-chart h4 {
   color: rudder.$txt-light;
   margin-bottom: 15px;
-  font-size: 1.3em;
+  font-size: 1.2em;
   width : $doughnut-size;
 }
 /* Statistics */
@@ -295,6 +293,22 @@ $doughnut-size : 160px;
       top: calc(50% + 2px);
     }
   }
+}
+
+// -- PLUGIN EXTENSIONS
+.plugin-extension{
+  display: none;
+  //Show plugin extensions only if they have been populated
+  &:has(.plugin-container:not(:empty)){
+    display: block;
+  }
+  .plugin-container:empty{
+    display: none;
+  }
+}
+.homePage:has(.plugin-extension #plugin-system-updates-container:not(:empty)) .no-patch-plugin{
+  //Hide the ‘system-updates’ default graph if the plugin is enabled
+  display: none;
 }
 
 // -- DEDICATED DASHBOARD PAGE

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
@@ -83,7 +83,7 @@
                         <div class="row gx-2 gx-lg-3 gx-xl-4 my-2 my-lg-3 my-xl-4">
                             <div class="col-md-auto mt-2 mt-md-0">
                                 <div id="nodeOverview" class="card h-100">
-                                    <h5 class="card-title py-2 px-3 mb-0">Global score breakdown</h5>
+                                    <h4 class="card-title py-2 px-3 mb-0">Global score breakdown</h4>
                                     <div class="card-body">
                                         <div class="node-compliance-chart d-flex align-items-center justify-content-center px-0 px-xl-3">
                                             <canvas id="nodeCompliance"></canvas>
@@ -95,7 +95,7 @@
                             </div>
                             <div class="col mt-2 mt-md-0">
                                 <div class="card h-100 global-compliance-details flex-grow-1">
-                                    <h5 class="card-title py-2 px-3 mb-0">Global compliance details</h5>
+                                    <h4 class="card-title py-2 px-3 mb-0">Global compliance details</h4>
                                     <div class="card-body d-flex flex-column">
                                         <div id="globalCompliance" class="w-100"></div>
                                         <div class="text-center mt-3 text-center text-secondary fs-5 mt-4" id="globalComplianceStats"></div>
@@ -110,7 +110,7 @@
                             <div class="row h-100">
                                 <div class="col">
                                     <div class="card h-100">
-                                        <h5 class="card-title py-2 px-3 mb-0">Activity</h5>
+                                        <h4 class="card-title py-2 px-3 mb-0">Activity</h4>
                                         <div class="card-body">
                                             <div id="activity-app"></div>
                                         </div>
@@ -124,7 +124,7 @@
                 <div class="row g-2 g-lg-3 g-xl-4 mb-2 mb-lg-3 mb-xl-4 flex-wrap">
                     <div class="col-auto flex-grow-1">
                         <div id="nodeBreakdown" class="card h-100 canvas-only">
-                            <h5 class="card-title py-2 px-3 mb-0">Node breakdown</h5>
+                            <h4 class="card-title py-2 px-3 mb-0">Node breakdown</h4>
                             <div class="card-body">
                                 <div class="node-charts d-flex flex-wrap gap-1 gap-lg-2 gap-xl-4 row-gap-4">
 
@@ -150,24 +150,34 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-auto flex-grow-1">
+                    <div class="col flex-grow-1 no-patch-plugin">
                         <div class="card canvas-only h-100">
-                            <h5 class="card-title py-2 px-3 mb-0">Patches & vulnerabilities</h5>
+                            <h4 class="card-title py-2 px-3 mb-0">Patches</h4>
                             <div class="card-body">
-                                <div class="patch-vuln-charts d-flex flex-wrap gap-1 gap-lg-2 gap-xl-4 row-gap-4"></div>
+                                <div class="patch-chart d-flex flex-wrap gap-1 gap-lg-2 gap-xl-4 row-gap-4"></div>
                             </div>
                         </div>
                     </div>
                     <div class="col-auto flex-grow-1">
                         <div class="card canvas-only h-100">
-                            <h5 class="card-title py-2 px-3 mb-0">Security benchmarks</h5>
+                            <h4 class="card-title py-2 px-3 mb-0">Security benchmarks</h4>
                             <div class="card-body">
                                 <div class="security-benchmark-charts d-flex flex-wrap gap-1 gap-lg-2 gap-xl-4 row-gap-4"></div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div id="plugin-container" ></div>
+                <div class="row plugin-extension">
+                    <div class="col w-100">
+                        <div class="card">
+                            <h4 class="card-title py-2 px-3 mb-0">Patches & vulnerabilities</h4>
+                            <div class="card-body p-0 row">
+                                <div class="plugin-container col" id="plugin-system-updates-container"></div>
+                                <div class="plugin-container col" id="plugin-cve-container"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/vuln-patch-dashboard.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/vuln-patch-dashboard.html
@@ -8,7 +8,24 @@
     </head>
 
     <div class="rudder-template"  data-lift="VulnPatchDashboard.details">
-        <div id="cve-container"></div>
-        <div id="system-update-container"></div>
+        <div class="one-col dashboard w-100">
+            <div class="main-header">
+                <div class="header-title">
+                    <h1>
+                        <span>Patches & vulnerabilities</span>
+                    </h1>
+                </div>
+            </div>
+            <div class="main-navbar"></div>
+            <div class="container-fluid p-0 w-100">
+                <div class="row">
+                    <div class="col" id="system-update-container"></div>
+                </div>
+                <div class="row">
+                    <div class="col" id="cve-container"></div>
+                </div>
+            </div>
+        </div>
+
     </div>
 </lift:surround>


### PR DESCRIPTION
https://issues.rudder.io/issues/29149

- In the main Dashboard, `div#plugin-container` has been split into two so that each plugin has its own container, making it easier to position them
- These containers are hidden if their corresponding plugin is not enabled
- The ‘system-updates’ default graph is hidden if the system-updates plugin is enabled, to avoid duplication of information
- The card title of the ‘system-updates’ default graph has been changed to 'Patches', to avoid confusion
- The size of the dashboard card title has been readjusted

:warning: This PR and [#29151](https://github.com/Normation/rudder-plugins-private/pull/1418) need to be reviewed and merged together to work properly!

Here is the result:

### With no plugin installed:
<img width="1852" height="1081" alt="image" src="https://github.com/user-attachments/assets/9c454a5e-6b00-411e-8407-8faf3a627c63" />

### With only system-updates installed:
<img width="1852" height="1081" alt="image" src="https://github.com/user-attachments/assets/c94bac5c-6ee8-4b14-9e58-e0868daf5dc4" />


### With cve & security benchmarks plugins installed:
<img width="1852" height="1081" alt="image" src="https://github.com/user-attachments/assets/598cd66d-4a1c-4982-8f7e-36dd63ecf2a5" />


### With all plugins installed (system-updates, cve, security benchmarks)
<img width="1852" height="1081" alt="dashboard-v3" src="https://github.com/user-attachments/assets/417f540b-a6fe-47df-b912-52fa827ca5d8" />

### And finally the dedicated dashboard page:
<img width="1852" height="1081" alt="image" src="https://github.com/user-attachments/assets/56d29d18-3599-4e89-9ee8-1cf28f47f932" />
