### PR TITLE
Fixes #29177: Log of importing archive are missing archive name

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -898,10 +898,6 @@ final case class PolicyArchiveMetadata(
     filename: String
 )
 
-case object PolicyArchiveMetadata {
-  def empty: PolicyArchiveMetadata = PolicyArchiveMetadata("")
-}
-
 final case class TechniqueCategoryArchive(
     metadata: TechniqueCategoryMetadata,
     // the path, last one is category with the metadata (ie also category id)
@@ -995,9 +991,9 @@ final case class PolicyArchive(
   // format: on
 }
 object PolicyArchive {
-  def empty: PolicyArchive = {
+  def empty(archiveName: String): PolicyArchive = {
     PolicyArchive(
-      PolicyArchiveMetadata.empty,
+      PolicyArchiveMetadata(archiveName),
       Chunk.empty,
       Chunk.empty,
       Chunk.empty,
@@ -1029,7 +1025,7 @@ final case class PolicyArchiveUnzip(
 )
 
 object PolicyArchiveUnzip {
-  def empty: PolicyArchiveUnzip = PolicyArchiveUnzip(PolicyArchive.empty, Chunk.empty)
+  def empty(archiveName: String): PolicyArchiveUnzip = PolicyArchiveUnzip(PolicyArchive.empty(archiveName), Chunk.empty)
 }
 
 sealed trait TechniqueType { def name: String }
@@ -1368,7 +1364,7 @@ class ZipArchiveReaderImpl(
                            )
       // check for ZipSlip path traversal
       _                 <- ZIO.foreach(zipEntries) { case (e, _) => ZipUtils.checkForZipSlip(e) }
-      withTechniques    <- parseTechniques(archiveName, PolicyArchiveUnzip.empty, techniqueUnzips)
+      withTechniques    <- parseTechniques(archiveName, PolicyArchiveUnzip.empty(archiveName), techniqueUnzips)
       _                 <-
         ApplicationLoggerPure.Archive.debug(
           s"Processing archive '${archiveName}': technique categories: '${sortedEntries.techniquesCats.map(_._1).mkString("', '")}'"

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SaveArchiveServiceTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SaveArchiveServiceTest.scala
@@ -122,7 +122,7 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
   }
 
   private def policyArchiveRuleCategory(rootCategory: RuleCategory) = {
-    PolicyArchive.empty.copy(ruleCats = Chunk.single(rootCategory.transformInto[RuleCategoryArchive]))
+    PolicyArchive.empty("test archive").copy(ruleCats = Chunk.single(rootCategory.transformInto[RuleCategoryArchive]))
   }
 
   /**


### PR DESCRIPTION
https://issues.rudder.io/issues/29177

So, we were just not setting the archive name anymore. I quickly tried to see where it came from, but it was just quicker to fix it. 