### PR TITLE
Fixes #28849: Secedit remove user for user right assignements

### DIFF
--- a/policies/module-types/secedit/src/secedit.rs
+++ b/policies/module-types/secedit/src/secedit.rs
@@ -121,14 +121,8 @@ fn parse_config(path: &Path) -> Result<Ini> {
         enabled_quote: false,
         ..Default::default()
     };
-    let mut template = Ini::load_from_str_opt(&data, opt)
+    let template = Ini::load_from_str_opt(&data, opt)
         .with_context(|| format!("Failed to read template file '{}'", path.display()))?;
-
-    template
-        .with_section(Some("Privilege Rights"))
-        .set("SeTrustedCredManAccessPrivilege", "")
-        .set("SeRelabelPrivilege", "")
-        .set("SeUnsolicitedInputPrivilege", "");
 
     Ok(template)
 }

--- a/policies/module-types/secedit/src/secedit.rs
+++ b/policies/module-types/secedit/src/secedit.rs
@@ -121,8 +121,14 @@ fn parse_config(path: &Path) -> Result<Ini> {
         enabled_quote: false,
         ..Default::default()
     };
-    let template = Ini::load_from_str_opt(&data, opt)
+    let mut template = Ini::load_from_str_opt(&data, opt)
         .with_context(|| format!("Failed to read template file '{}'", path.display()))?;
+
+    template
+        .with_section(Some("Privilege Rights"))
+        .set("SeTrustedCredManAccessPrivilege", "")
+        .set("SeRelabelPrivilege", "")
+        .set("SeUnsolicitedInputPrivilege", "");
 
     Ok(template)
 }

--- a/policies/module-types/secedit/src/secedit.rs
+++ b/policies/module-types/secedit/src/secedit.rs
@@ -156,17 +156,17 @@ fn invoke_with_args(args: Vec<&str>) -> Result<()> {
     Ok(())
 }
 
-fn validate_property(key: &str, section: &str, value: &Value) -> Result<String> {
+fn validate_property(key: &str, section: &str, value: &Value) -> Result<Option<String>> {
     match value {
-        Value::String(s) if property_is_string(key, section) => Ok(s.clone()),
+        Value::String(s) if property_is_string(key, section) => Ok(Some(s.clone())),
         Value::String(s) => Err(anyhow!(
             "Invalid value '{s}' for property '{key}'. String values are not supported for this property."
         )),
         Value::Number(n) if property_is_string(key, section) => Err(anyhow!(
             "Invalid value '{n}' for property '{key}'. Integer values are not supported for this property."
         )),
-        Value::Number(n) => Ok(n.to_string()),
-        Value::Null => Ok(String::default()),
+        Value::Number(n) => Ok(Some(n.to_string())),
+        Value::Null => Ok(None),
         _ => Err(anyhow!(
             "Invalid value '{value}'. Only strings and numbers are supported."
         )),
@@ -210,33 +210,37 @@ fn config_search_and_replace(
 
         let mut section_diff: Vec<String> = vec![];
         for (key, new_value) in entries {
-            let new_value = validate_property(key, section, new_value)?.replace("\"", "");
-            let new_value = if new_value.is_empty() {
-                // set to default value if the provided property is empty
+            let new_value = validate_property(key, section, new_value)?;
+            let new_value = new_value.map(|s| s.replace("\"", ""));
+            let new_value = match new_value.as_deref() {
+                Some("") => {
+                    // set to default value if the provided property is empty
 
-                let default_properties = match default.section(Some(section)) {
-                    Some(m) => m,
-                    None => {
-                        report.errors.push(format!(
-                            "section '{section}' does not exist in the default configuration"
-                        ));
-                        continue;
-                    }
-                };
-                match default_properties.get(key) {
-                    Some(default_value) => default_value.replace("\"", ""),
-                    None => {
-                        report
-                            .errors
-                            .push(format!("Property '{key}' does not have a default value"));
-                        continue;
+                    let default_properties = match default.section(Some(section)) {
+                        Some(m) => m,
+                        None => {
+                            report.errors.push(format!(
+                                "section '{section}' does not exist in the default configuration"
+                            ));
+                            continue;
+                        }
+                    };
+                    match default_properties.get(key) {
+                        Some(default_value) => default_value.replace("\"", ""),
+                        None => {
+                            report
+                                .errors
+                                .push(format!("Property '{key}' does not have a default value"));
+                            continue;
+                        }
                     }
                 }
-            } else {
-                new_value
+                Some(s) => s.to_string(),
+                None => "".to_string(),
             };
             let old_value = match properties.get(key) {
                 Some(old_value) => old_value.replace("\"", ""),
+                None if new_value.is_empty() => continue,
                 None => {
                     let default_properties = match default.section(Some(section)) {
                         Some(m) => m,


### PR DESCRIPTION
https://issues.rudder.io/issues/28849

Enables the use of `null` value in the JSON passed to the module to _unset_  properties in Secedit.

example:

```Json
{
  "Privilege Rights": {
    "SeRemoteShutdownPrivilege": null
  }
}
```