### PR TITLE
Fixes #29224: Add tests for OTP

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/Totp.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/Totp.scala
@@ -35,7 +35,13 @@
  */
 package com.normation.rudder.users
 
+import com.normation.errors.*
+import com.normation.utils.DateFormaterService
+import enumeratum.*
+import enumeratum.EnumEntry.Lowercase
 import java.time.Instant
+import zio.*
+import zio.json.enumeratum.EnumCodec
 
 opaque type UserId = String
 object UserId {
@@ -67,3 +73,60 @@ case class Totp(
     secret:  TotpSecret,
     created: Instant
 )
+
+/**
+ * Enforcement level for globally enforced TOTP.
+ * Derived globally from the configuration
+ */
+sealed trait TotpEnforcementLevel
+object TotpEnforcementLevel {
+  case object Enforced extends TotpEnforcementLevel
+  case object Disabled extends TotpEnforcementLevel
+  // case object Optional extends TotpEnforcementLevel // not used for now that we only have enforced configuration
+}
+
+/**
+ * Per-user enrollment state.
+ * This is the one exposed where we need to know if user OTP is defined or not yet
+ */
+sealed trait TotpUserStatus extends EnumEntry with Lowercase
+object TotpUserStatus       extends Enum[TotpUserStatus] with EnumCodec[TotpUserStatus] {
+  case object EnrollmentNeeded    extends TotpUserStatus
+  // derived from global enforcement level
+  case object EnrollmentNotNeeded extends TotpUserStatus
+  case object Enrolled            extends TotpUserStatus
+
+  extension (self: TotpUserStatus) {
+    def isEnabled: Boolean = self match {
+      case Enrolled                               => true
+      case EnrollmentNeeded | EnrollmentNotNeeded => false
+    }
+  }
+
+  // In case of not known enrollment, we can have "not enrolled" if enrollment is optional
+  def default(enforcement: TotpEnforcementLevel): TotpUserStatus = enforcement match {
+    case TotpEnforcementLevel.Enforced => EnrollmentNeeded
+    case TotpEnforcementLevel.Disabled => EnrollmentNotNeeded
+  }
+
+  override def values: IndexedSeq[TotpUserStatus] = findValues
+}
+
+/**
+ * Logic:
+ *  - if user does not exist, reject
+ *  - if user already has one, reject (we only support 1 OTP, to simplify management page, but WRT storage it could be extended to more)
+ */
+class UserTotpValidator(userRepository: UserRepository, totpRepository: TotpRepository) {
+  def validateUserCanCreateTotp(userId: UserId): IOResult[Unit] = {
+    for {
+      _ <- userRepository.get(userId.value).notOptional(s"User '${userId.value}' is not known, cannot create TOTP")
+      _ <- totpRepository.getByUserId(userId).reject {
+             case Some(value) =>
+               Inconsistency(
+                 s"User '${userId.value}' already has a TOTP (created on ${DateFormaterService.getDisplayDate(value.created)}), reset it first to create a new one"
+               )
+           }
+    } yield ()
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/TotpRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/TotpRepository.scala
@@ -41,6 +41,8 @@ import doobie.*
 import doobie.implicits.*
 import doobie.postgres.implicits.*
 import doobie.util.*
+import zio.Ref
+import zio.UIO
 import zio.interop.catz.*
 
 trait TotpRepository {
@@ -95,4 +97,23 @@ class JdbcTotpRepository(doobie: Doobie) extends TotpRepository {
       getAllByUserSQL().to[Set].map(_.map(UserId(_))).transact(_)
     )
   }
+}
+
+class InMemoryTotpRepository(ref: Ref[Map[UserId, Totp]]) extends TotpRepository {
+  def getByUserId(userId: UserId): UIO[Option[Totp]] =
+    ref.get.map(_.get(userId))
+
+  def create(userId: UserId, totp: Totp): UIO[Unit] =
+    ref.update(_.updated(userId, totp))
+
+  def delete(userId: UserId): UIO[Unit] =
+    ref.update(_ - userId)
+
+  def getEnabledUsers(): UIO[Set[UserId]] =
+    ref.get.map(_.keySet)
+}
+
+object InMemoryTotpRepository {
+  def make(): UIO[InMemoryTotpRepository] =
+    Ref.make(Map.empty).map(InMemoryTotpRepository(_))
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -383,7 +383,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
       userIds:         List[String],
       trace:           EventTrace,
       isCaseSensitive: Boolean
-  ): IOResult[Set[String]] = {
+  ): UIO[Set[String]] = {
     /*
      * We need to modify only user:
      * - with status deleted and in the list of given users
@@ -414,7 +414,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
     }
   }
 
-  override def addUser(origin: String, userId: String, trace: EventTrace, isCaseSensitive: Boolean): IOResult[Boolean] = {
+  override def addUser(origin: String, userId: String, trace: EventTrace, isCaseSensitive: Boolean): UIO[Boolean] = {
     userBase.get
       .flatMap(m => {
         val current = m.collect { case (k, u) if u.managedBy == origin && u.status != UserStatus.Deleted => k }.toList

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/TotpRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/TotpRepositoryTest.scala
@@ -1,0 +1,193 @@
+/*
+ * *************************************************************************************
+ * Copyright 2026 Normation SAS
+ * *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * *************************************************************************************
+ */
+
+package com.normation.rudder.users
+
+import TotpRepositoryTest.given
+import com.normation.errors.IOResult
+import com.normation.rudder.TestActor
+import com.normation.rudder.db.DBCommon
+import com.normation.rudder.db.Doobie
+import com.normation.zio.*
+import doobie.*
+import doobie.specs2.analysisspec.IOChecker
+import java.time.Instant
+import java.time.ZoneOffset
+import net.liftweb.common.Loggable
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+// Shared trait with test logic — runs in both InMemory and Jdbc modes
+trait TotpRepositoryTest extends Specification with Loggable {
+  def doobie: Doobie
+  def doJdbcTest = false
+
+  sequential
+
+  def repo: TotpRepository
+
+  val secretAlice = TotpSecret("alice-totp-secret")
+  val secretBob   = TotpSecret("bob-totp-secret")
+  val totpAlice   = Totp(secretAlice, Instant.parse("2024-01-01T00:00:00Z"))
+  val totpBob     = Totp(secretBob, Instant.parse("2024-02-01T00:00:00Z"))
+
+  "create" >> {
+    "store a new TOTP for a user" in {
+      repo.create("alice", totpAlice).runNow
+      repo.getByUserId("alice").runNow must beSome(totpAlice)
+    }
+
+    "overwrite an existing TOTP for the same user (upsert semantics)" in {
+      val newSecret = TotpSecret("alice-new-secret")
+      val newTotp   = Totp(newSecret, Instant.parse("2024-03-01T00:00:00Z"))
+      repo.create("alice", newTotp).runNow
+      repo.getByUserId("alice").runNow must beSome(newTotp)
+    }
+  }
+
+  "getByUserId" >> {
+    "return None for a user without TOTP" in {
+      repo.getByUserId("unknown").runNow must beNone
+    }
+
+    "return Some(Totp) for an enrolled user" in {
+      // Ensure alice is enrolled for this test
+      repo.create("alice", totpAlice).runNow
+      repo.getByUserId("alice").runNow must beSome(totpAlice)
+    }
+  }
+
+  "delete" >> {
+    "remove a user's TOTP" in {
+      repo.create("bob", totpBob).runNow
+      repo.delete("bob").runNow
+      repo.getByUserId("bob").runNow must beNone
+    }
+
+    "succeed silently when deleting a non-existent TOTP" in {
+      repo.delete("nonexistent").runNow // should not throw
+      repo.getByUserId("nonexistent").runNow must beNone
+    }
+  }
+
+  "getEnabledUsers" >> {
+    "return all user IDs that have a TOTP" in {
+      repo.create("alice", totpAlice).runNow
+      repo.create("bob", totpBob).runNow
+      repo.getEnabledUsers().runNow must containTheSameElementsAs(List("alice", "bob"))
+    }
+
+    "return empty set when no users have TOTP" in {
+      repo.delete("alice").runNow
+      repo.delete("bob").runNow
+      repo.getEnabledUsers().runNow must beEmpty
+    }
+  }
+}
+
+// This one uses postgres and runs only with -Dtest.postgres="true"
+@RunWith(classOf[JUnitRunner])
+class JdbcTotpRepositoryTest extends TotpRepositoryTest with IOChecker with DBCommon {
+  sequential
+
+  def transactor: Transactor[cats.effect.IO] = doobie.xaio
+
+  override def doJdbcTest = doDatabaseConnection
+
+  // format: off
+  org.slf4j.LoggerFactory.getLogger("sql").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+  org.slf4j.LoggerFactory.getLogger("application.user").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+  // format: on
+
+  override def afterAll(): Unit = {
+    cleanDb()
+  }
+
+  if (!doJdbcTest) skipAll
+
+  private val TEST_ORIGIN = "test-totp"
+
+  private lazy val userRepo = JdbcUserRepository(doobie)
+  lazy val repo: TotpRepository = new JdbcTotpRepository(doobie) {
+    // need to init users repo too
+    override def create(userId: UserId, totp: Totp): IOResult[Unit] = {
+      userRepo.addUser(TEST_ORIGIN, userId.value, EventTrace(TestActor.get, totp.created.atOffset(ZoneOffset.UTC))) *>
+      super.create(userId, totp)
+    }
+  }
+
+  check(JdbcTotpRepository.getByUserIdSQL("alice"))
+  check(JdbcTotpRepository.upsertQuerySQL("alice", Totp(TotpSecret("secret"), Instant.now())))
+  check(JdbcTotpRepository.deleteQuerySQL("alice"))
+  check(JdbcTotpRepository.getAllByUserSQL())
+
+  "repository interface" >> {
+    "getByUserId returns Some(Totp) after create" in {
+      val secret = TotpSecret("test-secret")
+      val totp   = Totp(secret, Instant.parse("2024-04-01T12:00:00Z"))
+      repo.create("alice", totp).runNow
+      repo.getByUserId("alice").runNow must beSome(totp)
+    }
+
+    "getByUserId returns None before create" in {
+      repo.getByUserId("nonexistent").runNow must beNone
+    }
+
+    "delete removes the TOTP" in {
+      val secret = TotpSecret("test-secret")
+      val totp   = Totp(secret, Instant.parse("2024-05-01T00:00:00Z"))
+      repo.create("bob", totp).runNow
+      repo.delete("bob").runNow
+      repo.getByUserId("bob").runNow must beNone
+    }
+
+    "getEnabledUsers returns all users with TOTP" in {
+      val totp1 = Totp(TotpSecret("user1-secret"), Instant.parse("2024-06-01T00:00:00Z"))
+      val totp2 = Totp(TotpSecret("user2-secret"), Instant.parse("2024-07-01T00:00:00Z"))
+      repo.create("charlie", totp1).runNow
+      repo.create("dave", totp2).runNow
+      // bob has been deleted :(
+      repo.getEnabledUsers().runNow must containTheSameElementsAs(List("alice", "charlie", "dave"))
+    }
+  }
+}
+
+private object TotpRepositoryTest {
+  // helper to avoid readability hurt
+  given Conversion[String, UserId] = UserId(_)
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/OtpApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/OtpApi.scala
@@ -70,9 +70,8 @@ class OtpApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      val userId         = UserId(authzToken.user.name)
-      val needGeneration = otpGeneratorService.needGeneration(userId)
-      val status         = needGeneration.map(n => TotpStatus(n))
+      val userId = UserId(authzToken.user.name)
+      val status = otpGeneratorService.getUserStatus(userId)
       status.toLiftResponseOne(params, schema, None)
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.users.JsonUser
 import com.normation.rudder.users.JsonUserFormData
 import com.normation.rudder.users.Serialisation.*
 import com.normation.rudder.users.TotpService
+import com.normation.rudder.users.TotpUserStatus
 import com.normation.rudder.users.UpdateUserInfo
 import com.normation.rudder.users.UserId
 import com.normation.rudder.users.UserInfo
@@ -256,13 +257,13 @@ class UserManagementApiImpl(
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
 
       (for {
-        users       <- userRepo.getAll()
-        allRoles    <- RudderRoles.getAllRoles
-        file         = userService.authConfig
-        roles        = allRoles.values.toSet
-        otpUsers    <- totpService.getEnabledUsers()
-        otpEnforced <- totpService.getGlobalStatus()
-        jsonUsers   <-
+        users        <- userRepo.getAll()
+        allRoles     <- RudderRoles.getAllRoles
+        file          = userService.authConfig
+        roles         = allRoles.values.toSet
+        otpStatusMap <- totpService.getAllUserStatus()
+        otpEnforced  <- totpService.getGlobalStatus()
+        jsonUsers    <-
           ZIO.foreach(users)(u => {
             implicit val currentRoles: Set[Role] = roles
             // we take last session to get last known roles and authz of the user
@@ -289,7 +290,7 @@ class UserManagementApiImpl(
 
               // depending on provider property configuration, we should merge or override roles
               val mainProviderRoleExtension = getProviderRoleExtensions().get(u.managedBy)
-              val otpEnabled                = otpUsers.contains(UserId(u.id))
+              val otpEnabled                = otpStatusMap.get(UserId(u.id)).exists(_ == TotpUserStatus.Enrolled)
 
               val userWithoutPermissions = transformUser(
                 u.id,

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/TotpService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/TotpService.scala
@@ -35,6 +35,7 @@
  */
 package com.normation.rudder.users
 
+import cats.syntax.functor.*
 import com.bastiaanjansen.otp.*
 import com.normation.errors.*
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
@@ -52,12 +53,6 @@ import zio.syntax.*
  */
 trait TotpService {
 
-  /**
-   * Check if the user needs to enroll (generate) a new OTP secret.
-   * Returns true if the user does not yet have an OTP configured.
-   */
-  def needGeneration(userId: UserId): IOResult[Boolean]
-
   def generateUserSecret(userId: UserId): IOResult[TotpSecretData]
 
   /**
@@ -74,24 +69,22 @@ trait TotpService {
   def reset(userId: UserId): IOResult[Unit]
 
   /**
-   * Check if OTP is globally enforced for all users.
+   * Check OTP is globally enforced for all users.
    */
   def getGlobalStatus(): IOResult[Boolean]
 
   /**
-   * Get the set of users that have an OTP configured.
+   * Get per-user enrollment status
    */
-  def getEnabledUsers(): IOResult[Set[UserId]]
+  def getAllUserStatus(): IOResult[Map[UserId, TotpUserStatus]]
+
+  /**
+   * Get user enrollment status, if user does not exist, they need to enroll
+   */
+  def getUserStatus(userId: UserId): IOResult[TotpUserStatus]
 
   def verify(userId: UserId, code: String): IOResult[Unit]
 }
-
-/**
- * Status of OTP enrollment for a user
- */
-case class TotpStatus(
-    needEnrollment: Boolean
-) derives JsonEncoder
 
 private given JsonEncoder[TotpSecret] = JsonEncoder[String].contramap(_.exposeSecret())
 private given JsonEncoder[URI]        = JsonEncoder[String].contramap(_.toString)
@@ -110,25 +103,6 @@ case class TotpSecretContainer(
 
 trait TotpSecretGenerator {
   def generate: IOResult[TotpSecret]
-}
-
-/**
- * Logic:
- *  - if user does not exist, reject
- *  - if user already has one, reject (we only support 1 OTP, to simplify management page, but WRT storage it could be extended to more)
- */
-class UserTotpValidator(userRepository: UserRepository, totpRepository: TotpRepository) {
-  def validateUserCanCreateTotp(userId: UserId): IOResult[Unit] = {
-    for {
-      _ <- userRepository.get(userId.value).notOptional(s"User '${userId.value}' is not known, cannot create TOTP")
-      _ <- totpRepository.getByUserId(userId).reject {
-             case Some(value) =>
-               Inconsistency(
-                 s"User '${userId.value}' already has a TOTP (created on ${DateFormaterService.getDisplayDate(value.created)}), reset it first to create a new one"
-               )
-           }
-    } yield ()
-  }
 }
 
 sealed private trait TotpVerificator {
@@ -151,9 +125,7 @@ class InMemoryVerificationTotpService(
     totpRepository: TotpRepository,
     verificator:    TotpVerificator
 ) extends TotpService {
-  override def needGeneration(userId: UserId): IOResult[Boolean] = {
-    totpRepository.getByUserId(userId).map(_.isEmpty)
-  }
+  private val globalLevel = if (enabledOtp) TotpEnforcementLevel.Enforced else TotpEnforcementLevel.Disabled
 
   override def generateUserSecret(userId: UserId): IOResult[TotpSecretData] = {
     for {
@@ -207,10 +179,17 @@ class InMemoryVerificationTotpService(
     enabledOtp.succeed
   }
 
-  override def getEnabledUsers(): IOResult[Set[UserId]] = {
-    totpRepository.getEnabledUsers()
+  override def getAllUserStatus(): IOResult[Map[UserId, TotpUserStatus]] = {
+    totpRepository
+      .getEnabledUsers()
+      .map(_.map(u => u -> TotpUserStatus.Enrolled).toMap)
   }
 
+  override def getUserStatus(userId: UserId): IOResult[TotpUserStatus] = {
+    totpRepository
+      .getByUserId(userId)
+      .map(_.as(TotpUserStatus.Enrolled).getOrElse(TotpUserStatus.default(globalLevel)))
+  }
 }
 
 private def totpUri(userId: String, secret: TotpSecret): IOResult[URI] = {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -1052,10 +1052,10 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     }
   }
   val otpService = new TotpService {
-    override def getEnabledUsers(): IOResult[Set[UserId]] = Set.empty.succeed
-    override def getGlobalStatus(): IOResult[Boolean]     = false.succeed
+    override def getAllUserStatus(): IOResult[Map[UserId, TotpUserStatus]] = Map.empty.succeed
+    override def getUserStatus(userId: UserId): IOResult[TotpUserStatus] = TotpUserStatus.EnrollmentNotNeeded.succeed
+    override def getGlobalStatus(): IOResult[Boolean] = false.succeed
 
-    override def needGeneration(userId:     UserId): IOResult[Boolean] = ???
     override def generateUserSecret(userId: UserId): IOResult[TotpSecretData] = ???
     override def verifyGenerated(userId:    UserId, code: String): IOResult[Totp] = ???
     override def reset(userId:              UserId): IOResult[Unit] = ???

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserTotpValidatorTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserTotpValidatorTest.scala
@@ -1,0 +1,124 @@
+/*
+ * *************************************************************************************
+ * Copyright 2026 Normation SAS
+ * *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * *************************************************************************************
+ */
+package com.normation.rudder.rest.users
+
+import com.normation.errors.*
+import com.normation.rudder.TestActor
+import com.normation.rudder.users.*
+import java.time.Instant
+import java.time.OffsetDateTime
+import org.junit.runner.RunWith
+import zio.*
+import zio.test.*
+import zio.test.junit.ZTestJUnitRunner
+
+/**
+ * Tests for UserTotpValidator which has main logic for user TOTP unit of work
+ */
+@RunWith(classOf[ZTestJUnitRunner])
+class UserTotpValidatorTest extends ZIOSpecDefault {
+  import UserTotpValidatorTest.given
+
+  val spec: Spec[Any, Nothing] = suite("UserTotpValidator")(
+    test("should succeed when user exists and has no TOTP") {
+      withCtx { validator =>
+        for {
+          _      <- addUser("alice")
+          result <- validator.validateUserCanCreateTotp("alice").either
+        } yield {
+          assertTrue(result.isRight)
+        }
+      }
+    },
+    test("should fail with Inconsistency when user does not exist") {
+      withCtx { validator =>
+        for {
+          result <- validator.validateUserCanCreateTotp("nonexistent").either
+        } yield {
+          assertTrue(
+            result.isLeft,
+            result match {
+              case Left(msg: Inconsistency) => msg.fullMsg.contains(s"User 'nonexistent' is not known")
+              case _                        => false
+            }
+          )
+        }
+      }
+    },
+    test("should fail when user already has a TOTP") {
+      withCtx { validator =>
+        for {
+          _      <- addUser("bob")
+          _      <- addTotp("bob", "secret123")
+          result <- validator.validateUserCanCreateTotp("bob").either
+        } yield {
+          assertTrue(
+            result.isLeft,
+            result match {
+              case Left(msg: Inconsistency) => msg.fullMsg.contains(s"User 'bob' already has a TOTP")
+              case _                        => false
+            }
+          )
+        }
+      }
+    }
+  )
+
+  /***  BUILDING CONTEXT FOR TESTS: HELPERS TO HELP READABILITY OF GIVEN PART OF TESTS ***/
+
+  private type Ctx[A] = UserTotpValidator => InMemoryUserRepository ?=> InMemoryTotpRepository ?=> UIO[A]
+
+  private def withCtx[A](block: Ctx[A]): UIO[A] = {
+    (InMemoryUserRepository.make() <*> InMemoryTotpRepository.make()).flatMap((u, t) =>
+      block(UserTotpValidator(u, t))(using u)(using t)
+    )
+  }
+
+  private def addUser(str: String)(using repo: InMemoryUserRepository):                  UIO[Unit] = {
+    val origin    = "test-totp"
+    val traceDate = OffsetDateTime.now()
+    val trace     = EventTrace(TestActor.get, traceDate)
+    repo.addUser(origin, str, trace).unit
+  }
+  private def addTotp(user: String, secret: String)(using repo: InMemoryTotpRepository): UIO[Unit] = {
+    repo.create(UserId(user), Totp(TotpSecret(secret), Instant.now()))
+  }
+}
+
+private object UserTotpValidatorTest {
+  // helper to avoid readability hurt
+  given Conversion[String, UserId] = UserId(_)
+}

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp.elm
@@ -1,21 +1,17 @@
 module Otp exposing (..)
 
 import Browser
-import Html exposing (..)
-import Html.Attributes exposing (..)
 import Http.Detailed as Detailed
 import Json.Decode exposing (decodeString, string)
 import List
-import Maybe.Extra
 import Otp.ApiCalls exposing (..)
 import Otp.DataTypes exposing (..)
 import Otp.Init exposing (..)
-import Otp.JsonDecoder exposing (..)
 import Otp.View exposing (..)
 import Result
 import String
 import Url exposing (Url)
-import Url.Parser as Parser exposing ((</>), (<?>), Parser, parse, query, top)
+import Url.Parser as Parser exposing ((</>), (<?>), Parser)
 import Url.Parser.Query as Query
 
 
@@ -58,7 +54,7 @@ update msg model =
         OtpStatusResponse result ->
             case result of
                 Ok ( _, status ) ->
-                    ( { model | needEnrollment = Just status, isLoading = False }, Cmd.none )
+                    ( { model | mode = enrollmentMode status, isLoading = False }, Cmd.none )
 
                 Err err ->
                     processApiError "Failed to fetch OTP status" err model
@@ -66,7 +62,8 @@ update msg model =
         GenerateResponse result ->
             case result of
                 Ok ( _, resp ) ->
-                    ( { model | isLoading = False, needEnrollment = Just True, generatedSecret = Just resp.secret }, Cmd.none )
+                    -- even if we enter a generation, we should be able to skip, if NotEnrolled we shouldn't
+                    ( { model | isLoading = False, mode = SecretEnrollment resp.secret }, Cmd.none )
 
                 Err err ->
                     processApiError "Failed to generate OTP secret" err model

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/DataTypes.elm
@@ -30,14 +30,20 @@ type alias GenerateResponse =
     TotpSecretContainer
 
 
+type Mode
+    = CodeVerification
+    | SecretGeneration
+    | SecretEnrollment TotpSecretData
 
--- Request to verify OTP code
+
+type Enrollment
+    = Enrolled
+    | EnrollmentNeeded
 
 
 type alias Model =
     { contextPath : String
-    , needEnrollment : Maybe Bool
-    , generatedSecret : Maybe TotpSecretData
+    , mode : Mode
     , code : String
     , errorMsg : Maybe String
     , isLoading : Bool
@@ -49,7 +55,17 @@ type Msg
     = SetCode String
     | GenerateOtp
     | VerifyOtp String
-    | OtpStatusResponse (Result (Detailed.Error String) ( Http.Metadata, Bool ))
+    | OtpStatusResponse (Result (Detailed.Error String) ( Http.Metadata, Enrollment ))
     | GenerateResponse (Result (Detailed.Error String) ( Http.Metadata, GenerateResponse ))
     | VerifyResponse (Result (Detailed.Error String) ())
     | UrlChanged String
+
+
+enrollmentMode : Enrollment -> Mode
+enrollmentMode e =
+    case e of
+        EnrollmentNeeded ->
+            SecretGeneration
+
+        Enrolled ->
+            CodeVerification

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/Init.elm
@@ -26,8 +26,7 @@ init flags =
     let
         initModel =
             { contextPath = flags.contextPath
-            , needEnrollment = Nothing
-            , generatedSecret = Nothing
+            , mode = CodeVerification
             , code = ""
             , errorMsg = Nothing
             , isLoading = False

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/JsonDecoder.elm
@@ -1,18 +1,30 @@
 module Otp.JsonDecoder exposing (..)
 
-import Http.Detailed as Detailed
 import Json.Decode as D
 import Json.Decode.Pipeline exposing (required)
 import Otp.DataTypes exposing (..)
 
 
-
--- Decode status response: { action, result, data: { needEnrollment: Bool } }
-
-
-decodeStatus : D.Decoder Bool
+decodeStatus : D.Decoder Enrollment
 decodeStatus =
-    D.at [ "data", "needEnrollment" ] D.bool
+    D.at [ "data" ] decodeEnrollment
+
+
+decodeEnrollment : D.Decoder Enrollment
+decodeEnrollment =
+    D.string
+        |> D.andThen
+            (\s ->
+                case s of
+                    "enrolled" ->
+                        D.succeed Enrolled
+
+                    "enrollmentNeeded" ->
+                        D.succeed EnrollmentNeeded
+
+                    _ ->
+                        D.fail <| "Could not decode enrollment value '" ++ s ++ "', must be enrolled/enrollmentNeeded"
+            )
 
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/View.elm
@@ -21,99 +21,95 @@ view model =
     div [ class "otp-container" ]
         [ h1 [ class "fs-3" ] [ text "Two-factor authentication" ]
         , hr [] []
-        , enrollmentBanner model
-        , actions model
+        , viewModeHeader model.mode
+        , viewErrorMsg model.errorMsg
+        , div [ class "d-flex flex-column align-items-center" ]
+            (viewMode model.mode model.code model.isLoading)
         ]
 
 
-enrollmentBanner : Model -> Html Msg
-enrollmentBanner model =
-    case model.needEnrollment of
-        Just True ->
+viewModeHeader : Mode -> Html Msg
+viewModeHeader mode =
+    case mode of
+        CodeVerification ->
+            div [ class "alert alert-info d-flex justify-content-center" ]
+                [ text "TOTP code verification required for login" ]
+
+        _ ->
             div [ class "alert alert-warning mt-3" ]
                 [ i [ class "fa fa-warning me-2" ] []
                 , text "You need to enable a two-factor authentication. Generate a TOTP secret for your authenticator app below."
                 ]
 
-        _ ->
-            div [ class "alert alert-info d-flex justify-content-center" ]
-                [ text "TOTP code verification required for login" ]
+
+viewErrorMsg errorMsg =
+    case errorMsg of
+        Just msg ->
+            div [ class "alert alert-danger" ]
+                [ text msg ]
+
+        Nothing ->
+            text ""
 
 
-actions : Model -> Html Msg
-actions model =
-    let
-        showEnrollment =
-            Maybe.Extra.isNothing model.generatedSecret
-                && (model.needEnrollment
-                        |> Maybe.withDefault False
-                   )
-    in
-    div [ class "d-flex flex-column align-items-center" ]
-        [ case model.errorMsg of
-            Just msg ->
-                div [ class "alert alert-danger" ]
-                    [ text msg ]
-
-            Nothing ->
-                text ""
-        , if showEnrollment then
-            div [ class "d-flex justify-content-center" ]
+viewMode : Mode -> String -> Bool -> List (Html Msg)
+viewMode mode code loading =
+    case mode of
+        SecretGeneration ->
+            [ div [ class "d-flex justify-content-center" ]
                 [ button
                     [ class "btn btn-primary my-3"
-                    , disabled model.isLoading
+                    , disabled loading
                     , onClick GenerateOtp
                     ]
-                    [ if model.isLoading then
+                    [ if loading then
                         text "Generating..."
 
                       else
                         text "Generate TOTP"
                     ]
                 ]
+            ]
 
-          else
-            text ""
-        , case model.generatedSecret of
-            Just secret ->
-                div [ class "mt-3 d-flex flex-column align-items-center" ]
-                    [ h2 [ class "fs-5" ] [ text "Scan QR Code with your authenticator app" ]
-                    , qrCodeView secret.uri
-                    , div [ class "mt-2 d-flex flex-column align-items-center" ]
-                        [ label [] [ text "Or enter this key manually:" ]
-                        , pre [] [ text secret.value ]
-                        ]
-                    ]
-
-            Nothing ->
-                text ""
-        , if showEnrollment then
-            text ""
-
-          else
-            div [ class "mt-3 d-flex flex-column align-items-center" ]
-                [ input
-                    [ class "form-control mb-2"
-                    , type_ "text"
-                    , placeholder "Enter 6-digit code"
-                    , value model.code
-                    , size 12
-                    , onInput SetCode
-                    , onEnter (VerifyOtp model.code)
-                    ]
-                    []
-                , button
-                    [ class "my-3 px-4 btn btn-success"
-                    , disabled (model.code == "" || model.isLoading)
-                    , onClick (VerifyOtp model.code)
-                    ]
-                    [ if model.isLoading then
-                        text "Verifying..."
-
-                      else
-                        text "Verify"
+        SecretEnrollment secret ->
+            [ div [ class "mt-3 d-flex flex-column align-items-center" ]
+                [ h2 [ class "fs-5" ] [ text "Scan QR Code with your authenticator app" ]
+                , qrCodeView secret.uri
+                , div [ class "mt-2 d-flex flex-column align-items-center" ]
+                    [ label [] [ text "Or enter this key manually:" ]
+                    , pre [] [ text secret.value ]
                     ]
                 ]
+            , viewCode code loading
+            ]
+
+        CodeVerification ->
+            [ viewCode code loading ]
+
+
+viewCode code loading =
+    div [ class "mt-3 d-flex flex-column align-items-center" ]
+        [ input
+            [ class "form-control mb-2"
+            , type_ "text"
+            , placeholder "Enter 6-digit code"
+            , value code
+            , size 12
+            , onInput SetCode
+            , onEnter (VerifyOtp code)
+            ]
+            []
+        , button
+            [ class "my-3 px-4 btn btn-success"
+            , disabled (code == "" || loading)
+            , onClick (VerifyOtp code)
+            ]
+            [ if loading then
+                text "Verifying..."
+
+              else
+                text "Verify"
+            ]
         ]
 
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29224


* have an enum model instead of boolean, see https://github.com/Normation/rudder/pull/7223#discussion_r3445539001
  * moving datastructures into rudder-core
  * on Elm side there is some adaptation too because of Enum VS bool
* test the main logic for OTP creation `UserTotpValidator`
* JDBC tests (query type-check and repository tests)



Some other tests that could be added in another PR
* tests on the service and the enum results
* same test as JDBC for in memory repository test
* UI tests on Elm side