### PR TITLE
Fixes #29241: Change validation rudder-core internal API lose isCreator parameter

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/WorkflowService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/WorkflowService.scala
@@ -61,6 +61,21 @@ import zio.syntax.ToZio
 case object WorkflowUpdate
 
 /*
+ * Tells whether the user acting on a change request is the one who authored it. Used to
+ * enforce the self-validation / self-deployment control (segregation of duties): a user
+ * may be forbidden to validate/deploy their own change request.
+ */
+sealed trait ChangeRequestAuthorship
+object ChangeRequestAuthorship {
+  case object Author    extends ChangeRequestAuthorship
+  case object NotAuthor extends ChangeRequestAuthorship
+
+  // single place that decides if the acting user authored the change request
+  def of(changeRequest: ChangeRequest, user: AuthenticatedUser): ChangeRequestAuthorship =
+    if (changeRequest.owner == user.name) Author else NotAuthor
+}
+
+/*
  * For rules, we have dedicated actions
  */
 sealed abstract class RuleModAction(val name: String)
@@ -225,9 +240,16 @@ trait WorkflowService {
 
   def stepsValue: List[WorkflowNodeId]
 
-  def findNextSteps(currentStep: WorkflowNodeId)(implicit auth: AuthenticatedUser): WorkflowAction
+  /*
+   * `authorship` tells if the current user is the author of the change request the step
+   * belongs to. It is needed to enforce the self-validation / self-deployment control
+   * (segregation of duties): a user may be forbidden to validate/deploy their own change.
+   */
+  def findNextSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
+      auth: AuthenticatedUser
+  ): WorkflowAction
 
-  def findBackSteps(currentStep: WorkflowNodeId)(implicit
+  def findBackSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
       auth: AuthenticatedUser
   ): Seq[(WorkflowNodeId, (ChangeRequestId, EventActor, Option[String]) => IOResult[WorkflowNodeId])]
 
@@ -241,8 +263,7 @@ trait WorkflowService {
    */
   def getAllChangeRequestsStep(): IOResult[Map[ChangeRequestId, WorkflowNodeId]]
 
-  def isEditable(currentUserRights: Seq[String], currentStep: WorkflowNodeId, isCreator: Boolean): Boolean
-  def isPending(currentStep:        WorkflowNodeId): Boolean
+  def isPending(currentStep: WorkflowNodeId): Boolean
 
   /*
    * A method that tells if the workflow requires an external validation.
@@ -275,9 +296,11 @@ class NoWorkflowServiceImpl(
 
   val name = "no-changes-validation-workflow"
 
-  def findNextSteps(currentStep: WorkflowNodeId)(implicit authz: AuthenticatedUser): WorkflowAction = NoWorkflowAction
+  def findNextSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
+      authz: AuthenticatedUser
+  ): WorkflowAction = NoWorkflowAction
 
-  def findBackSteps(currentStep: WorkflowNodeId)(implicit
+  def findBackSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
       auth: AuthenticatedUser
   ): Seq[(WorkflowNodeId, (ChangeRequestId, EventActor, Option[String]) => IOResult[WorkflowNodeId])] = Seq()
 
@@ -298,8 +321,6 @@ class NoWorkflowServiceImpl(
       result.id
     }
   }
-
-  def isEditable(currentUserRights: Seq[String], currentStep: WorkflowNodeId, isCreator: Boolean): Boolean = false
 
   def isPending(currentStep: WorkflowNodeId): Boolean = false
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/workflows/SelfValidationAuthorTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/workflows/SelfValidationAuthorTest.scala
@@ -1,0 +1,90 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.services.workflows
+
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.Rights
+import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.domain.workflows.ChangeRequestInfo
+import com.normation.rudder.domain.workflows.RollbackChangeRequest
+import com.normation.rudder.facts.nodes.NodeSecurityContext
+import com.normation.rudder.users.AuthenticatedUser
+import com.normation.rudder.users.RudderAccount
+import com.normation.rudder.users.UserPassword
+import org.junit.runner.RunWith
+import zio.*
+import zio.test.*
+import zio.test.junit.ZTestJUnitRunner
+
+/*
+ * Test the logic for single owner-vs-user mapping → Author/NotAuthor
+ * https://issues.rudder.io/issues/29241 and https://issues.rudder.io/issues/29240
+ */
+@RunWith(classOf[ZTestJUnitRunner])
+class SelfValidationAuthorTest extends ZIOSpecDefault {
+
+  // an authenticated user granted exactly `granted`; `name` is what a change request `owner` is matched against
+  private def userWith(granted: Set[AuthorizationType], userLogin: String): AuthenticatedUser = {
+    new AuthenticatedUser {
+      override val account:   RudderAccount       = RudderAccount.User(userLogin, UserPassword.fromSecret("pwd"))
+      override val authz:     Rights              = Rights.AnyRights
+      override val apiAuthz:  ApiAuthorization    = ApiAuthorization.RW
+      override val nodePerms: NodeSecurityContext = NodeSecurityContext.All
+
+      override def checkRights(auth: AuthorizationType): Boolean = granted.contains(auth)
+    }
+  }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] = suite("self-validation / self-deployment control")(
+    // ---------------------------------------------------------------------------------------
+    // how authorship is derived: ChangeRequestAuthorship.of compares the change
+    // request owner to the acting user's name (the single place holding that logic).
+    // ---------------------------------------------------------------------------------------
+    suite("F - ChangeRequestAuthorship.of maps (change request, user) to authorship")(
+      test("the change request owner is the acting user -> Author") {
+        val cr = RollbackChangeRequest(ChangeRequestId(1), None, ChangeRequestInfo("cr", "desc"), owner = "alice")
+        assertTrue(ChangeRequestAuthorship.of(cr, userWith(Set.empty, userLogin = "alice")) == ChangeRequestAuthorship.Author)
+      },
+      test("the change request owner is someone else -> NotAuthor") {
+        val cr = RollbackChangeRequest(ChangeRequestId(1), None, ChangeRequestInfo("cr", "desc"), owner = "alice")
+        assertTrue(ChangeRequestAuthorship.of(cr, userWith(Set.empty, userLogin = "bob")) == ChangeRequestAuthorship.NotAuthor)
+      }
+    )
+  )
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/29241

So, the parameter `isCreator` was removed at some point in a refactoring, deleting the corresponding behavior. 
I reintroduced the parameter, taking the opportunity to switch it from a `Boolean` to an enum to follow my own review comments. 

I deleted the `isEditable` method because it looks like dead code for years, and I didn't find it used anywhere. 
