### PR TITLE
Fixes #29187: Add a template rendering trust mode

### DIFF
--- a/policies/lib/tests/integration/unix/file_from_template_options_test.rs
+++ b/policies/lib/tests/integration/unix/file_from_template_options_test.rs
@@ -18,6 +18,7 @@ fn it_should_render_template_to_new_file() {
             r#"{{foo}} + {{bar}} = {{foobar}}"#,
             "",
             "true",
+            "sandboxed",
         ],
     )
     .enforce();
@@ -51,6 +52,7 @@ fn it_should_audit_template() {
             r#"{{foo}} + {{bar}} = {{foobar}}"#,
             "",
             "true",
+            "sandboxed",
         ],
     )
     .audit();
@@ -93,6 +95,7 @@ fn it_should_render_template_to_new_file_using_datastate() {
             r#"Welcome {{ vars.db.users.Bob.name }}!"#,
             "",
             "false",
+            "sandboxed",
         ],
     )
     .enforce();
@@ -126,6 +129,7 @@ fn it_should_fail_if_not_template_is_given() {
             "",
             "",
             "false",
+            "sandboxed",
         ],
     )
     .enforce();
@@ -137,5 +141,95 @@ fn it_should_fail_if_not_template_is_given() {
     r.assert_log_v4_result_conditions(tested_method, MethodStatus::Error);
 
     assert!(!file_path.exists(), "The target file should not be created");
+    end_test(workdir);
+}
+// Requires a rudder-module-template that supports the `lookup` function and the
+// sandboxed/unrestricted modes (>= 9.2). The lib integration tests run the
+// installed /opt/rudder/bin/rudder-module-template, so this fails against older
+// published packages (e.g. on ARM runners lagging behind the feature).
+#[ignore = "requires template module with lookup/unrestricted support (>= 9.2)"]
+#[test]
+fn it_should_block_lookup_when_sandboxed_by_default() {
+    let workdir = init_test();
+    let file_path = workdir.path().join("output.txt");
+    let source_path = workdir.path().join("source.txt");
+
+    // Mode is left empty, so it defaults to "sandboxed": the `lookup` function
+    // is not available and rendering must fail.
+    let tested_method = &method(
+        "file_from_template_options",
+        &[
+            file_path.to_str().unwrap(),
+            "minijinja",
+            "",
+            &format!(
+                "{{{{ lookup('file', '{}') }}}}",
+                source_path.to_str().unwrap()
+            ),
+            "",
+            "false",
+            "",
+        ],
+    )
+    .enforce();
+
+    let r = MethodTestSuite::new()
+        .given(Given::file_present(
+            source_path.to_str().unwrap(),
+            "secret content",
+        ))
+        .when(tested_method)
+        .execute(get_lib_path(), workdir.path().to_path_buf());
+    r.assert_legacy_result_conditions(tested_method, vec![MethodStatus::Error]);
+    r.assert_log_v4_result_conditions(tested_method, MethodStatus::Error);
+
+    assert!(
+        !file_path.exists(),
+        "The target file must not be created when lookup is blocked"
+    );
+    end_test(workdir);
+}
+// See the note on it_should_block_lookup_when_sandboxed_by_default.
+#[ignore = "requires template module with lookup/unrestricted support (>= 9.2)"]
+#[test]
+fn it_should_allow_lookup_when_unrestricted() {
+    let workdir = init_test();
+    let file_path = workdir.path().join("output.txt");
+    let file_str = file_path.to_str().unwrap();
+    let source_path = workdir.path().join("source.txt");
+
+    // With mode = "unrestricted", `lookup` is available and reads the file.
+    let tested_method = &method(
+        "file_from_template_options",
+        &[
+            file_path.to_str().unwrap(),
+            "minijinja",
+            "",
+            &format!(
+                "{{{{ lookup('file', '{}') }}}}",
+                source_path.to_str().unwrap()
+            ),
+            "",
+            "false",
+            "unrestricted",
+        ],
+    )
+    .enforce();
+
+    let r = MethodTestSuite::new()
+        .given(Given::file_present(
+            source_path.to_str().unwrap(),
+            "secret content",
+        ))
+        .when(tested_method)
+        .execute(get_lib_path(), workdir.path().to_path_buf());
+    r.assert_legacy_result_conditions(tested_method, vec![MethodStatus::Repaired]);
+    r.assert_log_v4_result_conditions(tested_method, MethodStatus::Repaired);
+
+    let content = std::fs::read_to_string(file_str).unwrap();
+    assert_eq!(
+        content, "secret content",
+        "lookup should have inlined the source file content"
+    );
     end_test(workdir);
 }

--- a/policies/lib/tree/30_generic_methods/file_from_template_options.cf
+++ b/policies/lib/tree/30_generic_methods/file_from_template_options.cf
@@ -29,6 +29,11 @@
 #   - If `data` is provided, the template will only use those data to render the template. The agent datastate will not be passed to the templating engine.
 #   - If `data` is not provided, the **agent datastate** is used instead (containing the existing variables and classes of the current agent run).
 #
+# ### Security: template data exposure
+#   - `mode: sandboxed` limits what a template can *do* (no filesystem access, bounded compute) but not what it can *see*.
+#   - When `data` is empty, the **entire agent datastate** — every variable and class of the run, across all directives, including any secrets stored in variables and node properties — is passed to the template. A sandboxed template can still read all of it and write it into the destination file (and, with `show_content: true`, into the report).
+#   - To render an untrusted template safely, always pass an explicit, minimal `data` object instead of relying on the implicit datastate.
+#
 # ### Template Source:
 #   - `template_string`: Inline template string.
 #   - `template_path`: Path to an external template file.
@@ -112,6 +117,9 @@
 # @parameter            show_content Show the file content in the report, "true" or "false" (defaults to "true")
 # @parameter_constraint show_content "allow_empty_string" : true
 # @parameter_constraint show_content "select" : [ "", "true", "false" ]
+# @parameter            mode Trust level for the template content: "sandboxed" limits the risk from untrusted content (including filesystem access), "unrestricted" removes those limits (defaults to "sandboxed")
+# @parameter_constraint mode "allow_empty_string" : true
+# @parameter_constraint mode "select" : [ "", "sandboxed", "unrestricted" ]
 #
 # @class_prefix file_from_template_options
 # @class_parameter destination
@@ -121,7 +129,7 @@ promise agent template {
   path => "/opt/rudder/bin/rudder-module-template";
 }
 
-bundle agent file_from_template_options(destination, engine, data, template_string, template_path, show_content) {
+bundle agent file_from_template_options(destination, engine, data, template_string, template_path, show_content, mode) {
   vars:
       "module_file"  string => "/opt/rudder/bin/rudder-module-template";
       "class_prefix" string => canonify("file_from_template_options_${destination}");
@@ -129,6 +137,7 @@ bundle agent file_from_template_options(destination, engine, data, template_stri
   defaults:
       "engine"       string => "minijinja", if_match_regex => "";
       "show_content" string => "true", if_match_regex => "";
+      "mode"         string => "sandboxed", if_match_regex => "";
 
   classes:
       "has_module"   expression => fileexists("${module_file}");
@@ -139,7 +148,7 @@ bundle agent file_from_template_options(destination, engine, data, template_stri
   methods:
     pass3.has_module::
       "${report_data.method_id}" usebundle => call_method("rudder_actual_file_from_template_options");
-      "${report_data.method_id}" usebundle => rudder_actual_file_from_template_options("${destination}", "${engine}", "${data}", "${template_string}", "${template_path}", "${show_content}");
+      "${report_data.method_id}" usebundle => rudder_actual_file_from_template_options("${destination}", "${engine}", "${data}", "${template_string}", "${template_path}", "${show_content}", "${mode}");
       "${report_data.method_id}" usebundle => call_method_classes("${class_prefix}");
       "${report_data.method_id}" usebundle => call_method_classes_caller;
       "${report_data.method_id}" usebundle => call_method_end("rudder_actual_file_from_template_options");
@@ -151,7 +160,7 @@ bundle agent file_from_template_options(destination, engine, data, template_stri
       "${report_data.method_id}" usebundle => log_rudder_v4_2("${destination}", "Template module is not supported on this agent");
 }
 
-bundle agent template_module_serializer(r_destination, r_engine, r_data, r_template_string, r_template_path, r_datastate_path, r_report_file) {
+bundle agent template_module_serializer(r_destination, r_engine, r_data, r_template_string, r_template_path, r_datastate_path, r_report_file, r_mode) {
   vars:
     "path"            string => "${r_destination}";
     "engine"          string => "${r_engine}";
@@ -160,9 +169,10 @@ bundle agent template_module_serializer(r_destination, r_engine, r_data, r_templ
     "template_path"   string => "${r_template_path}";
     "datastate_path"  string => "${r_datastate_path}";
     "report_file"     string => "${r_report_file}";
+    "mode"            string => "${r_mode}";
 }
 
-bundle agent rudder_actual_file_from_template_options(destination, engine, data, template_string, template_path, show_content) {
+bundle agent rudder_actual_file_from_template_options(destination, engine, data, template_string, template_path, show_content, mode) {
   vars:
      "destination_c"   string => canonify("${destination}");
      "report_file"     string => "/var/rudder/tmp/rudder-module-template${destination_c}.log";
@@ -221,7 +231,8 @@ show_content: ${show_content}
                                                                          "${template_string}",
                                                                          "${template_path}",
                                                                          "${datastate_path}",
-                                                                         "${report_file}");
+                                                                         "${report_file}",
+                                                                         "${mode}");
 
     pass3.!has_report::
       "${report_data.method_id}" usebundle => _classes_failure("${report_data.method_id}");

--- a/policies/module-types/template/Cargo.toml
+++ b/policies/module-types/template/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # we want stable order in produced config files
 # json and urlencode provide built-in filters
-minijinja = { version = "2", features = ["debug", "preserve_order", "json", "urlencode", "builtins"] }
+minijinja = { version = "2", features = ["debug", "preserve_order", "json", "urlencode", "builtins", "loader", "fuel", "loop_controls"] }
 mustache = { version = "0.9.0", git = "https://github.com/Normation/rust-mustache.git" , features = ["CFEngine"] }
 rudder_module_type = { path = "../../rudder-module-type", features = ["diff"] }
 clap = { version = "4.5.32", features = ["derive"] }

--- a/policies/module-types/template/rudder_module_type.yml
+++ b/policies/module-types/template/rudder_module_type.yml
@@ -45,3 +45,13 @@ parameters:
       allow_empty: true
       allow_whitespace_string: false
     p_type: bool
+  mode:
+    description: "Trust level for the template content: 'sandboxed' limits the risk from untrusted content (including filesystem access), 'unrestricted' removes those limits (defaults to sandboxed)"
+    constraints:
+      allow_empty: true
+      allow_whitespace_string: false
+      select:
+        - "sandboxed"
+        - "unrestricted"
+      default: "sandboxed"
+    p_type: String

--- a/policies/module-types/template/src/cli.rs
+++ b/policies/module-types/template/src/cli.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2021 Normation SAS
 
+use crate::engine::Mode;
 use crate::{Engine, compute_diff_or_warning};
 
 use anyhow::{Context, Result, bail};
@@ -36,6 +37,10 @@ pub struct Cli {
     /// Controls output of diffs
     #[arg(short, long)]
     show_content: bool,
+
+    /// Trust level for the template content
+    #[arg(long, default_value_t = Mode::Sandboxed)]
+    mode: Mode,
 }
 
 impl Cli {
@@ -49,7 +54,7 @@ impl Cli {
 
         let value: Value = serde_json::from_str(&data)?;
         let renderer = cli.engine.renderer(None)?;
-        let output = renderer.render(Some(cli.template.as_path()), None, &value)?;
+        let output = renderer.render(Some(cli.template.as_path()), None, &value, cli.mode)?;
 
         let already_present = cli.out.exists();
 

--- a/policies/module-types/template/src/engine.rs
+++ b/policies/module-types/template/src/engine.rs
@@ -33,11 +33,40 @@ impl std::fmt::Display for Engine {
     }
 }
 
+/// What template content is allowed to do at render time.
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, ValueEnum, Default,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Mode {
+    /// No filesystem access, no escape to the host runtime.
+    #[default]
+    Sandboxed,
+    /// No restriction; trusted templates only.
+    Unrestricted,
+}
+
+impl Mode {
+    pub fn is_sandboxed(self) -> bool {
+        matches!(self, Mode::Sandboxed)
+    }
+}
+
+impl std::fmt::Display for Mode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mode = match self {
+            Mode::Sandboxed => "sandboxed",
+            Mode::Unrestricted => "unrestricted",
+        };
+        write!(f, "{mode}")
+    }
+}
+
 impl Engine {
     pub fn renderer(&self, python_version: Option<String>) -> Result<Box<dyn TemplateEngine>> {
         Ok(match self {
             Engine::Mustache => Box::new(mustache::MustacheEngine),
-            Engine::Minijinja => Box::new(minijinja::MiniJinjaEngine),
+            Engine::Minijinja => Box::new(minijinja::MiniJinjaEngine::default()),
             Engine::Jinja2 => Box::new(
                 jinja2::Jinja2Engine::new(python_version)
                     .context("Failed to create Jinja2 engine")?,
@@ -47,10 +76,15 @@ impl Engine {
 }
 
 pub trait TemplateEngine {
+    /// With `Mode::Sandboxed`, implementations must keep the render a pure
+    /// function of the template and `data`: no filesystem reads besides the
+    /// template file itself, no writes, no code execution on the host, and
+    /// bounded compute (as strictly as the engine allows).
     fn render(
         &self,
         template_path: Option<&Path>,
         template_string: Option<&str>,
         data: &Value,
+        mode: Mode,
     ) -> Result<String>;
 }

--- a/policies/module-types/template/src/engine/jinja2.rs
+++ b/policies/module-types/template/src/engine/jinja2.rs
@@ -1,18 +1,29 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2021-2025 Normation SAS
 
-use std::io::Write;
+use std::io::{Read, Write};
 use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 use tempfile::{NamedTempFile, TempPath};
 
-use crate::engine::TemplateEngine;
+use crate::engine::{Mode, TemplateEngine};
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::{fs, path::Path};
 
+/// Wall-clock timeout for a single jinja2 render in sandboxed mode. The engine
+/// shells out to Python and has no way to cap compute from inside, so this
+/// bounds runaway or untrusted templates instead of letting them hang the agent.
+const JINJA2_SANDBOX_TIMEOUT: Duration = Duration::from_secs(3);
+/// Timeout for unrestricted (trusted) renders: only catches a hung render.
+const JINJA2_UNRESTRICTED_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub(crate) struct Jinja2Engine {
     python_interpreter: String,
+    sandbox_timeout: Duration,
+    unrestricted_timeout: Duration,
 }
 
 impl Jinja2Engine {
@@ -21,7 +32,11 @@ impl Jinja2Engine {
             Some(v) => v,
             None => detect_python_version().context("Could not get python version")?,
         };
-        Ok(Jinja2Engine { python_interpreter })
+        Ok(Jinja2Engine {
+            python_interpreter,
+            sandbox_timeout: JINJA2_SANDBOX_TIMEOUT,
+            unrestricted_timeout: JINJA2_UNRESTRICTED_TIMEOUT,
+        })
     }
 }
 
@@ -31,22 +46,30 @@ impl TemplateEngine for Jinja2Engine {
         template_path: Option<&Path>,
         template_string: Option<&str>,
         data: &Value,
+        mode: Mode,
     ) -> Result<String> {
+        let is_inline = template_path.is_none();
         let named: TempPath;
         let template_path = match (&template_path, template_string) {
-            (Some(p), _) => p.to_str().unwrap(),
+            (Some(p), _) => p
+                .to_str()
+                .with_context(|| format!("Template path is not valid UTF-8: {}", p.display()))?,
             (_, Some(s)) => {
-                let mut tmp_file = NamedTempFile::new().expect("Failed to create tempfile");
+                let mut tmp_file =
+                    NamedTempFile::new().context("Failed to create temporary file for template")?;
                 tmp_file
                     .write_all(s.as_bytes())
-                    .expect("Failed to write template in tempfile");
+                    .context("Failed to write template to temporary file")?;
                 named = tmp_file.into_temp_path();
-                named.to_str().unwrap()
+                named
+                    .to_str()
+                    .context("Temporary file path is not valid UTF-8")?
             }
             _ => unreachable!(),
         };
 
-        let tmp_script = NamedTempFile::new().expect("Failed to create temp script");
+        let tmp_script =
+            NamedTempFile::new().context("Failed to create temporary file for render script")?;
         let template_script_path = tmp_script.into_temp_path();
         let templating_script_content = include_str!("jinja2/render.py");
 
@@ -65,30 +88,73 @@ impl TemplateEngine for Jinja2Engine {
         }
 
         let output = if cfg!(target_os = "linux") {
-            let mut child = Command::new(&self.python_interpreter)
-                .arg(&template_script_path)
-                .arg(template_path)
+            let mut cmd = Command::new(&self.python_interpreter);
+            cmd.arg(&template_script_path).arg(template_path);
+            if mode.is_sandboxed() {
+                cmd.arg("--sandboxed");
+            }
+            if is_inline {
+                cmd.arg("--inline");
+            }
+            let mut child = cmd
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .spawn()
-                .unwrap_or_else(|_| panic!("Failed to execute {}", template_script_path.display()));
+                .with_context(|| format!("Failed to execute {}", template_script_path.display()))?;
 
-            let stdin = child.stdin.as_mut().unwrap();
-            stdin
-                .write_all(data.to_string().as_bytes())
-                .expect("Failed to write to stdin");
+            // Feed the data on stdin and drain stdout/stderr from threads, so a
+            // large template output cannot deadlock against a full pipe while we
+            // wait for the process.
+            let mut stdin = child.stdin.take().expect("stdin was piped");
+            let payload = data.to_string();
+            let stdin_writer = thread::spawn(move || stdin.write_all(payload.as_bytes()));
+            let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
+            let stdout_reader = thread::spawn(move || {
+                let mut buf = Vec::new();
+                let _ = stdout_pipe.read_to_end(&mut buf);
+                buf
+            });
+            let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+            let stderr_reader = thread::spawn(move || {
+                let mut buf = Vec::new();
+                let _ = stderr_pipe.read_to_end(&mut buf);
+                buf
+            });
 
-            let output_info = child.wait_with_output()?;
-            if !output_info.status.success() {
-                let output = String::from_utf8_lossy(&output_info.stderr).to_string();
+            // Bound the run so an untrusted or runaway template cannot hang the
+            // agent forever.
+            let timeout = if mode.is_sandboxed() {
+                self.sandbox_timeout
+            } else {
+                self.unrestricted_timeout
+            };
+            let start = Instant::now();
+            let status = loop {
+                if let Some(status) = child.try_wait()? {
+                    break status;
+                }
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    bail!("Jinja2 rendering timed out after {}s", timeout.as_secs());
+                }
+                thread::sleep(Duration::from_millis(100));
+            };
+
+            let _ = stdin_writer.join();
+            let stdout = stdout_reader.join().unwrap_or_default();
+            let stderr = stderr_reader.join().unwrap_or_default();
+
+            if !status.success() {
+                let output = String::from_utf8_lossy(&stderr).to_string();
                 bail!(
                     "Error {} failed with : {}",
                     template_script_path.display(),
                     output
                 );
             }
-            String::from_utf8_lossy(&output_info.stdout).to_string()
+            String::from_utf8_lossy(&stdout).to_string()
         } else {
             bail!("Jinja2 templating engine is not supported on Windows")
         };
@@ -115,4 +181,113 @@ fn detect_python_version() -> Result<String> {
         "Failed to locate a Python interpreter with Jinja2 installed. Tried the following commands:\n{}",
         used_cmd.join("\n")
     )
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn engine(sandbox_timeout: Duration) -> Jinja2Engine {
+        let python_interpreter = detect_python_version().expect(
+            "no Python interpreter with jinja2 available; \
+             install jinja2 to run the template module tests",
+        );
+        Jinja2Engine {
+            python_interpreter,
+            sandbox_timeout,
+            unrestricted_timeout: JINJA2_UNRESTRICTED_TIMEOUT,
+        }
+    }
+
+    #[test]
+    fn test_jinja2_renders_basic() {
+        let engine = engine(JINJA2_SANDBOX_TIMEOUT);
+        let out = engine
+            .render(
+                None,
+                Some("Hello {{ name }}"),
+                &json!({ "name": "World" }),
+                Mode::Sandboxed,
+            )
+            .expect("render failed");
+        assert_eq!(out, "Hello World");
+    }
+
+    #[test]
+    fn test_jinja2_sandbox_blocks_python_internals() {
+        let engine = engine(JINJA2_SANDBOX_TIMEOUT);
+        // The classic Jinja2 sandbox-escape vector: reaching Python internals
+        // through dunder attributes. The SandboxedEnvironment must reject it.
+        let template = "{{ ''.__class__.__mro__ }}";
+        let err = engine
+            .render(None, Some(template), &json!({}), Mode::Sandboxed)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("SecurityError"),
+            "sandboxed render should fail with a security error, got: {err}"
+        );
+
+        // The same access succeeds when unrestricted, proving it is the sandbox
+        // — not a syntax or attribute error — that blocks it in sandboxed mode.
+        let out = engine
+            .render(None, Some(template), &json!({}), Mode::Unrestricted)
+            .expect("unrestricted render should expose Python internals");
+        assert!(
+            out.contains("class 'str'"),
+            "unrestricted render should reach the class, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_jinja2_times_out_on_runaway() {
+        let engine = engine(Duration::from_secs(1));
+        // Nested loops stay under the sandbox's per-range cap but iterate far
+        // too long to finish; the timeout must abort them.
+        let template =
+            "{% for i in range(99999) %}{% for j in range(99999) %}{% endfor %}{% endfor %}";
+        let err = engine
+            .render(None, Some(template), &json!({}), Mode::Sandboxed)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("timed out"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_jinja2_file_include_works_when_unrestricted() {
+        let engine = engine(JINJA2_SANDBOX_TIMEOUT);
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("part.j2"), "PART").unwrap();
+        let main = dir.path().join("main.j2");
+        fs::write(&main, r#"A {% include "part.j2" %} B"#).unwrap();
+
+        let out = engine
+            .render(Some(main.as_path()), None, &json!({}), Mode::Unrestricted)
+            .expect("render failed");
+        assert_eq!(out, "A PART B");
+    }
+
+    #[test]
+    fn test_jinja2_inline_include_ignores_temp_dir_when_unrestricted() {
+        let engine = engine(JINJA2_SANDBOX_TIMEOUT);
+        // A file in the same temp dir where inline templates are written. If the
+        // inline template got a loader rooted there, this would leak in.
+        let marker = tempfile::Builder::new()
+            .prefix("rudder_s3_probe_")
+            .suffix(".j2")
+            .tempfile_in(std::env::temp_dir())
+            .unwrap();
+        fs::write(marker.path(), "LEAKED").unwrap();
+        let name = marker.path().file_name().unwrap().to_str().unwrap();
+
+        let template = format!("{{% include \"{name}\" %}}");
+        let result = engine.render(None, Some(&template), &json!({}), Mode::Unrestricted);
+
+        assert!(
+            result.is_err(),
+            "inline template must have no loader, but the include resolved"
+        );
+    }
 }

--- a/policies/module-types/template/src/engine/jinja2/render.py
+++ b/policies/module-types/template/src/engine/jinja2/render.py
@@ -31,6 +31,7 @@ from optparse import OptionParser
 
 import jinja2
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
 
 try:
     import simplejson as json
@@ -39,7 +40,7 @@ except ImportError:
 
 PY3 = sys.version_info > (3,)
 
-def render(args):
+def render(args, sandboxed, inline):
     if len(args) == 1:
         data = sys.stdin.read()
     else:
@@ -59,16 +60,25 @@ def render(args):
         sys.stderr.write(str(err))
         sys.exit(1)
 
+    # Sandboxed: SandboxedEnvironment blocks Python-internals access (no code
+    # execution). A filesystem loader (for include/import/extends) is used only
+    # for trusted file-based templates, rooted at the template's own directory.
+    # Inline templates have no real directory (theirs is a temp file in the
+    # shared temp dir), so they get no loader.
+    use_loader = not sandboxed and not inline
+    env_class = SandboxedEnvironment if sandboxed else Environment
+    loader = FileSystemLoader(os.path.dirname(template_path)) if use_loader else None
+
     # keep_trailing_newline appeared in jinja 2.7, see http://jinja.pocoo.org/docs/dev/api/
     # we add a case for this as it can be really important in configuration management context
     if [int(x) for x in jinja2.__version__.split(".")[0:2]] >= [2, 7]:
-        env = Environment(
-            loader=FileSystemLoader(os.path.dirname(template_path)),
+        env = env_class(
+            loader=loader,
             keep_trailing_newline=True
         )
     else:
-        env = Environment(
-            loader=FileSystemLoader(os.path.dirname(template_path)),
+        env = env_class(
+            loader=loader,
         )
 
     env.undefined = StrictUndefined
@@ -93,24 +103,43 @@ def render(args):
             env.tests.update(CUSTOM_TESTS)
     sys.path.pop()
 
-    if PY3:
-      output = env.get_template(os.path.basename(template_path)).render(data)
+    if use_loader:
+        template = env.get_template(os.path.basename(template_path))
     else:
-      output = env.get_template(os.path.basename(template_path)).render(data).encode("utf-8")
+        # No loader, so load straight from content.
+        with open(template_path, encoding='utf-8') if PY3 else open(template_path) as f:
+            template = env.from_string(f.read())
+
+    if PY3:
+      output = template.render(data)
+    else:
+      output = template.render(data).encode("utf-8")
 
     sys.stdout.write(output)
 
 def main():
     parser = OptionParser(
-        usage="usage: %prog <template_file> [data_file]",
+        usage="usage: %prog [--sandboxed] [--inline] <template_file> [data_file]",
     )
-    _, args = parser.parse_args()
+    parser.add_option(
+        "--sandboxed",
+        action="store_true",
+        default=False,
+        help="restrict untrusted templates: sandboxed env, no filesystem access",
+    )
+    parser.add_option(
+        "--inline",
+        action="store_true",
+        default=False,
+        help="template is inline (no file loader for include/import/extends)",
+    )
+    options, args = parser.parse_args()
 
     if len(args) not in [1, 2]:
         parser.print_help()
         sys.exit(1)
 
-    render(args)
+    render(args, options.sandboxed, options.inline)
     sys.exit(0)
 
 if __name__ == '__main__':

--- a/policies/module-types/template/src/engine/minijinja.rs
+++ b/policies/module-types/template/src/engine/minijinja.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2021-2025 Normation SAS
 
-use crate::engine::TemplateEngine;
+use crate::engine::{Mode, TemplateEngine};
 use anyhow::{Context, Result, anyhow};
 use minijinja::UndefinedBehavior;
 use rudder_module_type::cli::{FileError, FileRange};
@@ -10,7 +10,31 @@ use std::{fs::read_to_string, path::Path};
 
 mod filters;
 
-pub(crate) struct MiniJinjaEngine;
+/// Fuel budget: caps the operations a single render may perform, to
+/// stop runaway templates (e.g. huge loops) from untrusted content. Deliberately
+/// high so legitimate templates are never affected.
+///
+/// At this value a tight runaway loop is aborted after ~1.3s (release),
+/// but it does not cap memory.
+const SANDBOX_FUEL: u64 = 100_000_000;
+
+/// Prevent accidental DoS in a trusted template, while staying well out of
+/// the way of legitimate heavy templates.
+const UNRESTRICTED_FUEL: u64 = 1_000_000_000;
+
+pub(crate) struct MiniJinjaEngine {
+    sandbox_fuel: u64,
+    unrestricted_fuel: u64,
+}
+
+impl Default for MiniJinjaEngine {
+    fn default() -> Self {
+        Self {
+            sandbox_fuel: SANDBOX_FUEL,
+            unrestricted_fuel: UNRESTRICTED_FUEL,
+        }
+    }
+}
 
 impl MiniJinjaEngine {
     fn error_formatting(e: minijinja::Error, template: &str, template_name: &str) -> anyhow::Error {
@@ -37,6 +61,7 @@ impl TemplateEngine for MiniJinjaEngine {
         template_path: Option<&Path>,
         template_string: Option<&str>,
         data: &Value,
+        mode: Mode,
     ) -> Result<String> {
         // We need to create the Environment even for one template
         let mut env = minijinja::Environment::new();
@@ -48,6 +73,13 @@ impl TemplateEngine for MiniJinjaEngine {
         minijinja_contrib::add_to_environment(&mut env);
         // To get detailed error messages on template compilation
         env.set_debug(true);
+        // Bound compute in both modes; unrestricted gets a much larger budget.
+        let fuel = if mode.is_sandboxed() {
+            self.sandbox_fuel
+        } else {
+            self.unrestricted_fuel
+        };
+        env.set_fuel(Some(fuel));
 
         let (template_name, template) = match (template_path, template_string) {
             (Some(p), _) => {
@@ -70,6 +102,15 @@ impl TemplateEngine for MiniJinjaEngine {
         env.add_filter("quote", filters::quote);
         env.add_filter("regex_escape", filters::regex_escape);
         env.add_filter("regex_replace", filters::regex_replace);
+        // Restrict FS access
+        if !mode.is_sandboxed() {
+            env.add_function("lookup", filters::lookup);
+            // Resolve included templates relative to the source template's dir.
+            // Inline templates have no base dir.
+            if let Some(dir) = template_path.and_then(Path::parent) {
+                env.set_loader(minijinja::path_loader(dir));
+            }
+        }
         let tmpl = env.get_template(&template_name)?;
         tmpl.render(data)
             .map_err(|e| Self::error_formatting(e, &template, &template_name))
@@ -85,13 +126,13 @@ mod tests {
 
     #[test]
     fn test_minijinja_rendering() {
-        let engine = MiniJinjaEngine;
+        let engine = MiniJinjaEngine::default();
 
         let template = "Hello, {{ name }}!";
         let data = json!({ "name": "World" });
 
         let result = engine
-            .render(None, Some(template), &data)
+            .render(None, Some(template), &data, Mode::Sandboxed)
             .expect("Rendering failed");
 
         assert_eq!(result, r#"Hello, World!"#);
@@ -99,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_minijinja_rendering_from_file() {
-        let engine = MiniJinjaEngine;
+        let engine = MiniJinjaEngine::default();
 
         let tmp_dir = tempdir().unwrap();
         let tmp_file = tmp_dir.path().join("template");
@@ -110,7 +151,7 @@ mod tests {
         let data = json!({ "name": "World" });
 
         let result = engine
-            .render(Some(tmp_file.as_path()), None, &data)
+            .render(Some(tmp_file.as_path()), None, &data, Mode::Sandboxed)
             .expect("Rendering failed");
 
         assert_eq!(result, r#"Hello, World!"#);
@@ -118,27 +159,178 @@ mod tests {
 
     #[test]
     fn test_minijinja_rendering_trim_block() {
-        let engine = MiniJinjaEngine;
+        let engine = MiniJinjaEngine::default();
 
         let template = "{% for item in items %}
 Item: {{ item }}
 {% endfor %}";
         let data = json!({ "items": ["A", "B", "C"] });
         let result = engine
-            .render(None, Some(template), &data)
+            .render(None, Some(template), &data, Mode::Sandboxed)
             .expect("Rendering failed");
         assert_eq!(result, "Item: A\nItem: B\nItem: C\n");
     }
 
     #[test]
     fn test_minijinja_empty_line_end() {
-        let engine = MiniJinjaEngine;
+        let engine = MiniJinjaEngine::default();
 
         let template = "test\n";
         let data = json!({ "items": ["A", "B", "C"] });
         let result = engine
-            .render(None, Some(template), &data)
+            .render(None, Some(template), &data, Mode::Sandboxed)
             .expect("Rendering failed");
         assert_eq!(result, "test\n");
+    }
+
+    #[test]
+    fn test_minijinja_lookup_available_when_unrestricted() {
+        let engine = MiniJinjaEngine::default();
+
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("source.txt");
+        fs::write(&source, "secret content").unwrap();
+
+        // Pass the path through data so it is not parsed as a template literal
+        // (a Windows path would contain invalid string escapes).
+        let data = json!({ "p": source });
+        let result = engine
+            .render(
+                None,
+                Some("{{ lookup('file', p) }}"),
+                &data,
+                Mode::Unrestricted,
+            )
+            .expect("Rendering failed");
+
+        assert_eq!(result, "secret content");
+    }
+
+    #[test]
+    fn test_minijinja_lookup_blocked_when_sandboxed() {
+        let engine = MiniJinjaEngine::default();
+
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("source.txt");
+        fs::write(&source, "secret content").unwrap();
+
+        // `lookup` is not registered, so the unknown function fails the render.
+        let data = json!({ "p": source });
+        let result = engine.render(
+            None,
+            Some("{{ lookup('file', p) }}"),
+            &data,
+            Mode::Sandboxed,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_minijinja_include_available_when_unrestricted() {
+        let engine = MiniJinjaEngine::default();
+
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("included.txt"), "MIDDLE").unwrap();
+        let main = dir.path().join("main.txt");
+        fs::write(&main, r#"Start {% include "included.txt" %} End"#).unwrap();
+
+        let result = engine
+            .render(Some(main.as_path()), None, &json!({}), Mode::Unrestricted)
+            .expect("Rendering failed");
+
+        assert_eq!(result, "Start MIDDLE End");
+    }
+
+    #[test]
+    fn test_minijinja_include_blocked_when_sandboxed() {
+        let engine = MiniJinjaEngine::default();
+
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("included.txt"), "MIDDLE").unwrap();
+        let main = dir.path().join("main.txt");
+        fs::write(&main, r#"Start {% include "included.txt" %} End"#).unwrap();
+
+        // No loader in sandboxed mode: the include cannot be resolved.
+        let result = engine.render(Some(main.as_path()), None, &json!({}), Mode::Sandboxed);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_minijinja_filters_available_when_sandboxed() {
+        let engine = MiniJinjaEngine::default();
+
+        // Sandboxing must not disable the regular filters.
+        let template = "{{ 'Hello, Ferris!' | b64encode }}";
+        let result = engine
+            .render(None, Some(template), &json!({}), Mode::Sandboxed)
+            .expect("Rendering failed");
+
+        assert_eq!(result, "SGVsbG8sIEZlcnJpcyE=");
+    }
+
+    #[test]
+    fn test_minijinja_fuel_limits_runaway_when_sandboxed() {
+        // Tiny fuel budget so the loop runs out almost immediately.
+        let engine = MiniJinjaEngine {
+            sandbox_fuel: 100,
+            ..Default::default()
+        };
+
+        let template = "{% for i in range(1000000) %}{{ i }}{% endfor %}";
+        let result = engine.render(None, Some(template), &json!({}), Mode::Sandboxed);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_minijinja_unrestricted_allows_more_fuel_than_sandboxed() {
+        // range(700) costs ~3500 fuel (~5/iteration): above the sandbox budget
+        // but well under the unrestricted one.
+        let engine = MiniJinjaEngine {
+            sandbox_fuel: 1000,
+            unrestricted_fuel: 10_000,
+        };
+        let template = "{% for i in range(700) %}{{ i }}{% endfor %}";
+
+        assert!(
+            engine
+                .render(None, Some(template), &json!({}), Mode::Sandboxed)
+                .is_err()
+        );
+        assert!(
+            engine
+                .render(None, Some(template), &json!({}), Mode::Unrestricted)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_minijinja_fuel_bounds_unrestricted_too() {
+        // Even the unrestricted budget is far exceeded here.
+        let engine = MiniJinjaEngine {
+            sandbox_fuel: 100,
+            unrestricted_fuel: 1000,
+        };
+
+        let template = "{% for i in range(1000000) %}{{ i }}{% endfor %}";
+        let result = engine.render(None, Some(template), &json!({}), Mode::Unrestricted);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_minijinja_loop_controls() {
+        let engine = MiniJinjaEngine::default();
+
+        // `break`/`continue` require the `loop_controls` feature.
+        let template =
+            "{% for i in range(10) %}{% if i == 3 %}{% break %}{% endif %}{{ i }}{% endfor %}";
+        let result = engine
+            .render(None, Some(template), &json!({}), Mode::Sandboxed)
+            .expect("Rendering failed");
+
+        assert_eq!(result, "012");
     }
 }

--- a/policies/module-types/template/src/engine/minijinja/filters.rs
+++ b/policies/module-types/template/src/engine/minijinja/filters.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha512};
 use shlex::try_quote;
-use std::{ffi::OsStr, path::Path};
+use std::{ffi::OsStr, fs::read_to_string, path::Path};
 use urlencoding::decode;
 
 pub fn b64encode(plain: String) -> String {
@@ -119,6 +119,24 @@ pub fn regex_replace(
     Ok(r.replacen(&data, n, re).to_string())
 }
 
+/// `lookup(kind, ...)`. Only `file` is supported: it reads a
+/// file's raw UTF-8 content at render time on the node.
+pub fn lookup(kind: String, path: String) -> Result<String, Error> {
+    match kind.as_str() {
+        "file" => read_to_string(&path).map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidOperation,
+                format!("cannot read file: {path}"),
+            )
+            .with_source(e)
+        }),
+        other => Err(Error::new(
+            ErrorKind::InvalidOperation,
+            format!("unsupported lookup type: '{other}' (only 'file' is supported)"),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,9 +144,7 @@ mod tests {
     use rudder_commons_test::module_type::unix;
     #[cfg(target_family = "unix")]
     use rudder_module_type::{Outcome, PolicyMode};
-    #[cfg(target_family = "unix")]
-    use std::fs::{self, read_to_string};
-    #[cfg(target_family = "unix")]
+    use std::fs;
     use tempfile::tempdir;
 
     #[cfg(target_family = "unix")]
@@ -432,6 +448,74 @@ mod tests {
         );
         let output = read_to_string(&test_path).unwrap();
         assert_eq!(quote, output);
+    }
+
+    #[test]
+    fn test_minijinja_lookup_file() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("f.txt");
+        fs::write(&p, "raw content").unwrap();
+        assert_eq!(
+            lookup("file".to_string(), p.to_string_lossy().to_string()).unwrap(),
+            "raw content"
+        );
+        // Missing file must error (and so fail the render).
+        assert!(
+            lookup(
+                "file".to_string(),
+                dir.path().join("missing").to_string_lossy().to_string()
+            )
+            .is_err()
+        );
+        // Unknown lookup kind must error.
+        assert!(lookup("env".to_string(), "PATH".to_string()).is_err());
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn test_lookup_file_function() {
+        let root_dir = tempdir().unwrap();
+        let test_path = root_dir.path().join("output");
+        let source_path = root_dir.path().join("source");
+        fs::write(&source_path, "raw content").unwrap();
+
+        unix::test(
+            Path::new(BIN),
+            &format!(
+                r#"{{"path": "{}", "engine": "{}", "mode": "unrestricted", "template_path": "", "datastate_path": "", "template_string": "{{{{ lookup('file', '{}') }}}}", "data": {{ }} }}"#,
+                test_path.display(),
+                "minijinja",
+                source_path.display(),
+            ),
+            PolicyMode::Enforce,
+            Ok(Outcome::repaired("".to_string())),
+        );
+        let output = read_to_string(&test_path).unwrap();
+        assert_eq!("raw content", output);
+    }
+
+    /// Default mode: `lookup` is unavailable, so the render must fail.
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn test_lookup_file_blocked_when_sandboxed() {
+        let root_dir = tempdir().unwrap();
+        let test_path = root_dir.path().join("output");
+        let source_path = root_dir.path().join("source");
+        fs::write(&source_path, "raw content").unwrap();
+
+        unix::test(
+            Path::new(BIN),
+            &format!(
+                r#"{{"path": "{}", "engine": "{}", "template_path": "", "datastate_path": "", "template_string": "{{{{ lookup('file', '{}') }}}}", "data": {{ }} }}"#,
+                test_path.display(),
+                "minijinja",
+                source_path.display(),
+            ),
+            PolicyMode::Enforce,
+            Err(anyhow::anyhow!("lookup is disabled in sandboxed mode")),
+        );
+        // Output file must not have been written with the file's content.
+        assert!(!test_path.exists());
     }
 
     #[test]

--- a/policies/module-types/template/src/engine/mustache.rs
+++ b/policies/module-types/template/src/engine/mustache.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2021-2025 Normation SAS
 
-use crate::engine::TemplateEngine;
+use crate::engine::{Mode, TemplateEngine};
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::fs;
@@ -15,6 +15,11 @@ impl TemplateEngine for MustacheEngine {
         template_path: Option<&Path>,
         template_string: Option<&str>,
         data: &Value,
+        // FIXME: mode is not enforced. Mustache is logic-less, but `{{> name}}`
+        // partials read `<name>.mustache` from disk (relative to the cwd here,
+        // since we use `compile_str`), violating the sandboxed contract.
+        // Sandboxed mode should reject templates containing partials.
+        _mode: Mode,
     ) -> Result<String> {
         let template = match (template_path, template_string) {
             // The lib has a `compile_path` method, but it requires a mustache file extension.
@@ -46,7 +51,7 @@ mod tests {
         let data = json!({ "name": "World" });
 
         let result = engine
-            .render(None, Some(template), &data)
+            .render(None, Some(template), &data, Mode::Sandboxed)
             .expect("Rendering failed");
 
         assert_eq!(result, r#"Hello, World!"#);
@@ -65,7 +70,7 @@ mod tests {
         let data = json!({ "name": "World" });
 
         let result = engine
-            .render(Some(tmp_file.as_path()), None, &data)
+            .render(Some(tmp_file.as_path()), None, &data, Mode::Sandboxed)
             .expect("Rendering failed");
 
         assert_eq!(result, r#"Hello, World!"#);
@@ -78,7 +83,7 @@ mod tests {
         let template = "{{%-top-}}";
         let data = json!({ "items": ["A", "B", "C"] });
         let result = engine
-            .render(None, Some(template), &data)
+            .render(None, Some(template), &data, Mode::Sandboxed)
             .expect("Rendering failed");
         assert_eq!(
             result,
@@ -93,7 +98,7 @@ mod tests {
         let template = "test\n";
         let data = json!({ "items": ["A", "B", "C"] });
         let result = engine
-            .render(None, Some(template), &data)
+            .render(None, Some(template), &data, Mode::Sandboxed)
             .expect("Rendering failed");
         assert_eq!(result, "test\n");
     }

--- a/policies/module-types/template/src/lib.rs
+++ b/policies/module-types/template/src/lib.rs
@@ -4,7 +4,7 @@
 mod cli;
 mod engine;
 use crate::cli::Cli;
-use engine::Engine;
+use engine::{Engine, Mode};
 use rudder_module_type::ProtocolResult;
 use rudder_module_type::diff::diff;
 
@@ -63,6 +63,9 @@ pub struct TemplateParameters {
     /// Controls output of diffs in the report
     #[serde(default = "default_as_true")]
     show_content: bool,
+    /// Trust level for the template content.
+    #[serde(default)]
+    mode: Mode,
     #[serde(default)]
     report_file: Option<PathBuf>,
 }
@@ -187,6 +190,7 @@ impl Template {
             p.template_path.as_deref(),
             p.template_string.as_deref(),
             template_data,
+            p.mode,
         )?;
 
         let already_present = output_file.exists();

--- a/policies/module-types/template/tests/mustache.rs
+++ b/policies/module-types/template/tests/mustache.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2021 Normation SAS
 
+// The whole suite drives cf-agent through `unix::test`, which only exists on Unix.
+#![cfg(target_family = "unix")]
 use std::{env, fs, fs::read_to_string, path::Path};
 
 use anyhow::anyhow;

--- a/policies/rudder-commons-test/src/module_type.rs
+++ b/policies/rudder-commons-test/src/module_type.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2021 Normation SAS
 
+#[cfg(target_family = "unix")]
 pub mod unix {
-    use std::{fs, path::Path};
+    use std::{fs, os::unix::fs::PermissionsExt, path::Path};
 
     use assert_cmd::{Command, prelude::*};
     use predicates::prelude::*;
@@ -32,7 +33,10 @@ pub mod unix {
         fs::copy(cfe_dir.join("cf-promises"), bin_dir.join("cf-promises")).unwrap();
         // write test policy into promises.cf
         fs::create_dir(work_dir.path().join("inputs")).unwrap();
-        fs::write(policy_path, policy.as_bytes()).unwrap();
+        fs::write(&policy_path, policy.as_bytes()).unwrap();
+        // cf-agent refuses to load a policy file that is writable by group or
+        // others, so restrict it regardless of the environment's umask.
+        fs::set_permissions(&policy_path, fs::Permissions::from_mode(0o600)).unwrap();
 
         let action_policy = match policy_mode {
             PolicyMode::Enforce => "fix",

--- a/policies/rudderc/docs/src/modules/template.md
+++ b/policies/rudderc/docs/src/modules/template.md
@@ -2,7 +2,7 @@
 
 The module supports the following template engines:
 
-* MiniJinja (which is a subset of Jinja2)
+* MiniJinja (which is based on Jinja2)
 * Mustache
 * Jinja2 (available only on Linux)
 
@@ -19,6 +19,56 @@ The module takes the following arguments:
 | `engine` | Template engine | `mustache`, `minijinja`, `jinja2` (default: `minijinja`) |
 | `data` | JSON data used for templating | A valid JSON |
 | `show_content` | Controls output of diffs in the report | `true`/`false` (default: `true`) |
+| `mode` | Trust level for the template content | `sandboxed`, `unrestricted` (default: `sandboxed`) |
+
+## Security
+
+### Engine sandboxing
+
+The `mode` argument sets the trust level for the template content:
+
+* `sandboxed` (the default) restricts what a template can do — no reading of
+  arbitrary files, no cross-file includes, and bounded compute — to limit the
+  impact of rendering untrusted content.
+* `unrestricted` lifts those restrictions for **trusted** templates that need
+  them (reading files, cross-file includes, or Jinja2 dynamic features).
+
+Set `mode: unrestricted` only for templates you trust. Note that sandboxing
+limits what a template can *do*, not what it can *see*.
+
+### Template data and the agent state
+
+<div class="warning">
+<b>⚠️ When `data` is empty, the `file_from_template_*` methods pass the **entire
+agent datastate** to the template.</b>
+</div>
+
+By default these methods render with no explicit `data`, in which case the whole
+agent internal state — every variable and class of the current run, across **all**
+directives, including secrets stored in variables and node properties — is handed
+to the template as `data`. A `sandboxed` template cannot touch the filesystem, but
+it can still read that entire state and write it out.
+
+So `mode: sandboxed` alone does **not** make it safe to render a fully untrusted
+template. To render untrusted content safely, also pass an explicit, minimal
+`data` object so the template only ever sees what you intend — never the implicit
+datastate.
+
+### Reporting and sensitive content
+
+<div class="warning">
+
+<b>⚠️ With `show_content: true` (the default), the rendered file
+content is included in the agent report.</b>
+</div>
+
+The diff (and, for a new file, the full content) is sent to the server and stored
+as compliance data. If the template renders secrets — values from
+`data`, or a file read with `lookup('file', …)` in
+`unrestricted` mode — those secrets end up in the reports.
+
+Set `show_content: false` when rendering files that contain sensitive
+data (passwords, private keys, tokens, …).
 
 ## CLI
 
@@ -34,13 +84,14 @@ Options:
   -d, --data <DATA>          JSON data file
   -o, --out <OUT>            Output file
   -a, --audit                Audit mode
+      --mode <MODE>          Trust level for the template content [default: sandboxed] [possible values: sandboxed, unrestricted]
   -h, --help                 Print help
   -V, --version              Print version
 ```
 
 ## Minijinja 
 
-MiniJinja is a subset of the Jinja2 templating language, implemented in pure Rust.
+MiniJinja is based on the Jinja2 templating language.
 For a complete reference on MiniJinja syntax, see the [Jinja2 documentation](http://jinja.pocoo.org/docs/dev/templates/)
 and the [MiniJinja compatibility](https://github.com/mitsuhiko/minijinja/blob/main/COMPATIBILITY.md).
 
@@ -94,6 +145,8 @@ You can also modify what is displayed by using filters.
 Will display the variable in uppercase.
 
 #### Iteration
+
+Loops support `{% break %}` and `{% continue %}` to exit early or skip an item.
 
 To iterate over a list, for example defined with:
 
@@ -179,6 +232,13 @@ prop1 -> value1
 prop2 -> value2
 ```
 
+##### Key order
+
+When iterating a dict (`.items()`, `.keys()`, `.values()`) or serializing it
+(`tojson`, `{{%-top-}}`), keys keep the order they have in the input data — they
+are **not** sorted alphabetically. As a result, changing the order of keys in the
+source data changes the rendered output (and so triggers a file update).
+
 #### Filters
 
 | Name | Description | Required Args | Optional Args | Example |
@@ -245,6 +305,41 @@ prop2 -> value2
 | `regex_escape` | Escape regex chars. | None | None | `{{ re\|regex_escape }}` |
 | `regex_replace` | Replace a string via regex. | None | `count` | `{{ re\|regex_replace }}` |
 
+#### Reading files
+
+**Reading files is only available with `mode: unrestricted`.**
+
+The `lookup('file', path)` function reads a file's raw UTF-8
+content **at render time, on the node**:
+
+```
+{{ lookup('file', "/etc/issue") }}
+```
+
+A missing file, or one that is not valid UTF-8, makes the rendering fail.
+`lookup` currently only supports the `file` kind.
+
+Use absolute paths, and only use trusted template contents.
+
+#### Including other template files
+
+**Including files is only available with `mode: unrestricted`.**
+
+`{% include %}`, `{% import %}` and `{% extends %}`
+load other templates relative to the rendered template file's directory.
+
+```
+{% include "header.j2" %}
+{% import "macros.j2" as macros %}
+```
+
+Paths are resolved relative to the rendered template, so a `header.j2` sitting
+next to your `template_path` is included as `"header.j2"`.
+
+This requires `template_path` (inline templates have no base directory).
+
+#### Additional methods for Python compatibility
+
 The following methods on basic types are provided:
 
 - dict.get
@@ -275,20 +370,20 @@ The following methods on basic types are provided:
 - str.strip
 - str.title
 
+### Sandboxing
+
+With `mode: sandboxed` (the default):
+
+* the `lookup('file', …)` function (which reads arbitrary files) is not
+  registered, and
+* no template loader is configured, so `include`/`import`/`extends` cannot read
+  files.
+
+A fuel limit caps the total number of operations a render may perform in **both**
+modes (higher when `unrestricted`), so a runaway template — even an
+accidental infinite loop in a trusted one — fails instead of hanging.
+
 ## Jinja2 
-
-<div class="warning">
-<b>⚠️ Important: The Jinja2 engine is not sandboxed in this module.</b>
-
-It executes within the full Python runtime context of the process, without
-Jinja2’s sandboxed environment enabled. This means templates are not restricted
-from accessing Python objects exposed to the rendering context and may,
-depending on the environment, interact with underlying Python internals or
-imported modules.
-
-Jinja2 is provided on Linux systems, strictly for backward compatibility and
-<b>trusted-template use cases only</b>.
-</div>
 
 Jinja2 behaves for the most part the same way as MiniJinja. For a complete
 reference of features, see the official [Jinja2 documentation](http://jinja.pocoo.org/docs/dev/templates/).
@@ -311,6 +406,24 @@ TESTS = {'odd': odd}
 ```
 
 These filters and tests will be usable in your jinja2 templates automatically.
+
+### Sandboxing
+
+<div class="warning">
+<b>⚠️ Important: `mode: unrestricted` disables all protections on the Jinja2 engine.</b>
+</div>
+
+With `mode: unrestricted`, Jinja2 executes within the full Python runtime
+context of the process, without Jinja2’s sandboxed environment enabled.
+
+Only set `mode: unrestricted` for <b>trusted templates</b>. With the
+default `mode: sandboxed`, Jinja2 uses its `SandboxedEnvironment`
+(which restricts access to Python internals), has no filesystem loader (so
+`include`/`import`/`extends` cannot read files),
+and each render is bounded by a timeout (3s sandboxed, longer when unrestricted).
+
+<b>The Jinja2 sandbox is best-effort, not a hard security boundary.</b>
+For untrusted templates, prefer the <b>MiniJinja</b> engine.
 
 ## Mustache
 
@@ -487,3 +600,9 @@ Or rendered as a multi-line JSON representation
 ```
 {{%-top-}}
 ```
+
+### Sandboxing
+
+Mustache does not currently enforce `mode`. It is logic-less, but `{{> partial}}`
+partials are always evaluated and read files from disk, so **do not** rely on
+sandboxing for untrusted Mustache templates — use MiniJinja instead.


### PR DESCRIPTION
https://issues.rudder.io/issues/29187

* A a trust mode parameter, with two values for now.
* Implement the sanboxed mode
  * In MiniJinja
    * Add the ability to load templates from the template's dir (or subfolders)
    * Restrict the FS access (include+lookup) in sandboxed mode
    * Add compute limitations on both modes to prevent DoS
  * In Jinja2
    * Use built-in sandboxing mode
    * Add a timeout on the command itself
    * Prevent include in inline mode
  * In Mustache
     * Do nothing for now. TODO to handle partials which are currently enabled.

* Also replace some panics with proper errors.

This will lead to incompatibilities in Jinja2/Mustache with the new default value. This will need to be documented in release notes.