### PR TITLE
Fixes #29221: Export directive compliance by node to CSV

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/directives/compliance-id-by-node.sh
+++ b/webapp/sources/api-doc/code_samples/curl/directives/compliance-id-by-node.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/directives/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/byNode'

--- a/webapp/sources/api-doc/code_samples/curl/directives/compliance-id-by-rule.sh
+++ b/webapp/sources/api-doc/code_samples/curl/directives/compliance-id-by-rule.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/directives/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/byRule'

--- a/webapp/sources/api-doc/code_samples/curl/directives/compliance-id.sh
+++ b/webapp/sources/api-doc/code_samples/curl/directives/compliance-id.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/directives/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance'

--- a/webapp/sources/api-doc/code_samples/curl/directives/compliance.sh
+++ b/webapp/sources/api-doc/code_samples/curl/directives/compliance.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/directives/compliance'

--- a/webapp/sources/api-doc/components/responses/compliance-directive-id.yml
+++ b/webapp/sources/api-doc/components/responses/compliance-directive-id.yml
@@ -3,6 +3,7 @@
 type: object
 required:
   - result
+  - id
   - action
   - data
 properties:
@@ -13,6 +14,11 @@ properties:
       - success
       - error
     example: success
+  id:
+    type: string
+    format: uuid
+    description: id of the directive
+    example: 9a1773c9-0889-40b6-be89-f6504443ac1b
   action:
     type: string
     description: The id of the action
@@ -55,37 +61,12 @@ properties:
             description: Directive compliance level
             example: 83.34
           complianceDetails:
-            type: object
-            properties:
-              successAlreadyOK:
-                type: number
-                format: float
-                example: 66.68
-              noReport:
-                type: number
-                format: float
-                example: 7.45
-              successNotApplicable:
-                type: number
-                format: float
-                example: 16.66
-              unexpectedMissingComponent:
-                type: number
-                format: float
-                example: 2.63
-              error:
-                type: number
-                format: float
-                example: 1.32
-              unexpectedUnknownComponent:
-                type: number
-                format: float
-                example: 2.63
-              successRepaired:
-                type: number
-                format: float
-                example: 2.63
+            $ref: ../schemas/compliance-details.yml
           rules:
-            $ref: ../schemas/directive-rule-compliance.yml
+            type: array
+            items:
+              $ref: ../schemas/directive-rule-compliance.yml
           nodes:
-            $ref: ../schemas/directive-node-compliance.yml
+            type: array
+            items:
+              $ref: ../schemas/directive-node-compliance.yml

--- a/webapp/sources/api-doc/components/schemas/directive-node-compliance.yml
+++ b/webapp/sources/api-doc/components/schemas/directive-node-compliance.yml
@@ -21,35 +21,8 @@ properties:
     description: Directive compliance level
     example: 83.34
   complianceDetails:
-    type: object
-    properties:
-      successAlreadyOK:
-        type: number
-        format: float
-        example: 100.0
-      noReport:
-        type: number
-        format: float
-        example: 0.0
-      successNotApplicable:
-        type: number
-        format: float
-        example: 0.0
-      unexpectedMissingComponent:
-        type: number
-        format: float
-        example: 0.0
-      error:
-        type: number
-        format: float
-        example: 0.0
-      unexpectedUnknownComponent:
-        type: number
-        format: float
-        example: 0.0
-      successRepaired:
-        type: number
-        format: float
-        example: 0.0
+    $ref: compliance-details.yml
   rules:
-    $ref: rule-compliance-component.yml
+    type: array
+    items:
+      $ref: rule-compliance-component.yml

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -331,6 +331,14 @@ paths:
     $ref: paths/directives/id-check.yml
   "/directives/tree":
     $ref: paths/directives/tree.yml
+  "/directives/compliance":
+    $ref: paths/directives/compliance.yml
+  "/directives/{directiveId}/compliance":
+    $ref: paths/directives/compliance-id.yml
+  "/directives/{directiveId}/compliance/byNode":
+    $ref: paths/directives/compliance-id-by-node.yml
+  "/directives/{directiveId}/compliance/byRule":
+    $ref: paths/directives/compliance-id-by-rule.yml
   "/rules":
     $ref: paths/rules/all.yml
   "/rules/{ruleId}":

--- a/webapp/sources/api-doc/paths/compliance/directive.yml
+++ b/webapp/sources/api-doc/paths/compliance/directive.yml
@@ -3,7 +3,7 @@
 get:
   summary: Compliance details by directive
   description: Get current compliance of a directive of a Rudder server
-  operationId: getDirectiveComplianceId
+  operationId: getDirectiveComplianceIdOld
   parameters:
     - in: query
       name: format

--- a/webapp/sources/api-doc/paths/directives/compliance-id-by-node.yml
+++ b/webapp/sources/api-doc/paths/directives/compliance-id-by-node.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2026 Normation SAS
+get:
+  summary: Get compliance details by node for a given directive
+  description: Get current compliance by node of a directive of a Rudder server
+  operationId: getDirectiveComplianceByNodeId
+  parameters:
+    - in: query
+      name: format
+      schema:
+        type: string
+        enum:
+          - csv
+          - json
+        default: json
+      description: format of export
+      style: form
+      explode: false
+    - $ref: ../../components/parameters/directive-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getDirectiveComplianceByNodeId
+              data:
+                type: object
+                required:
+                  - nodes
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/directive-node-compliance.yml
+        text/plain:
+          schema:
+            type: string
+          example: |
+            "Node","Rule","Block","Component","Value","Status","Message"
+            "node1.localhost","R3","","directive2-component-br3-bn2","directive2-component-value-br3-bn2","error",""
+            "node1.localhost","R3","","directive2-component-br3-bn1","directive2-component-value-br3-bn1","error",""
+            "node1.localhost","R3","","directive2-component-r3-n2","directive2-component-value-r3-n2","error",""
+            "node1.localhost","R3","","directive2-component-r3-n1","directive2-component-value-r3-n1","error",""
+
+  tags:
+    - Directives
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/directives/compliance-id-by-node.sh
+
+

--- a/webapp/sources/api-doc/paths/directives/compliance-id-by-rule.yml
+++ b/webapp/sources/api-doc/paths/directives/compliance-id-by-rule.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2026 Normation SAS
+get:
+  summary: Get compliance details by rule for a given directive
+  description: Get current compliance by rule of a directive of a Rudder server
+  operationId: getDirectiveComplianceByRuleId
+  parameters:
+    - in: query
+      name: format
+      schema:
+        type: string
+        enum:
+          - csv
+          - json
+        default: json
+      description: format of export
+      style: form
+      explode: false
+    - $ref: ../../components/parameters/directive-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getDirectiveComplianceByRuleId
+              data:
+                type: object
+                required:
+                  - rules
+                properties:
+                  rules:
+                    type: array
+                    items: 
+                      $ref: ../../components/schemas/directive-rule-compliance.yml
+        text/plain:
+          schema:
+            type: string
+          example: |
+            "Rule","Block","Component","Node","Value","Status","Message"
+            "R3","","directive2-component-br3-bn1","node1.localhost","directive2-component-value-br3-bn1","error",""
+            "R3","","directive2-component-br3-bn2","node1.localhost","directive2-component-value-br3-bn2","error",""
+            "R3","","directive2-component-r3-n1","node1.localhost","directive2-component-value-r3-n1","error",""
+            "R3","","directive2-component-r3-n2","node1.localhost","directive2-component-value-r3-n2","error",""
+
+  tags:
+    - Directives
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/directives/compliance-id-by-rule.sh
+
+

--- a/webapp/sources/api-doc/paths/directives/compliance-id.yml
+++ b/webapp/sources/api-doc/paths/directives/compliance-id.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2026 Normation SAS
+get:
+  summary: Get compliance details for a given directive
+  description: Get current compliance of a directive of a Rudder server
+  operationId: getDirectiveComplianceId
+  parameters:
+    - $ref: ../../components/parameters/directive-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/responses/compliance-directive-id.yml
+
+  tags:
+    - Directives
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/directives/compliance-id.sh
+
+

--- a/webapp/sources/api-doc/paths/directives/compliance.yml
+++ b/webapp/sources/api-doc/paths/directives/compliance.yml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: CC-BY-SA-2.0
-# SPDX-FileCopyrightText: 2013-2023 Normation SAS
+# SPDX-FileCopyrightText: 2026 Normation SAS
 get:
-  summary: Compliance details for all directives
+  summary: Get compliance details for all directives
   description: Get current compliance of all the nodes of a Rudder server
-  operationId: getDirectivesComplianceOld
+  operationId: getDirectivesCompliance
   responses:
     "200":
       description: Success
@@ -65,44 +65,15 @@ get:
                         description: Directive compliance level
                         example: 83.34
                       complianceDetails:
-                        type: object
-                        properties:
-                          successAlreadyOK:
-                            type: number
-                            format: float
-                            example: 66.68
-                          noReport:
-                            type: number
-                            format: float
-                            example: 7.45
-                          successNotApplicable:
-                            type: number
-                            format: float
-                            example: 16.66
-                          unexpectedMissingComponent:
-                            type: number
-                            format: float
-                            example: 2.63
-                          error:
-                            type: number
-                            format: float
-                            example: 1.32
-                          unexpectedUnknownComponent:
-                            type: number
-                            format: float
-                            example: 2.63
-                          successRepaired:
-                            type: number
-                            format: float
-                            example: 2.63
+                        $ref: ../../components/schemas/compliance-details.yml
                       rules:
                         $ref: ../../components/schemas/directive-rule-compliance.yml
                       nodes:
                         $ref: ../../components/schemas/directive-node-compliance.yml
 
   tags:
-    - Compliance
+    - Directives
   x-codeSamples:
     - lang: curl
       source:
-        $ref: ../../code_samples/curl/compliance/directives.sh
+        $ref: ../../code_samples/curl/directives/compliance.sh

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -410,53 +410,83 @@ object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
 }
 
 sealed trait DirectiveApi extends EnumEntry with EndpointSchema with GeneralApi with SortIndex {
-  override def dataContainer: Some[String] = Some("directives")
+  override def dataContainer: Option[String] = Some("directives")
 }
 object DirectiveApi       extends Enum[DirectiveApi] with ApiModuleProvider[DirectiveApi]      {
 
-  case object ListDirectives     extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex  {
+  case object ListDirectives           extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex                  {
     val z: Int = implicitly[Line].value
     val description    = "List all directives"
     val (action, path) = GET / "directives"
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Read :: Nil
   }
-  case object DirectiveTree      extends DirectiveApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object DirectiveTree            extends DirectiveApi with ZeroParam with StartsAtVersion14 with SortIndex                 {
     val z: Int = implicitly[Line].value
     val description    = "Get Directive tree"
     val (action, path) = GET / "directives" / "tree"
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Read :: Nil
   }
-  case object DirectiveDetails   extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object GetDirectiveComplianceId extends DirectiveApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Get compliance for a given directive"
+    val (action, path) = GET / "directives" / "{id}" / "compliance"
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GetDirectiveComplianceByNodeId
+      extends DirectiveApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get compliance by node for a given directive"
+    val (action, path) = GET / "directives" / "{id}" / "compliance" / "byNode"
+    override def dataContainer: Option[String]          = Some("nodes")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GetDirectiveComplianceByRuleId
+      extends DirectiveApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get compliance by rule for a given directive"
+    val (action, path) = GET / "directives" / "{id}" / "compliance" / "byRule"
+    override def dataContainer: Option[String]          = Some("rules")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GetDirectivesCompliance  extends DirectiveApi with GeneralApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get compliance for all directives"
+    val (action, path) = GET / "directives" / "compliance"
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object DirectiveDetails         extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex                   {
     val z: Int = implicitly[Line].value
     val description    = "Get information about given directive"
     val (action, path) = GET / "directives" / "{id}"
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Read :: Nil
   }
-  case object DirectiveRevisions extends DirectiveApi with OneParam with StartsAtVersion14 with SortIndex  {
+  case object DirectiveRevisions       extends DirectiveApi with OneParam with StartsAtVersion14 with SortIndex                  {
     val z: Int = implicitly[Line].value
     val description    = "Get revisions for given directive"
     val (action, path) = GET / "directives" / "{id}" / "revisions"
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Read :: Nil
   }
-  case object CreateDirective    extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex  {
+  case object CreateDirective          extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex                  {
     val z: Int = implicitly[Line].value
     val description    = "Create a new directive or clone an existing one"
     val (action, path) = PUT / "directives"
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Write :: Nil
   }
-  case object DeleteDirective    extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object DeleteDirective          extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex                   {
     val z: Int = implicitly[Line].value
     val description    = "Delete given directive"
     val (action, path) = DELETE / "directives" / "{id}"
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Write :: Nil
   }
-  case object CheckDirective     extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object CheckDirective           extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex                   {
     val z: Int = implicitly[Line].value
     val description    = "Check if the given directive can be migrated to target technique version"
     val (action, path) = POST / "directives" / "{id}" / "check"
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Write :: Nil
   }
-  case object UpdateDirective    extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object UpdateDirective          extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex                   {
     val z: Int = implicitly[Line].value
     val description    = "Update given directive information"
     val (action, path) = POST / "directives" / "{id}"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -463,7 +463,7 @@ object CsvCompliance {
   // use "," , quote everything with ", line separator is \n
   val csvFormat: CSVFormat = CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).setRecordSeparator("\n").get()
 
-  def recurseComponent(
+  private def recurseComponent(
       component: ByRuleComponentCompliance,
       block:     List[ComponentField]
   ): Seq[RuleComponentResult] = {
@@ -486,6 +486,29 @@ object CsvCompliance {
         }
       case component: ByRuleBlockCompliance =>
         component.subComponents.flatMap(c => recurseComponent(c, block ::: (ComponentField(component) :: Nil)))
+    }
+  }
+
+  private def recurseComponent(
+      component: ByRuleByNodeByDirectiveByComponentCompliance,
+      block:     List[ComponentField]
+  ): Seq[DirectiveComponentResult] = {
+
+    component match {
+      case component: ByRuleByNodeByDirectiveByValueCompliance =>
+        component.values.flatMap { value =>
+          value.messages.map { report =>
+            (
+              BlockField(block),
+              ComponentField(component.componentName),
+              ValueField(value),
+              StatusField(report),
+              MessageField(report)
+            )
+          }
+        }
+      case component: ByRuleByNodeByDirectiveByBlockCompliance =>
+        component.subComponents.flatMap(c => recurseComponent(c, block ::: (ComponentField(component.componentName) :: Nil)))
     }
   }
 
@@ -536,7 +559,8 @@ object CsvCompliance {
 
     opaque type NodeField = String
     object NodeField extends CsvField[NodeField] {
-      def apply(node: ByRuleNodeCompliance): NodeField = node.name
+      def apply(node:     ByRuleNodeCompliance): NodeField = node.name
+      def apply(nodeName: String):               NodeField = nodeName
     }
 
     opaque type ValueField = String
@@ -564,6 +588,10 @@ object CsvCompliance {
   type RuleComponentResult =
     (block: BlockField, component: ComponentField, node: NodeField, value: ValueField, status: StatusField, message: MessageField)
 
+  type DirectiveComponentResult =
+    (block: BlockField, component: ComponentField, value: ValueField, status: StatusField, message: MessageField)
+
+  // Rule compliance
   case class RuleComplianceByDirectiveCsv(
       directive: DirectiveField,
       block:     BlockField,
@@ -586,15 +614,14 @@ object CsvCompliance {
     }
 
     given Transformer[ByRuleRuleCompliance, Seq[RuleComplianceByDirectiveCsv]] = (rule: ByRuleRuleCompliance) => {
-      rule.directives.flatMap(d => {
-        for {
-          c   <- d.components
-          res <- recurseComponent(c, Nil)
-        } yield {
-          given ByRuleDirectiveCompliance = d
-          res.transformInto[RuleComplianceByDirectiveCsv]
-        }
-      })
+      for {
+        d   <- rule.directives
+        c   <- d.components
+        res <- recurseComponent(c, Nil)
+      } yield {
+        given ByRuleDirectiveCompliance = d
+        res.transformInto[RuleComplianceByDirectiveCsv]
+      }
     }
   }
 
@@ -620,19 +647,19 @@ object CsvCompliance {
     }
 
     given Transformer[ByRuleRuleCompliance, Seq[RuleComplianceByNodeCsv]] = (rule: ByRuleRuleCompliance) => {
-      rule.directives.flatMap(d => {
-        for {
-          c   <- d.components
-          res <- recurseComponent(c, Nil)
-        } yield {
-          given ByRuleDirectiveCompliance = d
+      for {
+        d   <- rule.directives
+        c   <- d.components
+        res <- recurseComponent(c, Nil)
+      } yield {
+        given ByRuleDirectiveCompliance = d
 
-          res.transformInto[RuleComplianceByNodeCsv]
-        }
-      })
+        res.transformInto[RuleComplianceByNodeCsv]
+      }
     }
   }
 
+  // Node group compliance
   case class NodeGroupComplianceByRuleCsv(
       rule:      RuleField,
       directive: DirectiveField,
@@ -659,17 +686,17 @@ object CsvCompliance {
 
     given Transformer[Seq[ByNodeGroupRuleCompliance], Seq[NodeGroupComplianceByRuleCsv]] = {
       (rules: Seq[ByNodeGroupRuleCompliance]) =>
-        rules.flatMap(rule => {
-          rule.directives.flatMap(directive => {
-            directive.components.flatMap(component => {
-              given RuleField      = RuleField(rule.name)
-              given DirectiveField = DirectiveField(directive.name)
-              val components       = recurseComponent(component, Nil)
+        for {
+          rule      <- rules
+          directive <- rule.directives
+          component <- directive.components
+          c         <- recurseComponent(component, Nil)
+        } yield {
+          given RuleField      = RuleField(rule.name)
+          given DirectiveField = DirectiveField(directive.name)
 
-              components.map(_.transformInto[NodeGroupComplianceByRuleCsv])
-            })
-          })
-        })
+          c.transformInto[NodeGroupComplianceByRuleCsv]
+        }
     }
   }
 
@@ -720,6 +747,42 @@ object CsvCompliance {
           })
         })
       })
+    }
+  }
+
+  case class DirectiveComplianceByNodeCsv(
+      node:      NodeField,
+      rule:      RuleField,
+      block:     BlockField,
+      component: ComponentField,
+      value:     ValueField,
+      status:    StatusField,
+      message:   MessageField
+  ) derives Csv
+
+  object DirectiveComplianceByNodeCsv {
+
+    given (using node: NodeField, rule: RuleField): Transformer[DirectiveComponentResult, DirectiveComplianceByNodeCsv] = {
+      Transformer
+        .define[DirectiveComponentResult, DirectiveComplianceByNodeCsv]
+        .withFieldConst(_.node, node)
+        .withFieldConst(_.rule, rule)
+        .buildTransformer
+    }
+
+    given Transformer[Seq[ByDirectiveNodeCompliance], Seq[DirectiveComplianceByNodeCsv]] = {
+      (nodes: Seq[ByDirectiveNodeCompliance]) =>
+        for {
+          node      <- nodes
+          rule      <- node.rules
+          component <- rule.components
+          c         <- recurseComponent(component, Nil)
+        } yield {
+          given NodeField = NodeField(node.name)
+          given RuleField = RuleField(rule.name)
+
+          c.transformInto[DirectiveComplianceByNodeCsv]
+        }
     }
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.domain.RudderLDAPConstants
+import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.domain.policies.ChangeRequestDirectiveDiff
 import com.normation.rudder.domain.policies.DeleteDirectiveDiff
@@ -61,11 +62,16 @@ import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.ModifyToDirectiveDiff
+import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.WoDirectiveRepository
 import com.normation.rudder.rest.{DirectiveApi as API, *}
 import com.normation.rudder.rest.data.*
+import com.normation.rudder.rest.data.ComplianceApiData.JsonByDirectiveCompliance.ByDirectiveComplianceApi
+import com.normation.rudder.rest.data.ComplianceApiData.JsonByDirectiveCompliance.ByDirectiveNodeComplianceApi
+import com.normation.rudder.rest.data.CsvCompliance.CsvDirectiveCompliance
+import com.normation.rudder.rest.data.CsvCompliance.DirectiveComplianceByNodeCsv
 import com.normation.rudder.rest.syntax.*
 import com.normation.rudder.services.workflows.ChangeRequestService
 import com.normation.rudder.services.workflows.DGModAction
@@ -76,10 +82,14 @@ import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.model.DirectiveEditor
 import com.normation.rudder.web.services.DirectiveEditorService
 import com.normation.utils.Control.*
+import com.normation.utils.Csv.toCsv
 import com.normation.utils.StringUuidGenerator
+import com.normation.zio.currentTimeMillis
 import com.softwaremill.quicklens.*
+import io.scalaland.chimney.syntax.*
 import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
+import net.liftweb.http.PlainTextResponse
 import net.liftweb.http.Req
 import zio.*
 import zio.syntax.*
@@ -94,14 +104,18 @@ class DirectiveApi(
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map {
-      case API.DirectiveTree      => DirectiveTree
-      case API.ListDirectives     => ListDirective
-      case API.DirectiveDetails   => DirectiveDetails
-      case API.DirectiveRevisions => DirectiveRevisions
-      case API.CreateDirective    => CreateDirective
-      case API.UpdateDirective    => UpdateDirective
-      case API.DeleteDirective    => DeleteDirective
-      case API.CheckDirective     => CheckDirective
+      case API.DirectiveTree                  => DirectiveTree
+      case API.ListDirectives                 => ListDirective
+      case API.DirectiveDetails               => DirectiveDetails
+      case API.DirectiveRevisions             => DirectiveRevisions
+      case API.CreateDirective                => CreateDirective
+      case API.UpdateDirective                => UpdateDirective
+      case API.DeleteDirective                => DeleteDirective
+      case API.CheckDirective                 => CheckDirective
+      case API.GetDirectiveComplianceId       => GetDirectiveComplianceId
+      case API.GetDirectiveComplianceByNodeId => GetDirectiveComplianceByNodeId
+      case API.GetDirectiveComplianceByRuleId => GetDirectiveComplianceByRuleId
+      case API.GetDirectivesCompliance        => GetDirectivesCompliance
     }
   }
 
@@ -232,6 +246,191 @@ class DirectiveApi(
       }).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
+
+  object GetDirectiveComplianceId extends LiftApiModule {
+    override val schema: API.GetDirectiveComplianceId.type = API.GetDirectiveComplianceId
+
+    override def process(
+        version:     ApiVersion,
+        path:        ApiPath,
+        directiveId: String,
+        req:         Req,
+        params:      DefaultParams,
+        authzToken:  AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      (for {
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        t1        <- currentTimeMillis
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        id        <- DirectiveId.parse(directiveId).toIO
+        d         <- service.getDirective(id)
+        t2        <- currentTimeMillis
+        _         <- TimingDebugLoggerPure.trace(s"API DirectiveCompliance - getting query param in ${t2 - t1} ms")
+        directive <- service.getDirectiveCompliance(d, level)
+        t3        <- currentTimeMillis
+        _          = TimingDebugLoggerPure.trace(
+                       s"API DirectiveCompliance - getting directive compliance '${id.uid.value}' in ${t3 - t2} ms"
+                     )
+      } yield (level, precision, directive))
+        .toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { (level, precision, directive) =>
+          // by default, all details are displayed
+          given l: Int                 = level.getOrElse(10)
+          given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+          given f: Boolean             = params.prettify
+
+          val d = ComplianceApiData.JsonByDirectiveCompliance.ByDirectiveComplianceContainer(
+            directive.transformInto[ComplianceApiData.JsonByDirectiveCompliance.ByDirectiveComplianceApi]
+          )
+
+          RudderJsonResponse.successOne(RudderJsonResponse.toResponseSchema(schema), d, Some(directiveId))
+        }
+    }
+  }
+
+  object GetDirectiveComplianceByNodeId extends LiftApiModule {
+    override val schema: API.GetDirectiveComplianceByNodeId.type = API.GetDirectiveComplianceByNodeId
+
+    override def process(
+        version:     ApiVersion,
+        path:        ApiPath,
+        directiveId: String,
+        req:         Req,
+        params:      DefaultParams,
+        authzToken:  AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      (for {
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        t1        <- currentTimeMillis
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        format    <- ComplianceUtils.extractComplianceFormat(req.params)
+        id        <- DirectiveId.parse(directiveId).toIO
+        d         <- service.getDirective(id)
+        t2        <- currentTimeMillis
+        _         <- TimingDebugLoggerPure.trace(s"API DirectiveCompliance - getting query param in ${t2 - t1} ms")
+        directive <- service.getDirectiveCompliance(d, level)
+        t3        <- currentTimeMillis
+        _          = TimingDebugLoggerPure.trace(
+                       s"API DirectiveCompliance - getting directive compliance by node for directive '${id.uid.value}' in ${t3 - t2} ms"
+                     )
+      } yield (level, precision, format, directive))
+        .toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { (level, precision, format, directive) =>
+          format match {
+            case ComplianceFormat.CSV =>
+              PlainTextResponse(directive.nodes.transformInto[Seq[DirectiveComplianceByNodeCsv]].toCsv)
+
+            case ComplianceFormat.JSON =>
+              // by default, all details are displayed
+              given l: Int                 = level.getOrElse(10)
+              given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+              given f: Boolean             = params.prettify
+
+              val d = {
+                directive
+                  .transformInto[ComplianceApiData.JsonByDirectiveCompliance.ByDirectiveComplianceApi]
+                  .nodes
+                  .getOrElse(Seq.empty)
+                  .toList
+              }
+
+              RudderJsonResponse.successList(RudderJsonResponse.toResponseSchema(schema), d)
+          }
+        }
+    }
+  }
+
+  object GetDirectiveComplianceByRuleId extends LiftApiModule {
+    override val schema: API.GetDirectiveComplianceByRuleId.type = API.GetDirectiveComplianceByRuleId
+
+    override def process(
+        version:     ApiVersion,
+        path:        ApiPath,
+        directiveId: String,
+        req:         Req,
+        params:      DefaultParams,
+        authzToken:  AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      (for {
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        t1        <- currentTimeMillis
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        format    <- ComplianceUtils.extractComplianceFormat(req.params)
+        id        <- DirectiveId.parse(directiveId).toIO
+        d         <- service.getDirective(id)
+        t2        <- currentTimeMillis
+        _         <- TimingDebugLoggerPure.trace(s"API DirectiveCompliance - getting query param in ${t2 - t1} ms")
+        directive <- service.getDirectiveCompliance(d, level)
+        t3        <- currentTimeMillis
+        _          = TimingDebugLoggerPure.trace(
+                       s"API DirectiveCompliance - getting directive compliance by rule for directive '${id.uid.value}' in ${t3 - t2} ms"
+                     )
+      } yield (level, precision, format, directive))
+        .toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { (level, precision, format, directive) =>
+          format match {
+            case ComplianceFormat.CSV =>
+              PlainTextResponse(directive.toCsv) // CSVFormat takes care of line separators
+
+            case ComplianceFormat.JSON =>
+              // by default, all details are displayed
+              given l: Int                 = level.getOrElse(10)
+              given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+              given f: Boolean             = params.prettify
+
+              val d = {
+                directive
+                  .transformInto[ComplianceApiData.JsonByDirectiveCompliance.ByDirectiveComplianceApi]
+                  .rules
+                  .getOrElse(Seq.empty)
+                  .toList
+              }
+
+              RudderJsonResponse.successList(RudderJsonResponse.toResponseSchema(schema), d)
+          }
+        }
+    }
+  }
+
+  object GetDirectivesCompliance extends LiftApiModule0 {
+    override val schema: API.GetDirectivesCompliance.type = API.GetDirectivesCompliance
+
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      (for {
+        level      <- ComplianceUtils.extractComplianceLevel(req.params)
+        t1         <- currentTimeMillis
+        precision  <- ComplianceUtils.extractPercentPrecision(req.params)
+        t2         <- currentTimeMillis
+        _          <- TimingDebugLoggerPure.trace(s"API DirectivesCompliance - getting query param in ${t2 - t1} ms")
+        t4         <- currentTimeMillis
+        directives <- service.getDirectivesCompliance(level)
+        t5         <- currentTimeMillis
+        _          <- TimingDebugLoggerPure.trace(s"API DirectivesCompliance - getting directives compliance in ${t5 - t4} ms")
+        json        = {
+          given l: Int = level.getOrElse(10)
+
+          given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+
+          directives.map(_.transformInto[ComplianceApiData.JsonByDirectiveCompliance.ByDirectiveComplianceApi])
+        }
+        t6         <- currentTimeMillis
+        _          <- TimingDebugLoggerPure.trace(s"API DirectivesCompliance - serialize to json in ${t6 - t5} ms")
+      } yield {
+        json
+      }).toLiftResponseList(params, schema)
+    }
+  }
 }
 
 // utility methods used in both service
@@ -266,7 +465,8 @@ class DirectiveApiService14(
     asyncDeploymentAgent: AsyncDeploymentActor,
     workflowLevelService: WorkflowLevelService,
     editorService:        DirectiveEditorService,
-    techniqueRepository:  TechniqueRepository
+    techniqueRepository:  TechniqueRepository,
+    complianceService:    ComplianceAPIService
 ) {
 
   def directiveTree(includeSystem: Boolean)(using qc: QueryContext): IOResult[JRDirectiveTreeCategory] = {
@@ -561,5 +761,17 @@ class DirectiveApiService14(
       val updatedDirective = directiveUpdate.after.directive
       JRDirective.fromDirective(updatedTechnique, updatedDirective, None)
     }
+  }
+
+  def getDirective(id: DirectiveId)(using qc: QueryContext): IOResult[Directive] = {
+    readDirective.getDirective(id.uid).notOptional(s"Directive with id '${id.serialize}' not found")
+  }
+
+  def getDirectiveCompliance(d: Directive, level: Option[Int])(using qc: QueryContext): IOResult[ByDirectiveCompliance] = {
+    complianceService.getDirectiveCompliance(d, level)
+  }
+
+  def getDirectivesCompliance(level: Option[Int])(using qc: QueryContext): IOResult[Seq[ByDirectiveCompliance]] = {
+    complianceService.getDirectivesCompliance(level)
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
@@ -2314,3 +2314,727 @@ response:
         ]
       }
     }
+---
+description: Get a directive's compliance
+method: GET
+url: /secure/api/directives/e9a1a909-2490-4fc9-95c3-9d0aa01717c9/compliance?level=3
+comment: N1 and N2 and BR1 are in audit mode, the other N3-N5 are in enforce, and BR4 is targeting N2-N5 so it is mixed
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getDirectiveComplianceId",
+      "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+      "result" : "success",
+      "data" : {
+        "directiveCompliance" : {
+          "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+          "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+          "compliance" : 100.0,
+          "mode" : "full-compliance",
+          "policyMode" : "enforce",
+          "complianceDetails" : {
+            "successAlreadyOK" : 100.0
+          },
+          "rules" : [
+            {
+              "id" : "br1",
+              "name" : "R1",
+              "compliance" : 100.0,
+              "policyMode" : "audit",
+              "complianceDetails" : {
+                "successAlreadyOK" : 100.0
+              },
+              "components" : []
+            },
+            {
+              "id" : "br6",
+              "name" : "R6",
+              "compliance" : 0.0,
+              "policyMode" : "skipped",
+              "complianceDetails" : {},
+              "skippedDetails" : {
+                "overridingRuleId" : "br5",
+                "overridingRuleName" : "R5"
+              },
+              "components" : []
+            },
+            {
+              "id" : "br4",
+              "name" : "R4",
+              "compliance" : 100.0,
+              "policyMode" : "mixed",
+              "complianceDetails" : {
+                "successAlreadyOK" : 100.0
+              },
+              "components" : []
+            }
+          ],
+          "nodes" : []
+        }
+      }
+    }
+---
+description: Get directive Directive2 compliance
+method: GET
+url: /secure/api/directives/directive2/compliance
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getDirectiveComplianceId",
+      "id" : "directive2",
+      "result" : "success",
+      "data" : {
+        "directiveCompliance" : {
+          "id" : "directive2",
+          "name" : "directive2",
+          "compliance" : 0.0,
+          "mode" : "full-compliance",
+          "policyMode" : "enforce",
+          "complianceDetails" : {
+            "error" : 100.0
+          },
+          "rules" : [
+            {
+              "id" : "br3",
+              "name" : "R3",
+              "compliance" : 0.0,
+              "policyMode" : "audit",
+              "complianceDetails" : {
+                "error" : 100.0
+              },
+              "components" : [
+                {
+                  "name" : "directive2-component-br3-bn1",
+                  "compliance" : 0.0,
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "nodes" : [
+                    {
+                      "id" : "bn1",
+                      "name" : "node1.localhost",
+                      "compliance" : 0.0,
+                      "policyMode" : "audit",
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-br3-bn1",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name" : "directive2-component-br3-bn2",
+                  "compliance" : 0.0,
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "nodes" : [
+                    {
+                      "id" : "bn2",
+                      "name" : "node1.localhost",
+                      "compliance" : 0.0,
+                      "policyMode" : "audit",
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-br3-bn2",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id" : "r3",
+              "name" : "R3",
+              "compliance" : 0.0,
+              "policyMode" : "enforce",
+              "complianceDetails" : {
+                "error" : 100.0
+              },
+              "components" : [
+                {
+                  "name" : "directive2-component-r3-n1",
+                  "compliance" : 0.0,
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "nodes" : [
+                    {
+                      "id" : "n1",
+                      "name" : "node1.localhost",
+                      "compliance" : 0.0,
+                      "policyMode" : "enforce",
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-r3-n1",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name" : "directive2-component-r3-n2",
+                  "compliance" : 0.0,
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "nodes" : [
+                    {
+                      "id" : "n2",
+                      "name" : "node1.localhost",
+                      "compliance" : 0.0,
+                      "policyMode" : "enforce",
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-r3-n2",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "nodes" : [
+            {
+              "id" : "bn2",
+              "name" : "node1.localhost",
+              "compliance" : 0.0,
+              "policyMode" : "audit",
+              "complianceDetails" : {
+                "error" : 100.0
+              },
+              "rules" : [
+                {
+                  "id" : "br3",
+                  "name" : "R3",
+                  "compliance" : 0.0,
+                  "policyMode" : "audit",
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "components" : [
+                    {
+                      "name" : "directive2-component-br3-bn2",
+                      "compliance" : 0.0,
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-br3-bn2",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id" : "bn1",
+              "name" : "node1.localhost",
+              "compliance" : 0.0,
+              "policyMode" : "audit",
+              "complianceDetails" : {
+                "error" : 100.0
+              },
+              "rules" : [
+                {
+                  "id" : "br3",
+                  "name" : "R3",
+                  "compliance" : 0.0,
+                  "policyMode" : "audit",
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "components" : [
+                    {
+                      "name" : "directive2-component-br3-bn1",
+                      "compliance" : 0.0,
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-br3-bn1",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id" : "n2",
+              "name" : "node1.localhost",
+              "compliance" : 0.0,
+              "policyMode" : "enforce",
+              "complianceDetails" : {
+                "error" : 100.0
+              },
+              "rules" : [
+                {
+                  "id" : "r3",
+                  "name" : "R3",
+                  "compliance" : 0.0,
+                  "policyMode" : "enforce",
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "components" : [
+                    {
+                      "name" : "directive2-component-r3-n2",
+                      "compliance" : 0.0,
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-r3-n2",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id" : "n1",
+              "name" : "node1.localhost",
+              "compliance" : 0.0,
+              "policyMode" : "enforce",
+              "complianceDetails" : {
+                "error" : 100.0
+              },
+              "rules" : [
+                {
+                  "id" : "r3",
+                  "name" : "R3",
+                  "compliance" : 0.0,
+                  "policyMode" : "enforce",
+                  "complianceDetails" : {
+                    "error" : 100.0
+                  },
+                  "components" : [
+                    {
+                      "name" : "directive2-component-r3-n1",
+                      "compliance" : 0.0,
+                      "complianceDetails" : {
+                        "error" : 100.0
+                      },
+                      "values" : [
+                        {
+                          "value" : "directive2-component-value-r3-n1",
+                          "reports" : [
+                            {
+                              "status" : "error"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+---
+description: Get directive Directive2 compliance by node
+method: GET
+url: /secure/api/directives/directive2/compliance/byNode
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getDirectiveComplianceByNodeId",
+      "result" : "success",
+      "data" : {
+        "nodes" : [
+          {
+            "id" : "bn2",
+            "name" : "node1.localhost",
+            "compliance" : 0.0,
+            "policyMode" : "audit",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "br3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "audit",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "directive2-component-br3-bn2",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-br3-bn2",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id" : "bn1",
+            "name" : "node1.localhost",
+            "compliance" : 0.0,
+            "policyMode" : "audit",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "br3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "audit",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "directive2-component-br3-bn1",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-br3-bn1",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id" : "n2",
+            "name" : "node1.localhost",
+            "compliance" : 0.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "directive2-component-r3-n2",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-r3-n2",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id" : "n1",
+            "name" : "node1.localhost",
+            "compliance" : 0.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "components" : [
+                  {
+                    "name" : "directive2-component-r3-n1",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-r3-n1",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get directive Directive2 compliance by node in CSV format
+method: GET
+url: /secure/api/directives/directive2/compliance/byNode?format=csv
+response:
+  code: 200
+  type: text
+  content: |
+    "Node","Rule","Block","Component","Value","Status","Message"
+    "node1.localhost","R3","","directive2-component-br3-bn2","directive2-component-value-br3-bn2","error",""
+    "node1.localhost","R3","","directive2-component-br3-bn1","directive2-component-value-br3-bn1","error",""
+    "node1.localhost","R3","","directive2-component-r3-n2","directive2-component-value-r3-n2","error",""
+    "node1.localhost","R3","","directive2-component-r3-n1","directive2-component-value-r3-n1","error",""
+---
+description: Get directive Directive2 compliance by rule
+method: GET
+url: /secure/api/directives/directive2/compliance/byRule
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getDirectiveComplianceByRuleId",
+      "result" : "success",
+      "data" : {
+        "rules" : [
+          {
+            "id" : "br3",
+            "name" : "R3",
+            "compliance" : 0.0,
+            "policyMode" : "audit",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "components" : [
+              {
+                "name" : "directive2-component-br3-bn1",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "nodes" : [
+                  {
+                    "id" : "bn1",
+                    "name" : "node1.localhost",
+                    "compliance" : 0.0,
+                    "policyMode" : "audit",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-br3-bn1",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name" : "directive2-component-br3-bn2",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "nodes" : [
+                  {
+                    "id" : "bn2",
+                    "name" : "node1.localhost",
+                    "compliance" : 0.0,
+                    "policyMode" : "audit",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-br3-bn2",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id" : "r3",
+            "name" : "R3",
+            "compliance" : 0.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "components" : [
+              {
+                "name" : "directive2-component-r3-n1",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "nodes" : [
+                  {
+                    "id" : "n1",
+                    "name" : "node1.localhost",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-r3-n1",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name" : "directive2-component-r3-n2",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "nodes" : [
+                  {
+                    "id" : "n2",
+                    "name" : "node1.localhost",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive2-component-value-r3-n2",
+                        "reports" : [
+                          {
+                            "status" : "error"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get directive Directive2 compliance by rule in CSV format
+method: GET
+url: /secure/api/directives/directive2/compliance/byRule?format=csv
+response:
+  code: 200
+  type: text
+  content: |
+    "Rule","Block","Component","Node","Value","Status","Message"
+    "R3","","directive2-component-br3-bn1","node1.localhost","directive2-component-value-br3-bn1","error",""
+    "R3","","directive2-component-br3-bn2","node1.localhost","directive2-component-value-br3-bn2","error",""
+    "R3","","directive2-component-r3-n1","node1.localhost","directive2-component-value-r3-n1","error",""
+    "R3","","directive2-component-r3-n2","node1.localhost","directive2-component-value-r3-n2","error",""

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -700,7 +700,8 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       asyncDeploymentAgent,
       workflowLevelService,
       directiveEditorService,
-      mockTechniques.techniqueRepo
+      mockTechniques.techniqueRepo,
+      mockCompliance.complianceAPIService
     )
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ApiCalls.elm
@@ -51,16 +51,33 @@ getDirectiveCompliance model =
     req
 
 
-getCSVExport : Model -> Cmd Msg
-getCSVExport model =
+getCSVExportByRule : String -> Model -> Cmd Msg
+getCSVExportByRule filename model =
     let
         req =
             request
                 { method = "GET"
                 , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
-                , url = getUrl model [ "compliance", "directives", model.directiveId.value ] [ Url.Builder.string "format" "csv" ]
+                , url = getUrl model [ "directives", model.directiveId.value, "compliance", "byRule" ] [ Url.Builder.string "format" "csv" ]
                 , body = emptyBody
-                , expect = expectString Export
+                , expect = expectString (DirectiveComplianceCsvExported filename)
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
+    req
+
+
+getCSVExportByNode : String -> Model -> Cmd Msg
+getCSVExportByNode filename model =
+    let
+        req =
+            request
+                { method = "GET"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model [ "directives", model.directiveId.value, "compliance", "byNode" ] [ Url.Builder.string "format" "csv" ]
+                , body = emptyBody
+                , expect = expectString (DirectiveComplianceCsvExported filename)
                 , timeout = Nothing
                 , tracker = Nothing
                 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/DataTypes.elm
@@ -1,6 +1,7 @@
 module DirectiveCompliance.DataTypes exposing (..)
 
 import Compliance.DataTypes exposing (..)
+import Date
 import Dict exposing (Dict)
 import Http exposing (Error)
 import Rules.DataTypes exposing (RuleCompliance)
@@ -103,6 +104,8 @@ type Msg
     | ToggleRowSort String String SortOrder
     | GetPolicyModeResult (Result Error String)
     | GetDirectiveComplianceResult (Result Error DirectiveCompliance)
-    | Export (Result Error String)
     | CallApi (Model -> Cmd Msg)
     | LoadCompliance String
+    | ExportDirectiveComplianceByNode DirectiveId Date.Date
+    | ExportDirectiveComplianceByRule DirectiveId Date.Date
+    | DirectiveComplianceCsvExported String (Result Error String)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewNodesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewNodesCompliance.elm
@@ -1,6 +1,7 @@
 module DirectiveCompliance.ViewNodesCompliance exposing (..)
 
 import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance)
+import Date
 import Dict
 import DirectiveCompliance.ApiCalls exposing (..)
 import DirectiveCompliance.DataTypes exposing (..)
@@ -10,8 +11,10 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import List
 import List.Extra
+import Task
 import Tuple3
 import Ui.Datatable exposing (SortOrder(..), filterSearch, generateLoadingTable)
+import Utils.CsvExportUtils exposing (exportToCsvButton)
 
 
 displayNodesComplianceTable : Model -> Html Msg
@@ -99,8 +102,11 @@ displayNodesComplianceTable model =
                             ]
                             []
                         ]
-                    , button [ class "btn btn-sm btn-default btn-refresh", onClick (CallApi getDirectiveCompliance) ]
-                        [ i [ class "fa fa-refresh" ] [] ]
+                    , div [ class "ms-auto my-auto" ]
+                        [ exportToCsvButton (CallApi (\m -> Task.perform (ExportDirectiveComplianceByNode m.directiveId) Date.today))
+                        , button [ class "btn btn-sm btn-default btn-refresh", onClick (CallApi getDirectiveCompliance) ]
+                            [ i [ class "fa fa-refresh" ] [] ]
+                        ]
                     ]
                 , displayComplianceFilters complianceFilters UpdateComplianceFilters
                 ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewRulesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewRulesCompliance.elm
@@ -1,6 +1,7 @@
 module DirectiveCompliance.ViewRulesCompliance exposing (..)
 
 import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance)
+import Date
 import Dict
 import DirectiveCompliance.ApiCalls exposing (..)
 import DirectiveCompliance.DataTypes exposing (..)
@@ -10,8 +11,10 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import List
 import List.Extra
+import Task
 import Tuple3
 import Ui.Datatable exposing (SortOrder(..), filterSearch, generateLoadingTable)
+import Utils.CsvExportUtils exposing (exportToCsvButton)
 
 
 displayRulesComplianceTable : Model -> Html Msg
@@ -107,8 +110,7 @@ displayRulesComplianceTable model =
                             []
                         ]
                     , div [ class "ms-auto my-auto" ]
-                        [ button [ class "btn btn-sm btn-primary btn-export me-2", onClick (CallApi getCSVExport) ]
-                            [ text "Export ", i [ class "fa fa-download" ] [] ]
+                        [ exportToCsvButton (CallApi (\m -> Task.perform (ExportDirectiveComplianceByRule m.directiveId) Date.today))
                         , button [ class "btn btn-sm btn-default btn-refresh", onClick (CallApi getDirectiveCompliance) ]
                             [ i [ class "fa fa-refresh" ] [] ]
                         ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Directivecompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Directivecompliance.elm
@@ -2,6 +2,7 @@ port module Directivecompliance exposing (..)
 
 import Browser
 import Browser.Navigation as Nav
+import Date
 import Dict
 import Dict.Extra
 import DirectiveCompliance.ApiCalls exposing (..)
@@ -186,14 +187,6 @@ update msg model =
                 Err err ->
                     processApiError "Getting directive compliance" err newModel
 
-        Export res ->
-            case res of
-                Ok content ->
-                    ( model, File.Download.string (model.directiveId.value ++ ".csv") "text/csv" content )
-
-                Err err ->
-                    processApiError "Export directive compliance" err model
-
         LoadCompliance str ->
             let
                 ui =
@@ -214,6 +207,34 @@ update msg model =
             ( newModel
             , actions
             )
+
+        ExportDirectiveComplianceByNode directiveId date ->
+            let
+                timeStr =
+                    date |> Date.format "yyyy-MM-dd"
+
+                filename =
+                    "rudder_directive_" ++ directiveId.value ++ "_compliance_by_node_" ++ timeStr ++ ".csv"
+            in
+            ( model, getCSVExportByNode filename model )
+
+        ExportDirectiveComplianceByRule directiveId date ->
+            let
+                timeStr =
+                    date |> Date.format "yyyy-MM-dd"
+
+                filename =
+                    "rudder_directive_" ++ directiveId.value ++ "_compliance_by_rule_" ++ timeStr ++ ".csv"
+            in
+            ( model, getCSVExportByRule filename model )
+
+        DirectiveComplianceCsvExported filename result ->
+            case result of
+                Ok content ->
+                    ( model, File.Download.string filename "text/csv" content )
+
+                Err error ->
+                    processApiError "exporting directive compliance to CSV" error model
 
 
 processApiError : String -> Error -> Model -> ( Model, Cmd Msg )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2410,7 +2410,8 @@ object RudderConfigInit {
               asyncDeploymentAgent,
               workflowLevelService,
               directiveEditorService,
-              techniqueRepositoryImpl
+              techniqueRepositoryImpl,
+              complianceAPIService
             )
           ),
           new NodeApi(


### PR DESCRIPTION
https://issues.rudder.io/issues/29221

This PR aims to add an "export to CSV" button to every directive's compliance by node tab.

<img width="1132" height="445" alt="image" src="https://github.com/user-attachments/assets/9da739fa-2445-4033-9b10-ef0023950b21" />

commit history : 
1. copy compliance endpoints from compliance API
2. add new `byRule` and `byNode` endpoint definitions and corresponding API tests
3. add export to CSV button in elm for compliance by node, and replace API call to `compliance/directives/{directiveId}` with `directives/{directiveId}/compliance/byRule` for the existing csv export by rule button
4. update API documentation
5. fix mistake in API documentation code sample
6. review fixes
7. review fixes
