### PR TITLE
Fixes #29081: Add recent activity tab in technique detail page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
@@ -23,3 +23,30 @@ getActivities search filterType (ContextPath contextPath) =
                 }
     in
     req
+
+
+processApiError : String -> Detailed.Error String -> (String -> Cmd msg) -> Cmd msg
+processApiError apiName err errorNotification =
+    let
+        message =
+            case err of
+                Detailed.BadUrl url ->
+                    "The URL " ++ url ++ " was invalid"
+
+                Detailed.Timeout ->
+                    "Unable to reach the server, try again"
+
+                Detailed.NetworkError ->
+                    "Unable to reach the server, check your network connection"
+
+                Detailed.BadStatus _ body ->
+                    let
+                        ( title, errors ) =
+                            decodeErrorDetails body
+                    in
+                    title ++ "\n" ++ errors
+
+                Detailed.BadBody _ _ msg ->
+                    msg
+    in
+    errorNotification ("Error when " ++ apiName ++ ", details: \n" ++ message)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
@@ -1,6 +1,6 @@
 port module DirectiveRecentActivity exposing (..)
 
-import Activity.ApiCalls exposing (getActivities)
+import Activity.ApiCalls exposing (getActivities, processApiError)
 import Activity.DataTypes exposing (Activity, ActivityMsg(..), ContextPath(..), Search(..))
 import Activity.HtmlParserAdapter exposing (toHtml, toString)
 import Activity.JsonDecoder exposing (decodeErrorDetails)
@@ -116,33 +116,6 @@ view model =
     table model
 
 
-processApiError : String -> Detailed.Error String -> Cmd msg
-processApiError apiName err =
-    let
-        message =
-            case err of
-                Detailed.BadUrl url ->
-                    "The URL " ++ url ++ " was invalid"
-
-                Detailed.Timeout ->
-                    "Unable to reach the server, try again"
-
-                Detailed.NetworkError ->
-                    "Unable to reach the server, check your network connection"
-
-                Detailed.BadStatus _ body ->
-                    let
-                        ( title, errors ) =
-                            decodeErrorDetails body
-                    in
-                    title ++ "\n" ++ errors
-
-                Detailed.BadBody _ _ msg ->
-                    msg
-    in
-    errorNotification ("Error when " ++ apiName ++ ", details: \n" ++ message)
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -169,7 +142,7 @@ update msg model =
                             ( { model | activityTable = updatedTable }, Cmd.none )
 
                         Err err ->
-                            ( model, processApiError "Getting activities list" err )
+                            ( model, processApiError "Getting activities list" err errorNotification )
 
                 CopyToClipboard s ->
                     ( model, copy s )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -1,5 +1,8 @@
 port module Editor exposing (..)
 
+import Activity.ApiCalls exposing (getActivities, processApiError)
+import Activity.DataTypes exposing (Activity, ActivityMsg(..), ContextPath(..), Search(..))
+import Activity.HtmlParserAdapter exposing (toHtml, toString)
 import Browser
 import Dict exposing (Dict)
 import Dict.Extra
@@ -18,14 +21,21 @@ import Either exposing (Either(..))
 import File
 import File.Download
 import File.Select
+import Html exposing (Html, text)
+import Html.Attributes exposing (class)
 import Http.Detailed as Detailed
 import Json.Decode exposing (Value)
 import List.Extra
+import List.Nonempty as NonEmptyList
 import Maybe.Extra
+import Ordering exposing (Ordering)
 import Random
+import Rudder.Table exposing (ColumnName(..), buildConfig, buildCustomizations, buildOptions, updateData)
 import Task
-import Time
+import Time exposing (Posix, Zone)
+import TimeZone
 import UUID
+import Utils.DateUtils exposing (posixToString)
 
 
 
@@ -139,13 +149,91 @@ parseDraftsResponse json =
             Notification errorNotification "Invalid drafts in local storage, please clean your local storage"
 
 
-mainInit : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
+initTable : Zone -> Rudder.Table.Model Activity Msg
+initTable timezone =
+    let
+        columns : NonEmptyList.Nonempty (Rudder.Table.Column Activity Msg)
+        columns =
+            NonEmptyList.Nonempty
+                { name = ColumnName "Id", renderHtml = .id >> String.fromInt >> text, ordering = Ordering.byField .id }
+                [ { name = ColumnName "Actor", renderHtml = .actor >> text, ordering = Ordering.byField .actor }
+                , { name = ColumnName "Description"
+                  , renderHtml = .description >> toHtml
+                  , ordering = Ordering.byField (.description >> toString)
+                  }
+                , { name = ColumnName "Date", renderHtml = .date >> posixToString timezone >> text, ordering = Ordering.byField (.date >> Time.posixToMillis) }
+                ]
+
+        config =
+            buildConfig.newConfig columns
+                |> buildConfig.withOptions
+                    (buildOptions.newOptions
+                        |> buildOptions.withCustomizations
+                            (buildCustomizations.newCustomizations
+                                |> buildCustomizations.withTableContainerAttrs [ class "table-container" ]
+                                |> buildCustomizations.withTableAttrs [ class "no-footer dataTable" ]
+                            )
+                    )
+    in
+    Rudder.Table.init config []
+
+
+filterTypes : List String
+filterTypes =
+    [ "EditorTechniqueAdded", "EditorTechniqueDeleted", "EditorTechniqueModified" ]
+
+
+mainInit :
+    { contextPath : String
+    , hasWriteRights : Bool
+    , timeZone : String
+    }
+    -> ( Model, Cmd Msg )
 mainInit initValues =
     let
+        search =
+            Search ""
+
+        initTimeZone =
+            Dict.get initValues.timeZone TimeZone.zones
+                |> Maybe.withDefault (\() -> Time.utc)
+
+        zone =
+            initTimeZone ()
+
         model =
-            Model [] [] Dict.empty (TechniqueCategory "" "" "" (SubCategories [])) Dict.empty [] Introduction initValues.contextPath (TreeFilters "" []) (MethodListUI (MethodFilter "" False Nothing FilterClosed) []) False DragDrop.initialState Nothing initValues.hasWriteRights Nothing Nothing True [] "default"
+            { techniques = []
+            , errors = []
+            , methods = Dict.empty
+            , categories = TechniqueCategory "" "" "" (SubCategories [])
+            , drafts = Dict.empty
+            , directives = []
+            , mode = Introduction
+            , contextPath = initValues.contextPath
+            , techniqueFilter = TreeFilters "" []
+            , methodsUI = MethodListUI (MethodFilter "" False Nothing FilterClosed) []
+            , genericMethodsOpen = False
+            , dnd = DragDrop.initialState
+            , modal = Nothing
+            , hasWriteRights = initValues.hasWriteRights
+            , dropTarget = Nothing
+            , isMethodHovered = Nothing
+            , loadingTechniques = True
+            , recClone = []
+            , policyMode = "default"
+            , activityTable = initTable zone
+            }
     in
-    ( model, Cmd.batch [ getDrafts (), getMethods model, getTechniquesCategories model, getDirectives model, getPolicyMode model ] )
+    ( model
+    , Cmd.batch
+        [ getDrafts ()
+        , getMethods model
+        , getTechniquesCategories model
+        , getDirectives model
+        , getPolicyMode model
+        , Cmd.map ActivityMessage (getActivities search filterTypes (ContextPath initValues.contextPath))
+        ]
+    )
 
 
 updatedStoreTechnique : Model -> ( Model, Cmd Msg )
@@ -385,10 +473,10 @@ update msg model =
                         ( { model | mode = Introduction }, initInputs "" )
 
                     else
-                        ( newModel, cmd )
+                        ( newModel, Cmd.map ActivityMessage (getActivities (Search id.value) filterTypes (ContextPath model.contextPath)) )
 
                 _ ->
-                    ( newModel, cmd )
+                    ( newModel, Cmd.map ActivityMessage (getActivities (Search id.value) filterTypes (ContextPath model.contextPath)) )
 
         SelectDraft id ->
             let
@@ -1550,3 +1638,28 @@ update msg model =
 
                 _ ->
                     ( model, Cmd.none )
+
+        RudderTableMsg m ->
+            let
+                ( activityTable, tableMsg, _ ) =
+                    Rudder.Table.update m model.activityTable
+            in
+            ( { model | activityTable = activityTable }, tableMsg )
+
+        ActivityMessage activityMsg ->
+            case activityMsg of
+                GetActivities res ->
+                    case res of
+                        -- Update table data
+                        Ok ( _, activities ) ->
+                            let
+                                updatedTable =
+                                    updateData activities model.activityTable
+                            in
+                            ( { model | activityTable = updatedTable }, Cmd.none )
+
+                        Err err ->
+                            ( model, processApiError "Getting activities list" err errorNotification )
+
+                CopyToClipboard s ->
+                    ( model, copy s )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -1,5 +1,6 @@
 module Editor.DataTypes exposing (..)
 
+import Activity.DataTypes exposing (Activity, ActivityMsg)
 import Bytes exposing (Bytes)
 import Dict exposing (Dict)
 import Dom.DragDrop as DragDrop
@@ -8,6 +9,7 @@ import Either exposing (Either)
 import File exposing (File)
 import Http exposing (Error)
 import Http.Detailed
+import Rudder.Table
 import Time exposing (Posix)
 
 
@@ -335,6 +337,7 @@ type alias Model =
     , loadingTechniques : Bool
     , recClone : List Msg
     , policyMode : String
+    , activityTable : Rudder.Table.Model Activity Msg
     }
 
 
@@ -481,6 +484,7 @@ type Tab
     | Parameters
     | Resources
     | Directives
+    | RecentActivity
     | Output
     | None
 
@@ -572,6 +576,8 @@ type Msg
     | DisableDragDrop
     | EnableDragDrop CallId
     | HoverMethod (Maybe CallId)
+    | RudderTableMsg (Rudder.Table.Msg Msg)
+    | ActivityMessage ActivityMsg
 
 
 dragDropMessages : DragDrop.Messages Msg DragElement DropElement

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -750,6 +750,11 @@ showTechnique model technique origin ui editInfo =
                             ]
                         ]
                     ]
+                , li [ class "nav-item" ]
+                    [ button
+                        [ attribute "role" "tab", type_ "button", class ("nav-link " ++ activeTabClass RecentActivity), onClick (SwitchTab RecentActivity) ]
+                        [ text "Recent Activity" ]
+                    ]
                 , if Maybe.Extra.isJust technique.output then
                     li [ class "nav-item" ]
                         [ button
@@ -766,7 +771,7 @@ showTechnique model technique origin ui editInfo =
         , div [ class "main-details", id "details" ]
             [ div [ class "editForm", name "ui.editForm" ]
                 [ techniqueTab model technique creation ui
-                , if ui.tab == Directives then
+                , if ui.tab == Directives || ui.tab == RecentActivity then
                     text ""
 
                   else

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
@@ -1,5 +1,6 @@
 module Editor.ViewTechniqueTabs exposing (..)
 
+import Activity.DataTypes exposing (Activity)
 import Compliance.Utils exposing (badgePolicyMode)
 import Editor.AgentValueParser exposing (..)
 import Editor.DataTypes exposing (..)
@@ -10,6 +11,7 @@ import Html.Events exposing (..)
 import List.Extra
 import Maybe.Extra
 import Regex
+import Rudder.Table
 import String.Extra
 
 
@@ -46,6 +48,13 @@ techniqueResource resource =
                 [ i [ class "ion ion-clipboard" ] []
                 ]
             ]
+        ]
+
+
+techniqueRecentActivity : Rudder.Table.Model Activity Msg -> Html Msg
+techniqueRecentActivity activityTable =
+    div [ class "tab" ]
+        [ div [ class "main-table" ] [ Html.map RudderTableMsg (Rudder.Table.view activityTable) ]
         ]
 
 
@@ -743,6 +752,9 @@ techniqueTab model technique creation ui =
 
         Directives ->
             techniqueDirectives model technique
+
+        RecentActivity ->
+            techniqueRecentActivity model.activityTable
 
         Output ->
             case technique.output of

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
@@ -53,6 +53,7 @@ $(document).ready(function(){
   var initValues = {
     contextPath : contextPath
   , hasWriteRights : hasWriteRights
+  , timeZone: localStorage.getItem('timeZone') ?? 'UTC'
   };
   var app  = Elm.Editor.init({node: main, flags: initValues});
   app.ports.copy.subscribe(function(value) {


### PR DESCRIPTION
https://issues.rudder.io/issues/29081

Add recent activity tab in technique
<img width="1489" height="428" alt="Screenshot From 2026-07-09 14-56-50" src="https://github.com/user-attachments/assets/e1b97458-8a8f-44a3-9125-802e6744f752" />

Move method `processApiError` in Activity module to be available for all `Recent Activity` tabs.