### PR TITLE
Fixes #29079: WebApp non-root: run hooks with sudo only in production

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/cli/RudderPackagePlugin.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/cli/RudderPackagePlugin.scala
@@ -43,6 +43,7 @@ import com.normation.plugins.cli.RudderPackagePlugin.LicenseInfo
 import com.normation.rudder.hooks.Cmd
 import com.normation.rudder.hooks.CmdResult
 import com.normation.rudder.hooks.RunNuCommand
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.utils.DateFormaterService
 import io.scalaland.chimney.Transformer
 import java.time.ZonedDateTime
@@ -178,7 +179,7 @@ object RudderPackageService {
 /*
  * We assume that command in config is in format: `/path/to/main/command args1 args2 etc`
  */
-class RudderPackageCmdService(configCmdLine: String) extends RudderPackageService {
+class RudderPackageCmdService(configCmdLine: String, sudoRun: SudoRun) extends RudderPackageService {
 
   val configCmdRes = configCmdLine.split(" ").toList match {
     case Nil       => Left(Unexpected(s"Invalid command for rudder package from configuration: '${configCmdLine}'"))
@@ -241,7 +242,7 @@ class RudderPackageCmdService(configCmdLine: String) extends RudderPackageServic
   private def runCmd(params: List[String]):                         IOResult[(Cmd, CmdResult)] = {
     for {
       configCmd   <- configCmdRes.toIO
-      cmd          = Cmd(configCmd._1, configCmd._2 ::: params, Map("NO_COLOR" -> "1"), None)
+      cmd          = Cmd(configCmd._1, configCmd._2 ::: params, Map("NO_COLOR" -> "1"), None, sudoRun)
       packagesCmd <- RunNuCommand.run(cmd)
       result      <- packagesCmd.await
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignHooksService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignHooksService.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.campaigns
 import better.files.File
 import com.normation.errors.*
 import com.normation.rudder.hooks.*
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.utils.FileUtils
 import com.normation.zio.*
 import scala.jdk.CollectionConverters.*
@@ -138,7 +139,8 @@ object FsCampaignHooksRepository {
 
 class FsCampaignHooksService(
     HOOKS_D:               String,
-    HOOKS_IGNORE_SUFFIXES: List[String]
+    HOOKS_IGNORE_SUFFIXES: List[String],
+    sudoRun:               SudoRun
 ) extends CampaignHooksService {
 
   override def runPreHooks(c: Campaign, e: CampaignEvent): IOResult[HookResults] = {
@@ -196,7 +198,8 @@ class FsCampaignHooksService(
                                          .optAdd("CAMPAIGN_NEXT_STATE", nextState.map(_.entryName)),
                                        systemEnv,
                                        HookExecutionHistory.Keep,
-                                       1.minutes // warn if a hook took more than a minute
+                                       1.minutes, // warn if a hook took more than a minute
+                                       sudoRun = sudoRun
                                      )
                        timeHooks1 <- currentTimeMillis
                        _          <-

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
@@ -41,6 +41,7 @@ import com.normation.NamedZioLogger
 import com.normation.RudderLogger
 import com.normation.box.*
 import com.normation.errors.*
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.zio.*
 import enumeratum.Enum
 import enumeratum.EnumEntry
@@ -242,7 +243,8 @@ object RunHooks {
       envVariables:    HookEnvPairs,
       globalWarnAfter: Duration = 1.minutes,
       unitWarnAfter:   Duration = 30.seconds,
-      unitKillAfter:   Duration = 5.minutes
+      unitKillAfter:   Duration = 5.minutes,
+      sudoRun:         SudoRun
   ): IOResult[(HookReturnCode, Long)] = {
     asyncRunHistory(
       logIdentifier,
@@ -252,7 +254,8 @@ object RunHooks {
       HookExecutionHistory.DoNotKeep,
       globalWarnAfter,
       unitWarnAfter,
-      unitKillAfter
+      unitKillAfter,
+      sudoRun
     ).map { case (c, _, d) => (c, d) }
   }
 
@@ -283,7 +286,8 @@ object RunHooks {
       history:         HookExecutionHistory,
       globalWarnAfter: Duration = 1.minutes,
       unitWarnAfter:   Duration = 30.seconds,
-      unitKillAfter:   Duration = 5.minutes
+      unitKillAfter:   Duration = 5.minutes,
+      sudoRun:         SudoRun
   ): IOResult[(HookReturnCode, List[(String, HookReturnCode)], Long)] = {
     import HookReturnCode.*
 
@@ -356,7 +360,7 @@ object RunHooks {
                        .warn(s"Hook is taking more than ${warnTimeout.render} to finish: ${cmdInfo}")
                        .delay(warnTimeout)
                        .fork
-                p <- RunNuCommand.run(Cmd(path, Nil, env.toMap, Some(hooks.basePath)))
+                p <- RunNuCommand.run(Cmd(path, Nil, env.toMap, Some(hooks.basePath), sudoRun))
                 r <- p.await.timeout(killTimeout).flatMap {
                        case Some(ok) =>
                          ok.succeed
@@ -436,7 +440,8 @@ object RunHooks {
       envVariables:    HookEnvPairs,
       globalWarnAfter: Duration = 1.minutes,
       unitWarnAfter:   Duration = 30.seconds,
-      unitKillAfter:   Duration = 5.minutes
+      unitKillAfter:   Duration = 5.minutes,
+      sudoRun:         SudoRun
   ): HookReturnCode = {
     asyncRun(
       logIdentifier,
@@ -445,7 +450,8 @@ object RunHooks {
       envVariables,
       globalWarnAfter,
       unitWarnAfter,
-      unitKillAfter
+      unitKillAfter,
+      sudoRun
     ).either.runNow match {
       case Right(x)  => x._1
       case Left(err) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
@@ -37,6 +37,8 @@
 
 package com.normation.rudder.hooks
 
+import RunNuCommand.SudoRun
+import SudoRun.*
 import better.files.File
 import com.normation.NamedZioLogger
 import com.normation.errors.*
@@ -45,6 +47,8 @@ import com.zaxxer.nuprocess.NuProcess
 import com.zaxxer.nuprocess.NuProcessBuilder
 import com.zaxxer.nuprocess.codec.NuAbstractCharsetHandler
 import com.zaxxer.nuprocess.internal.BasePosixProcess
+import enumeratum.Enum
+import enumeratum.EnumEntry
 import java.nio.CharBuffer
 import java.nio.charset.CoderResult
 import java.nio.charset.StandardCharsets
@@ -79,10 +83,19 @@ import zio.syntax.*
  * cwd is the path for the current working directory for the command (ie for resolution of relative paths).
  * By default, it's the directory from which the application is started.
  */
-final case class Cmd(cmdPath: String, parameters: List[String], environment: Map[String, String], cwdPath: Option[String]) {
-  def display: String = s"${cmdPath} ${parameters.mkString(" ")}"
+final case class Cmd(
+    cmdPath:     String,
+    parameters:  List[String],
+    environment: Map[String, String],
+    cwdPath:     Option[String],
+    sudoRun:     SudoRun
+) {
+  def display: String = s"${sudoRun match {
+      case WithSudo    => "sudo -E "
+      case WithoutSudo => ""
+    }}${cmdPath} ${parameters.mkString(" ")}"
 }
-final case class CmdResult(code: Int, stdout: String, stderr: String)                                                      {
+final case class CmdResult(code: Int, stdout: String, stderr: String) {
 
   /**
     * Display the attributes of this result, by default each on a new line with indentation
@@ -102,6 +115,14 @@ final case class CmdResult(code: Int, stdout: String, stderr: String)           
 }
 
 object RunNuCommand {
+
+  sealed trait SudoRun extends EnumEntry
+  object SudoRun       extends Enum[SudoRun] {
+    case object WithSudo    extends SudoRun
+    case object WithoutSudo extends SudoRun
+
+    override def values: IndexedSeq[SudoRun] = findValues
+  }
 
   val logger: NamedZioLogger = NamedZioLogger("command-runner")
 
@@ -190,6 +211,10 @@ object RunNuCommand {
      */
     import scala.jdk.CollectionConverters.*
     val errorMsg = s"Error when executing command ${cmd.display}"
+    val command  = (cmd.sudoRun match {
+      case WithSudo    => "sudo" :: "-E" :: Nil
+      case WithoutSudo => Nil
+    }) ::: cmd.cmdPath :: cmd.parameters
 
     (for {
       _             <- ZIO.when(limit == Infinity || limit.toMillis <= 0) {
@@ -200,7 +225,7 @@ object RunNuCommand {
                        }
       promise       <- Promise.make[Nothing, CmdResult]
       handler        = new CmdProcessHandler(promise)
-      processBuilder = new NuProcessBuilder((cmd.cmdPath :: cmd.parameters).asJava, cmd.environment.asJava)
+      processBuilder = new NuProcessBuilder(command.asJava, cmd.environment.asJava)
       _              = setCwd(processBuilder, cmd.cwdPath)
       _             <- IOResult.attempt(errorMsg)(processBuilder.setProcessListener(handler))
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
@@ -91,8 +91,9 @@ final case class Cmd(
     sudoRun:     SudoRun
 ) {
   def display: String = s"${sudoRun match {
-      case WithSudo    => "sudo -E "
-      case WithoutSudo => ""
+      case WithSudo            => "sudo "
+      case WithSudoPreserveEnv => "sudo --preserve-env "
+      case WithoutSudo         => ""
     }}${cmdPath} ${parameters.mkString(" ")}"
 }
 final case class CmdResult(code: Int, stdout: String, stderr: String) {
@@ -118,8 +119,9 @@ object RunNuCommand {
 
   sealed trait SudoRun extends EnumEntry
   object SudoRun       extends Enum[SudoRun] {
-    case object WithSudo    extends SudoRun
-    case object WithoutSudo extends SudoRun
+    case object WithSudo            extends SudoRun
+    case object WithSudoPreserveEnv extends SudoRun
+    case object WithoutSudo         extends SudoRun
 
     override def values: IndexedSeq[SudoRun] = findValues
   }
@@ -212,8 +214,9 @@ object RunNuCommand {
     import scala.jdk.CollectionConverters.*
     val errorMsg = s"Error when executing command ${cmd.display}"
     val command  = (cmd.sudoRun match {
-      case WithSudo    => "sudo" :: "-E" :: Nil
-      case WithoutSudo => Nil
+      case WithSudo            => "sudo" :: Nil
+      case WithSudoPreserveEnv => "sudo" :: "--preserve-env" :: Nil
+      case WithoutSudo         => Nil
     }) ::: cmd.cmdPath :: cmd.parameters
 
     (for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.hooks.HookEnvPairs
 import com.normation.rudder.hooks.PureHooksLogger
 import com.normation.rudder.hooks.RunHooks
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.utils.DateFormaterService
 import com.normation.zio.*
@@ -338,7 +339,8 @@ class InventoryProcessor(
 
 class InventoryFailedHook(
     HOOKS_D:               String,
-    HOOKS_IGNORE_SUFFIXES: List[String]
+    HOOKS_IGNORE_SUFFIXES: List[String],
+    sudoRun:               SudoRun
 ) {
   import scala.jdk.CollectionConverters.*
 
@@ -357,7 +359,8 @@ class InventoryFailedHook(
                                        ("RUDDER_INVENTORY_PATH", file.pathAsString)
                                      ),
                                      systemEnv,
-                                     1.minutes // warn if a hook took more than a minute
+                                     1.minutes, // warn if a hook took more than a minute
+                                     sudoRun = sudoRun
                                    )
                      timeHooks1 <- currentTimeMillis
                      _          <- PureHooksLogger.For(name).trace(s"Inventory failed hooks ran in ${timeHooks1 - timeHooks0} ms")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
@@ -50,6 +50,7 @@ import com.normation.rudder.facts.nodes.NodeFactStorage
 import com.normation.rudder.hooks.HookEnvPairs
 import com.normation.rudder.hooks.PureHooksLogger
 import com.normation.rudder.hooks.RunHooks
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio.currentTimeMillis
@@ -68,7 +69,8 @@ import zio.syntax.*
 class PostCommitInventoryHooks[A](
     HOOKS_D:               String,
     HOOKS_IGNORE_SUFFIXES: List[String],
-    nodeFactRepo:          NodeFactRepository
+    nodeFactRepo:          NodeFactRepository,
+    sudoRun:               SudoRun
 ) extends PostCommit[A] {
   import QueryContext.todoQC
   import scala.jdk.CollectionConverters.*
@@ -108,7 +110,8 @@ class PostCommitInventoryHooks[A](
                                        ("RUDDER_AGENT_TYPE", inventory.node.agents.headOption.map(_.agentType.id).getOrElse("unknown"))
                                      ),
                                      systemEnv,
-                                     1.minutes // warn if a hook took more than a minute
+                                     1.minutes, // warn if a hook took more than a minute
+                                     sudoRun = sudoRun
                                    )
                      timeHooks1 <- currentTimeMillis
                      _          <- PureHooksLogger.For(n).trace(s"Inventory received hooks ran in ${timeHooks1 - timeHooks0} ms")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
@@ -13,6 +13,7 @@ import com.normation.rudder.git.GitRepositoryProvider
 import com.normation.rudder.hooks.Cmd
 import com.normation.rudder.hooks.CmdResult
 import com.normation.rudder.hooks.RunNuCommand
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.rudder.ncf.Constraint.Constraint
 import com.normation.rudder.ncf.ParameterType.ParameterTypeService
 import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
@@ -180,7 +181,7 @@ class EditorTechniqueReaderImpl(
     // We want everything in configuration repository to belong to the "rudder" group
     val groupOwner    = "rudder"
 
-    val cmd = Cmd(ruddercCmd, ruddercParams ::: ruddercLibs, Map.empty, None)
+    val cmd = Cmd(ruddercCmd, ruddercParams ::: ruddercLibs, Map.empty, None, WithoutSudo)
     for {
       _         <- RuddercLogger.debug(s"Reading generic methods information with command: '${cmd.display}'")
       updateCmd <- RunNuCommand.run(cmd)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -44,6 +44,7 @@ import com.normation.rudder.domain.logger.RuddercLogger
 import com.normation.rudder.hooks.Cmd
 import com.normation.rudder.hooks.CmdResult
 import com.normation.rudder.hooks.RunNuCommand
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.rudder.repository.xml.TechniqueFiles
 import com.normation.zio.currentTimeNanos
 import enumeratum.*
@@ -303,7 +304,7 @@ class RuddercServiceImpl(
       ("--directory" :: techniquePath.pathAsString :: "build" :: Nil)
     }
 
-    Cmd(ruddercCmd, params, Map("NO_COLOR" -> "1"), None)
+    Cmd(ruddercCmd, params, Map("NO_COLOR" -> "1"), None, WithoutSudo)
   }
 
   def logReturnCode(result: RuddercResult): IOResult[Unit] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
@@ -7,6 +7,7 @@ import com.normation.rudder.domain.logger.HealthcheckLoggerPure as logger
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.hooks.Cmd
 import com.normation.rudder.hooks.RunNuCommand
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.rudder.services.healthcheck.HealthcheckResult.Critical
 import com.normation.rudder.services.healthcheck.HealthcheckResult.Ok
 import com.normation.rudder.services.healthcheck.HealthcheckResult.Warning
@@ -143,7 +144,7 @@ final class CheckFileDescriptorLimit(val nodeFactRepository: NodeFactRepository)
   def run:  IOResult[HealthcheckResult] = {
     // Check the soft limit.
     // That can be raise or lower by any user but cannot exceed the hard limit
-    val cmd = Cmd("/usr/bin/prlimit", "-n" :: "-o" :: "SOFT" :: "--noheadings" :: Nil, Map.empty, None)
+    val cmd = Cmd("/usr/bin/prlimit", "-n" :: "-o" :: "SOFT" :: "--noheadings" :: Nil, Map.empty, None, WithoutSudo)
     for {
       fdLimitCmd <- RunNuCommand.run(cmd)
       res        <- fdLimitCmd.await

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -60,6 +60,7 @@ import com.normation.rudder.hooks.HookEnvPairs
 import com.normation.rudder.hooks.HooksLogger
 import com.normation.rudder.hooks.PureHooksLogger
 import com.normation.rudder.hooks.RunHooks
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.score.ScoreServiceManager
@@ -138,7 +139,8 @@ trait NewNodeManager {
 class PostNodeAcceptanceHookScripts(
     HOOKS_D:               String,
     HOOKS_IGNORE_SUFFIXES: List[String],
-    nodeFactRepository:    NodeFactRepository
+    nodeFactRepository:    NodeFactRepository,
+    sudoRun:               SudoRun
 ) extends NewNodePostAcceptHooks {
   override def name: String = "new-node-post-accept-hooks"
 
@@ -164,7 +166,7 @@ class PostNodeAcceptanceHookScripts(
                         )
       postHooks      <- RunHooks.getHooksPure(HOOKS_D + "/" + name, HOOKS_IGNORE_SUFFIXES)
       postHooksTime0 <- currentTimeMillis
-      runPostHook    <- RunHooks.asyncRun(name, postHooks, hookEnv, systemEnv, 1.minutes)
+      runPostHook    <- RunHooks.asyncRun(name, postHooks, hookEnv, systemEnv, 1.minutes, sudoRun = sudoRun)
       postHooksTime1 <- currentTimeMillis
       timePostHooks   = (postHooksTime1 - postHooksTime0)
       _              <- PureHooksLogger.For(name).trace(s"node-post-acceptance scripts hooks ran in $timePostHooks ms")
@@ -185,14 +187,15 @@ class UpdateScorePostAcceptance(scoreServiceManager: ScoreServiceManager, nodeFa
 class NewNodeManagerHooksImpl(
     nodeFactRepository:    NodeFactRepository,
     HOOKS_D:               String,
-    HOOKS_IGNORE_SUFFIXES: List[String]
+    HOOKS_IGNORE_SUFFIXES: List[String],
+    sudoRun:               SudoRun
 ) extends NewNodeManagerHooks {
 
   val codeHooks: Ref[Chunk[NewNodePostAcceptHooks]] = Ref
     .make(
       Chunk[NewNodePostAcceptHooks](
         // by default, add the script hooks
-        new PostNodeAcceptanceHookScripts(HOOKS_D, HOOKS_IGNORE_SUFFIXES, nodeFactRepository)
+        new PostNodeAcceptanceHookScripts(HOOKS_D, HOOKS_IGNORE_SUFFIXES, nodeFactRepository, sudoRun)
       )
     )
     .runNow

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.facts.nodes.*
 import com.normation.rudder.hooks.HookEnvPairs
 import com.normation.rudder.hooks.HookReturnCode
 import com.normation.rudder.hooks.RunHooks
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.UpdateExpectedReportsRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
@@ -192,7 +193,8 @@ class RemoveNodeServiceImpl(
     newNodeManager:            NewNodeManager,
     val postNodeDeleteActions: Ref[List[PostNodeDeleteAction]],
     HOOKS_D:                   String,
-    HOOKS_IGNORE_SUFFIXES:     List[String]
+    HOOKS_IGNORE_SUFFIXES:     List[String],
+    sudoRun:                   SudoRun
 ) extends RemoveNodeService {
 
   // effectually add an action
@@ -379,7 +381,7 @@ class RemoveNodeServiceImpl(
     for {
       start <- currentTimeMillis
       hooks <- RunHooks.getHooksPure(HOOKS_D + "/" + name, HOOKS_IGNORE_SUFFIXES)
-      res   <- RunHooks.asyncRun(name, hooks, env._1, env._2)
+      res   <- RunHooks.asyncRun(name, hooks, env._1, env._2, sudoRun = sudoRun)
       end   <- currentTimeMillis
       _     <- NodeLoggerPure.Delete.debug(s"    ${name} scripts hooks ran in ${end - start} ms")
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.hooks.HookReturnCode
 import com.normation.rudder.hooks.Hooks
 import com.normation.rudder.hooks.HooksLogger
 import com.normation.rudder.hooks.RunHooks
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.rudder.repository.*
 import com.normation.rudder.schedule.DirectiveSchedule
 import com.normation.rudder.schedule.DirectiveScheduleEvent
@@ -1358,7 +1359,8 @@ class PolicyGenerationHookServiceImpl(
     // file, it's just a constant.
     HOOKS_D:                           String,
     HOOKS_IGNORE_SUFFIXES:             List[String],
-    postGenerationHookCompabilityMode: Option[Boolean]
+    postGenerationHookCompabilityMode: Option[Boolean],
+    sudoRun:                           SudoRun
 ) extends PolicyGenerationHookService {
 
   /*
@@ -1393,7 +1395,8 @@ class PolicyGenerationHookServiceImpl(
           name,
           preHooks,
           HookEnvPairs.build(("RUDDER_GENERATION_DATETIME", generationTime.toString)),
-          systemEnv
+          systemEnv,
+          sudoRun = sudoRun
         ) match {
           case _: HookReturnCode.Success => ().succeed
           case x: HookReturnCode.Error   =>
@@ -1414,7 +1417,13 @@ class PolicyGenerationHookServiceImpl(
       // fetch all
       preHooks <- RunHooks.getHooksPure(HOOKS_D + "/" + name, HOOKS_IGNORE_SUFFIXES)
       _        <-
-        RunHooks.asyncRun(name, preHooks, HookEnvPairs.build(("RUDDER_GENERATION_DATETIME", generationTime.toString)), systemEnv)
+        RunHooks.asyncRun(
+          name,
+          preHooks,
+          HookEnvPairs.build(("RUDDER_GENERATION_DATETIME", generationTime.toString)),
+          systemEnv,
+          sudoRun = sudoRun
+        )
     } yield ()
   }
 
@@ -1582,7 +1591,8 @@ class PolicyGenerationHookServiceImpl(
                            name,
                            postHooks,
                            HookEnvPairs.build(envParams*),
-                           systemEnv
+                           systemEnv,
+                           sudoRun = sudoRun
                          )
 
     } yield ()
@@ -1648,7 +1658,8 @@ class PolicyGenerationHookServiceImpl(
                         name,
                         failureHooks,
                         HookEnvPairs.build(envParams*),
-                        systemEnv
+                        systemEnv,
+                        sudoRun = sudoRun
                       )
     } yield ()
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/WriteNodeCertificatesPem.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/WriteNodeCertificatesPem.scala
@@ -44,6 +44,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.hooks.Cmd
 import com.normation.rudder.hooks.RunNuCommand
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.zio.ZioRuntime
 import java.nio.charset.StandardCharsets
 import zio.*
@@ -71,7 +72,7 @@ trait WriteNodeCertificatesPem {
  * In a default Rudder app, the file path is: /var/rudder/lib/ssl/allnodescerts.pem
  * After file is written, a reload hook can be executed if `reloadScriptPath` is not empty
  */
-class WriteNodeCertificatesPemImpl(reloadScriptPath: Option[String]) extends WriteNodeCertificatesPem {
+class WriteNodeCertificatesPemImpl(reloadScriptPath: Option[String], sudoRun: SudoRun) extends WriteNodeCertificatesPem {
 
   val logger: NamedZioLogger = NamedZioLogger(this.getClass.getName)
 
@@ -137,7 +138,10 @@ class WriteNodeCertificatesPemImpl(reloadScriptPath: Option[String]) extends Wri
           case cmdPath :: args =>
             for {
               promise <-
-                RunNuCommand.run(Cmd(cmdPath, args, Map(), None), Duration.fromNanos(5L * 60 * 1000 * 1000)) // error after 5 mins
+                RunNuCommand.run(
+                  Cmd(cmdPath, args, Map(), None, sudoRun),
+                  Duration.fromNanos(5L * 60 * 1000 * 1000)
+                ) // error after 5 mins
               result  <- promise.await
               _       <- ZIO.when(result.code != 0) {
                            Unexpected(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -62,6 +62,7 @@ import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.hooks.HookEnvPairs
 import com.normation.rudder.hooks.HookReturnCode
 import com.normation.rudder.hooks.RunHooks
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
 import com.normation.rudder.schedule.DirectiveScheduleEvent
 import com.normation.rudder.services.policies.BundleOrder
 import com.normation.rudder.services.policies.NodeConfiguration
@@ -253,7 +254,8 @@ class PolicyWriterServiceImpl(
     HOOKS_D:                    String,
     HOOKS_IGNORE_SUFFIXES:      List[String],
     implicit val charset:       Charset,
-    groupOwner:                 Option[String]
+    groupOwner:                 Option[String],
+    sudoRun:                    SudoRun
 ) extends PolicyWriterService {
   import com.normation.rudder.services.policies.write.PolicyWriterServiceImpl.*
 
@@ -661,7 +663,8 @@ class PolicyWriterServiceImpl(
                                             hookGlobalWarnTimeout, // warn if all hooks took more than a minute
 
                                             hookUnitWarnTimeout,
-                                            hookUnitKillTimeout
+                                            hookUnitKillTimeout,
+                                            sudoRun
                                           )
                             timeHooks1 <- currentTimeMillis
                             _          <- timingLogger.hooks.trace(
@@ -707,7 +710,8 @@ class PolicyWriterServiceImpl(
                                               hookGlobalWarnTimeout, // warn if a hook took more than a minute
 
                                               hookUnitWarnTimeout,
-                                              hookUnitKillTimeout
+                                              hookUnitKillTimeout,
+                                              sudoRun
                                             )
                               timeHooks1 <- currentTimeMillis
                               _          <- timingLogger.hooks.trace(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -88,6 +88,7 @@ import com.normation.rudder.git.GitRevisionProvider
 import com.normation.rudder.git.SimpleGitRevisionProvider
 import com.normation.rudder.hooks.CmdResult
 import com.normation.rudder.hooks.HookEnvPairs
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.rudder.ncf.DeleteEditorTechnique
 import com.normation.rudder.ncf.EditorTechniqueCompilationResult
 import com.normation.rudder.ncf.EditorTechniqueReader
@@ -2685,7 +2686,8 @@ class MockNodes() {
     newNodeManager,
     Ref.make(List.empty[PostNodeDeleteAction]).runNow,
     "",
-    List.empty
+    List.empty,
+    WithoutSudo
   ) {
     override def buildHooksEnv(nodeInfo: CoreNodeFact): IOResult[(HookEnvPairs, HookEnvPairs)] = {
       (HookEnvPairs(List.empty), HookEnvPairs(List.empty)).succeed

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.git.GitRepositoryProviderImpl
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.rudder.inventory.DefaultProcessInventoryService
 import com.normation.rudder.inventory.InventoryFailedHook
 import com.normation.rudder.inventory.InventoryMover
@@ -548,7 +549,7 @@ trait TestSaveInventory extends Specification with BeforeAfterAll {
     val mover = new InventoryMover(
       INVENTORY_DIR_RECEIVED,
       INVENTORY_DIR_FAILED,
-      new InventoryFailedHook("/tmp", Nil)
+      new InventoryFailedHook("/tmp", Nil, WithoutSudo)
     )
     new DefaultProcessInventoryService(inventoryProcessorInternal, mover)
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.hooks.HookReturnCode.Ok
 import com.normation.rudder.hooks.HookReturnCode.ScriptError
 import com.normation.rudder.hooks.HookReturnCode.SystemError
 import com.normation.rudder.hooks.HookReturnCode.Warning
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.zio.ZioRuntime
 import java.nio.file.attribute.PosixFilePermissions
 import org.joda.time.DateTime
@@ -81,7 +82,8 @@ class HooksTest() extends Specification with AfterAll {
       HookEnvPairs(Nil),
       1.second,
       500.millis,
-      5.seconds
+      5.seconds,
+      WithoutSudo
     )
   }
 
@@ -96,7 +98,8 @@ class HooksTest() extends Specification with AfterAll {
           HookExecutionHistory.Keep,
           1.second,
           500.millis,
-          5.seconds
+          5.seconds,
+          WithoutSudo
         )
         .map(_._2.map(_._2))
     )
@@ -164,7 +167,8 @@ class HooksTest() extends Specification with AfterAll {
       HookEnvPairs(Nil),
       1.second,
       1.second,
-      500.millis
+      500.millis,
+      WithoutSudo
     )
     timeout must beEqualTo(HookTimeout(Some(6.seconds), Some(10.seconds)))
     res must beEqualTo(Ok(cmd("timeout_ok.sh"), "", ""))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.hooks
 
 import com.normation.errors.*
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.zio.*
 import java.io.File
 import org.joda.time.DateTime
@@ -69,7 +70,7 @@ class RunNuCommandTest() extends Specification {
     "has only the environment variable explicitly defined" in {
       val prog = {
         for {
-          p <- RunNuCommand.run(Cmd("env", Nil, Map("PATH" -> PATH, "foo" -> "bar"), None))
+          p <- RunNuCommand.run(Cmd("env", Nil, Map("PATH" -> PATH, "foo" -> "bar"), None, WithoutSudo))
           c <- p.await.timeout(500.millis).notOptional("oups, timed out")
         } yield {
           s"return code=${c.code}\n" ++
@@ -86,7 +87,7 @@ class RunNuCommandTest() extends Specification {
       // (we have one more line because last line ends with a "\n"
       val prog = {
         for {
-          p <- RunNuCommand.run(Cmd("ls", "-1" :: "/proc/self/fd" :: Nil, Map("PATH" -> PATH), None))
+          p <- RunNuCommand.run(Cmd("ls", "-1" :: "/proc/self/fd" :: Nil, Map("PATH" -> PATH), None, WithoutSudo))
           c <- p.await.timeout(500.millis).notOptional("oups, timed out")
         } yield {
           (c.code, c.stdout.split("\n").size)
@@ -104,7 +105,7 @@ class RunNuCommandTest() extends Specification {
 
       val prog = {
         for {
-          p <- RunNuCommand.run(Cmd("mkdir", "-p" :: file.getPath :: Nil, Map("PATH" -> PATH), None))
+          p <- RunNuCommand.run(Cmd("mkdir", "-p" :: file.getPath :: Nil, Map("PATH" -> PATH), None, WithoutSudo))
           c <- p.await.timeout(500.millis).notOptional("oups, timed out")
         } yield {
           c.code

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestWriteNodeCertificatesPem.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestWriteNodeCertificatesPem.scala
@@ -44,6 +44,7 @@ import ch.qos.logback.core.OutputStreamAppender
 import com.normation.inventory.domain.Certificate
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.zio.ZioRuntime
 import com.softwaremill.quicklens.*
 import java.io.ByteArrayOutputStream
@@ -141,7 +142,7 @@ class TestWriteNodeCertificatesPem extends Specification {
 
   "When nodes have certificates, they" should {
     "certificate are written to file only for nodes with certificate" in {
-      val writer = new WriteNodeCertificatesPemImpl(Some(s"/usr/bin/touch ${dest.pathAsString}"))
+      val writer = new WriteNodeCertificatesPemImpl(Some(s"/usr/bin/touch ${dest.pathAsString}"), WithoutSudo)
       val res    = ZioRuntime.runNow(writer.writeCertificates(dest, nodes).either)
 
       (res must beRight) and
@@ -151,7 +152,7 @@ class TestWriteNodeCertificatesPem extends Specification {
 
   "when there is an error in async, we shoud get a log" in {
 
-    val writer = new WriteNodeCertificatesPemImpl(Some("/non/existing/command"))
+    val writer = new WriteNodeCertificatesPemImpl(Some("/non/existing/command"), WithoutSudo)
 
     import scala.jdk.CollectionConverters.*
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -59,6 +59,7 @@ import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.Visibility.Hidden
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.WithoutSudo
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.schedule.DirectiveScheduleEvent
 import com.normation.rudder.schedule.JsonDirectiveSchedule
@@ -162,7 +163,8 @@ class TestSystemData {
       "/we-don-t-want-hooks-here",
       hookIgnore,
       StandardCharsets.UTF_8,
-      None
+      None,
+      WithoutSudo
     )
 
     (rootGeneratedPromisesDir, promiseWriter)

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -764,6 +764,11 @@ rudder.hooks.ignore-suffixes= .swp, ~, .bak, \
 #
 rudder.package.cmd=/opt/rudder/bin/rudder package
 
+
+# Rudder will run some commands as sudo such as rudder package commands, or any hooks it should run
+# This should be disabled on environment development only.
+command.with.sudo=true
+
 ########################
 # Relayd reload command ########################################################
 ########################

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1087,12 +1087,16 @@ object RudderParsedProperties {
       case ex: ConfigException => true
     }
   }
-  val RUN_WITH_SUDO:                          SudoRun  = {
+  val RUN_WITH_SUDO_NO_ENV:                   SudoRun  = {
     try {
       if (config.getBoolean("command.with.sudo")) then WithSudo else WithoutSudo
     } catch {
       case ex: ConfigException => WithSudo
     }
+  }
+  val RUN_WITH_SUDO_HOOKS:                    SudoRun  = RUN_WITH_SUDO_NO_ENV match {
+    case WithSudo => WithSudoPreserveEnv
+    case r        => r
   }
   val WATCHER_GARBAGE_OLD_INVENTORIES_PERIOD: Duration = {
     try {
@@ -1702,7 +1706,7 @@ object RudderConfigInit {
       (done: Boolean) => configService.set_rudder_setup_done(value = done).chainError("Could not get 'setup done' property")
     )
 
-    lazy val rudderPackageService = new RudderPackageCmdService(RUDDER_PACKAGE_CMD, RUN_WITH_SUDO)
+    lazy val rudderPackageService = new RudderPackageCmdService(RUDDER_PACKAGE_CMD, RUN_WITH_SUDO_NO_ENV)
     lazy val pluginSystemService  = new PluginsServiceImpl(
       rudderPackageService,
       PluginsInfo.plugins,
@@ -2056,7 +2060,7 @@ object RudderConfigInit {
 //      new FactRepositoryPostCommit[Unit](factRepo, nodeFactInfoService)
         // deprecated: we use fact repo now
 //      :: new PostCommitLogger(ldifInventoryLogger)
-        new PostCommitInventoryHooks[Unit](HOOKS_D, HOOKS_IGNORE_SUFFIXES, nodeFactRepository, RUN_WITH_SUDO)
+        new PostCommitInventoryHooks[Unit](HOOKS_D, HOOKS_IGNORE_SUFFIXES, nodeFactRepository, RUN_WITH_SUDO_HOOKS)
         // removed: this is done as a callback of CoreNodeFactRepos
         // :: new TriggerPolicyGenerationPostCommit[Unit](asyncDeploymentAgent, stringUuidGenerator)
         :: Nil
@@ -2111,7 +2115,7 @@ object RudderConfigInit {
         new InventoryFailedHook(
           HOOKS_D,
           HOOKS_IGNORE_SUFFIXES,
-          RUN_WITH_SUDO
+          RUN_WITH_SUDO_HOOKS
         )
       )
       new DefaultProcessInventoryService(inventoryProcessorInternal, mover)
@@ -3150,7 +3154,7 @@ object RudderConfigInit {
         HOOKS_IGNORE_SUFFIXES,
         RUDDER_CHARSET.value,
         Some(RUDDER_GROUP_OWNER_GENERATED_POLICIES),
-        RUN_WITH_SUDO
+        RUN_WITH_SUDO_HOOKS
       )
     }
 
@@ -3193,11 +3197,11 @@ object RudderConfigInit {
       HOOKS_D,
       HOOKS_IGNORE_SUFFIXES,
       UPDATED_NODE_IDS_COMPABILITY,
-      RUN_WITH_SUDO
+      RUN_WITH_SUDO_HOOKS
     )
     lazy val deploymentService              = {
       val writeCertificate        = new WriteCertificatesPemServiceImpl(
-        new WriteNodeCertificatesPemImpl(Some(RUDDER_RELAY_RELOAD), RUN_WITH_SUDO),
+        new WriteNodeCertificatesPemImpl(Some(RUDDER_RELAY_RELOAD), RUN_WITH_SUDO_HOOKS),
         better.files.File("/var/rudder/lib/ssl/allnodescerts.pem")
       )
       val buildNodeContext        = new NodeContextBuilderImpl(interpolationCompiler, systemVariableService)
@@ -3273,7 +3277,7 @@ object RudderConfigInit {
         unitRefuseGroup ::
         Nil
       }
-      val hooksRunner  = new NewNodeManagerHooksImpl(nodeFactRepository, HOOKS_D, HOOKS_IGNORE_SUFFIXES, RUN_WITH_SUDO)
+      val hooksRunner  = new NewNodeManagerHooksImpl(nodeFactRepository, HOOKS_D, HOOKS_IGNORE_SUFFIXES, RUN_WITH_SUDO_HOOKS)
 
       val composedManager = new ComposedNewNodeManager[Unit](
         nodeFactRepository,
@@ -3538,7 +3542,7 @@ object RudderConfigInit {
       postNodeDeleteActions,
       HOOKS_D,
       HOOKS_IGNORE_SUFFIXES,
-      RUN_WITH_SUDO
+      RUN_WITH_SUDO_HOOKS
     )
 
     lazy val healthcheckService = new HealthcheckService(
@@ -3553,7 +3557,7 @@ object RudderConfigInit {
     lazy val campaignSerializer             = new CampaignSerializer()
     lazy val campaignEventRepo              = new CampaignEventRepositoryImpl(doobie, campaignSerializer)
     lazy val campaignHooksRepository        = new FsCampaignHooksRepository(HOOKS_D)
-    lazy val campaignHooksService           = new FsCampaignHooksService(HOOKS_D, HOOKS_IGNORE_SUFFIXES, RUN_WITH_SUDO)
+    lazy val campaignHooksService           = new FsCampaignHooksService(HOOKS_D, HOOKS_IGNORE_SUFFIXES, RUN_WITH_SUDO_HOOKS)
     lazy val campaignArchiver               = new CampaignArchiverImpl(gitConfigRepo, "campaigns", personIdentService)
 
     lazy val campaignRepo = CampaignRepositoryImpl

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -80,6 +80,8 @@ import com.normation.rudder.git.GitItemRepository
 import com.normation.rudder.git.GitRepositoryProvider
 import com.normation.rudder.git.GitRepositoryProviderImpl
 import com.normation.rudder.git.GitRevisionProvider
+import com.normation.rudder.hooks.RunNuCommand.SudoRun
+import com.normation.rudder.hooks.RunNuCommand.SudoRun.*
 import com.normation.rudder.inventory.DefaultProcessInventoryService
 import com.normation.rudder.inventory.InventoryFailedHook
 import com.normation.rudder.inventory.InventoryFileWatcher
@@ -1078,14 +1080,20 @@ object RudderParsedProperties {
   val INVENTORY_DIR_RECEIVED: String = INVENTORY_ROOT_DIR + "/received"
   val INVENTORY_DIR_UPDATE:   String = INVENTORY_ROOT_DIR + "/accepted-nodes-updates"
 
-  val WATCHER_ENABLE: Boolean = {
+  val WATCHER_ENABLE:                         Boolean  = {
     try {
       config.getBoolean("inventories.watcher.enable")
     } catch {
       case ex: ConfigException => true
     }
   }
-
+  val RUN_WITH_SUDO:                          SudoRun  = {
+    try {
+      if (config.getBoolean("command.with.sudo")) then WithSudo else WithoutSudo
+    } catch {
+      case ex: ConfigException => WithSudo
+    }
+  }
   val WATCHER_GARBAGE_OLD_INVENTORIES_PERIOD: Duration = {
     try {
       Duration.fromScala(
@@ -1694,7 +1702,7 @@ object RudderConfigInit {
       (done: Boolean) => configService.set_rudder_setup_done(value = done).chainError("Could not get 'setup done' property")
     )
 
-    lazy val rudderPackageService = new RudderPackageCmdService(RUDDER_PACKAGE_CMD)
+    lazy val rudderPackageService = new RudderPackageCmdService(RUDDER_PACKAGE_CMD, RUN_WITH_SUDO)
     lazy val pluginSystemService  = new PluginsServiceImpl(
       rudderPackageService,
       PluginsInfo.plugins,
@@ -2048,7 +2056,7 @@ object RudderConfigInit {
 //      new FactRepositoryPostCommit[Unit](factRepo, nodeFactInfoService)
         // deprecated: we use fact repo now
 //      :: new PostCommitLogger(ldifInventoryLogger)
-        new PostCommitInventoryHooks[Unit](HOOKS_D, HOOKS_IGNORE_SUFFIXES, nodeFactRepository)
+        new PostCommitInventoryHooks[Unit](HOOKS_D, HOOKS_IGNORE_SUFFIXES, nodeFactRepository, RUN_WITH_SUDO)
         // removed: this is done as a callback of CoreNodeFactRepos
         // :: new TriggerPolicyGenerationPostCommit[Unit](asyncDeploymentAgent, stringUuidGenerator)
         :: Nil
@@ -2102,7 +2110,8 @@ object RudderConfigInit {
         INVENTORY_DIR_FAILED,
         new InventoryFailedHook(
           HOOKS_D,
-          HOOKS_IGNORE_SUFFIXES
+          HOOKS_IGNORE_SUFFIXES,
+          RUN_WITH_SUDO
         )
       )
       new DefaultProcessInventoryService(inventoryProcessorInternal, mover)
@@ -3140,7 +3149,8 @@ object RudderConfigInit {
         HOOKS_D,
         HOOKS_IGNORE_SUFFIXES,
         RUDDER_CHARSET.value,
-        Some(RUDDER_GROUP_OWNER_GENERATED_POLICIES)
+        Some(RUDDER_GROUP_OWNER_GENERATED_POLICIES),
+        RUN_WITH_SUDO
       )
     }
 
@@ -3182,11 +3192,12 @@ object RudderConfigInit {
     lazy val policyGenerationHookService    = new PolicyGenerationHookServiceImpl(
       HOOKS_D,
       HOOKS_IGNORE_SUFFIXES,
-      UPDATED_NODE_IDS_COMPABILITY
+      UPDATED_NODE_IDS_COMPABILITY,
+      RUN_WITH_SUDO
     )
     lazy val deploymentService              = {
       val writeCertificate        = new WriteCertificatesPemServiceImpl(
-        new WriteNodeCertificatesPemImpl(Some(RUDDER_RELAY_RELOAD)),
+        new WriteNodeCertificatesPemImpl(Some(RUDDER_RELAY_RELOAD), RUN_WITH_SUDO),
         better.files.File("/var/rudder/lib/ssl/allnodescerts.pem")
       )
       val buildNodeContext        = new NodeContextBuilderImpl(interpolationCompiler, systemVariableService)
@@ -3262,7 +3273,7 @@ object RudderConfigInit {
         unitRefuseGroup ::
         Nil
       }
-      val hooksRunner  = new NewNodeManagerHooksImpl(nodeFactRepository, HOOKS_D, HOOKS_IGNORE_SUFFIXES)
+      val hooksRunner  = new NewNodeManagerHooksImpl(nodeFactRepository, HOOKS_D, HOOKS_IGNORE_SUFFIXES, RUN_WITH_SUDO)
 
       val composedManager = new ComposedNewNodeManager[Unit](
         nodeFactRepository,
@@ -3526,7 +3537,8 @@ object RudderConfigInit {
       newNodeManagerImpl,
       postNodeDeleteActions,
       HOOKS_D,
-      HOOKS_IGNORE_SUFFIXES
+      HOOKS_IGNORE_SUFFIXES,
+      RUN_WITH_SUDO
     )
 
     lazy val healthcheckService = new HealthcheckService(
@@ -3541,7 +3553,7 @@ object RudderConfigInit {
     lazy val campaignSerializer             = new CampaignSerializer()
     lazy val campaignEventRepo              = new CampaignEventRepositoryImpl(doobie, campaignSerializer)
     lazy val campaignHooksRepository        = new FsCampaignHooksRepository(HOOKS_D)
-    lazy val campaignHooksService           = new FsCampaignHooksService(HOOKS_D, HOOKS_IGNORE_SUFFIXES)
+    lazy val campaignHooksService           = new FsCampaignHooksService(HOOKS_D, HOOKS_IGNORE_SUFFIXES, RUN_WITH_SUDO)
     lazy val campaignArchiver               = new CampaignArchiverImpl(gitConfigRepo, "campaigns", personIdentService)
 
     lazy val campaignRepo = CampaignRepositoryImpl


### PR DESCRIPTION
https://issues.rudder.io/issues/29079

## Fix #29079: Run hooks with sudo only in production when webapp runs as non-root

### Context

When Rudder's webapp runs as a non-root user, hooks and certain commands need
`sudo` to run with elevated privileges. However, using `sudo` in development
or test environments causes failures since it is not available or configured there.

Previously the decision of whether to use `sudo` was implicit and not propagated
cleanly through the codebase.

### What this PR does

Introduces a `SudoRun` enum with three cases and threads it explicitly through
the entire command and hook execution chain.

**Core change (`RunNuCommand.scala`)**

New `SudoRun` enum (using `enumeratum`) with three cases:
- `WithSudo` — plain `sudo`, used for non-hook commands (e.g. `rudder package`)
- `WithSudoPreserveEnv` — `sudo --preserve-env`, used for hooks so that environment variables set by Rudder are preserved
- `WithoutSudo` — no sudo, used in dev/test and for commands that never need elevation (`rudderc`, `prlimit`)

`Cmd` gains a `sudoRun: SudoRun` field. `Cmd.display` reflects the chosen mode for logging. `RunNuCommand.run` prepends the appropriate sudo invocation before execution.

**Configuration (`configuration.properties.sample`, `RudderConfig.scala`)**

New property `command.with.sudo=true` (defaults to `true` if absent, preserving production behaviour).

Two derived values are computed once at startup:
- `RUN_WITH_SUDO_NO_ENV` — `WithSudo` or `WithoutSudo`, used for non-hook commands like `rudder package`
- `RUN_WITH_SUDO_HOOKS` — `WithSudoPreserveEnv` or `WithoutSudo`, used for all hook runners so env vars are forwarded

**Propagation through hook callers**

`sudoRun` is forwarded through all hook-running paths: `RunHooks`
(`asyncRun`, `asyncRunHistory`, `syncRun`), and all callers —
`CampaignHooksService`, `InventoryProcessor`, `PostCommits`,
`NewNodeManager`, `RemoveNodeService`, `DeploymentService`,
`WriteNodeCertificatesPem`, `PolicyWriterService`.

**Commands that never need sudo**

`EditorTechniqueReader`, `TechniqueCompiler` (`rudderc`) and
`HealthcheckService` hardcode `WithoutSudo`.

**Tests**

All test fixtures explicitly use `WithoutSudo`.

### How to review

Start with `RunNuCommand.scala` (new `SudoRun` enum + `Cmd` field + execution
logic), then `RudderConfig.scala` (`RUN_WITH_SUDO_NO_ENV` vs `RUN_WITH_SUDO_HOOKS`
and where each is injected). The rest of the diff is mechanical propagation
through the dependency chain.