### PR TITLE
Fixes #28162: Technique parameter help text is half useful

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
@@ -118,7 +118,7 @@ techniqueParameter model technique param =
                     [ span [] [ text ("${" ++ param_var_name ++ "}") ]
                     ]
                 , div [ class "full-name" ]
-                    [ span [] [ text (technique.id.value ++ "." ++ param_var_name) ]
+                    [ span [] [ text ("{{vars." ++ technique.id.value ++ "." ++ param_var_name ++ "}}") ]
                     ]
                 ]
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
@@ -734,12 +734,12 @@ ul.files-list > li .full-name{
   display: block;
 }
 ul.files-list > li .use-with:before {
-  content: "Use with:";
+  content: "Use in methods with:";
   margin-right: 6px;
   display: inline-block;
 }
 ul.files-list > li .full-name:before{
-  content: ", Full name:";
+  content: ", use in templates with:";
   margin-right: 6px;
   display: inline-block;
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/28162

before:
<img width="690" height="111" alt="image" src="https://github.com/user-attachments/assets/0fd8ad36-4a0d-49f7-b7de-f3f904053b06" />

after:
<img width="619" height="64" alt="image" src="https://github.com/user-attachments/assets/542e3144-a769-42d9-8bd8-27c1b6423f64" />
