### PR TITLE
Fixes #29257: Missing usage of fragments in JDBC repository

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepositoryImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepositoryImpl.scala
@@ -175,13 +175,13 @@ final case class RoReportsExecutionRepositoryImpl(
 
     val batchedNodeConfigIds = nodeIds.grouped(jdbcMaxBatchSize).toSeq
     ZIO.foreach(batchedNodeConfigIds) { (ids: Set[NodeId]) =>
-      // map node id to // ('node-id') // to use in values
-      ids.map(id => s"('${id.value}')").toList match {
+      ids.toList match {
         case Nil   => Map[NodeId, Option[AgentRunWithNodeConfig]]().succeed
         case nodes =>
           // we can't use "Fragments.in", because of: https://github.com/tpolecat/doobie/issues/426
           // so we use:
           //  SELECT * FROM table where nodeid in (VALUES (a), (b), ...here some thousands more...)
+          // node ids are bound as parameters (VALUES list) to prevent SQL injection
 
           val innerFromFrag = (
             fr"""from (
@@ -190,7 +190,7 @@ final case class RoReportsExecutionRepositoryImpl(
                       select nodeid, max(insertionid) as insertionid
                         from reportsexecution
                         where nodeid in """ ++
-              Fragment.const(s"""(values ${nodes.mkString(",")} )""") ++
+              (fr0"(values " ++ pgInClause.valuesClause(nodes.map(_.value)) ++ fr0" )") ++
               fr"""
                         GROUP BY nodeid
                      )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.repository.jdbc
 
+import cats.data.NonEmptyList
 import cats.free.Free
 import cats.implicits.*
 import com.normation.errors.IOResult
@@ -67,34 +68,40 @@ class PostgresqlInClause(
     // see link below
     val inClauseMaxNbElt: Int
 ) {
+  import cats.implicits.*
+  import doobie.*
+  import doobie.implicits.*
+
   /*
-   * Build a clause to match if the given attribute is in the given list of values.
+   * Build a fragment matching if the given attribute is in the given list of values.
    *
-   * Try to be as efficient as possible for postgres. TODO: check VALUES; ARRAY
+   * All values are bound as SQL parameters (never string-interpolated), so this is safe
+   * against SQL injection. The `attribute` is a caller-provided, trusted column fragment.
    *
+   * Try to be as efficient as possible for postgres.
    * http://postgres.cz/wiki/PostgreSQL_SQL_Tricks_I#Predicate_IN_optimalization
    *
-   * Does not build anything is the list of values is empty
-   *
+   * Builds Fragment.empty if the list of values is empty.
    *
    * NOTE: do not use that on arrays with "generate_subscripts", this is highly inefficient.
    * See http://www.rudder-project.org/redmine/issues/8057 for details.
-   *
    */
-  def in(attribute: String, values: Iterable[String]): String = {
-    // with values, we need more ()
-    if (values.isEmpty) ""
-    else if (values.size < inClauseMaxNbElt) s"${attribute} IN (${values.mkString("'", "','", "'")})"
-    // use IN ( VALUES (), (), ... )
-    else s"${attribute} IN(VALUES ${values.mkString("('", "'),('", "')")})"
+  def in[A: Put](attribute: Fragment, values: Iterable[A]): Fragment = {
+    values.toList.toNel match {
+      case None                                     => Fragment.empty
+      // small list: attribute IN (?, ?, ...)
+      case Some(nel) if nel.size < inClauseMaxNbElt => Fragments.in(attribute, nel)
+      // large list: attribute IN (VALUES (?), (?), ...)
+      case Some(nel)                                => attribute ++ fr0" IN (VALUES " ++ valuesClause(nel.toList) ++ fr0")"
+    }
   }
 
-  def inNumber(attribute: String, values: Iterable[AnyVal]): String = {
-    // with values, we need more ()
-    if (values.isEmpty) ""
-    else if (values.size < inClauseMaxNbElt) s"${attribute} IN (${values.mkString("", ",", "")})"
-    // use IN ( VALUES (), (), ... )
-    else s"${attribute} IN(VALUES ${values.mkString("(", "),(", ")")})"
+  /*
+   * Build a parameterized single-column `(?), (?), ...` values list. Values are bound as
+   * parameters (never string-interpolated). Callers guarantee the collection is non-empty.
+   */
+  def valuesClause[A: Put](values: Iterable[A]): Fragment = {
+    values.toList.map(v => Fragments.parentheses(fr"$v")).intercalate(fr",")
   }
 }
 
@@ -120,15 +127,15 @@ class FindExpectedReportsJdbcRepository(
       ids.toList match { // "in" param can't be empty
         case Nil        => Full(Seq())
         case nodeAndIds =>
+          // (nodeid, nodeconfigid) pairs are bound as parameters to prevent SQL injection
+          val pairs = NonEmptyList.fromListUnsafe(nodeAndIds.map(x => (x.nodeId.value, x.version.value)))
           transactRunBox(xa => {
             (for {
-              configs <- query[Either[(NodeId, NodeConfigId, DateTime), NodeExpectedReports]](s"""
-                       select nodeid, nodeconfigid, begindate, enddate, configuration
-                       from nodeconfigurations
-                       where (nodeid, nodeconfigid) in (${nodeAndIds
-                             .map(x => s"('${x.nodeId.value}','${x.version.value}')")
-                             .mkString(",")} )
-                     """).to[Vector]
+              configs <- (fr"""select nodeid, nodeconfigid, begindate, enddate, configuration
+                       from nodeconfigurations where""" ++
+                         Fragments.in(fr"(nodeid, nodeconfigid)", pairs))
+                           .query[Either[(NodeId, NodeConfigId, DateTime), NodeExpectedReports]]
+                           .to[Vector]
             } yield {
               val configsMap = (configs.flatMap {
                 case Left((id, c, _)) =>
@@ -160,7 +167,8 @@ class FindExpectedReportsJdbcRepository(
         transactRunBox(xa => {
           (for {
             configs <-
-              (Fragment.const(s"with tempnodeid (id) as (values ${batchedIds.map(x => s"('${x.value}')").mkString(",")})") ++
+              // node ids are bound as parameters (VALUES list) to prevent SQL injection
+              (fr0"with tempnodeid (id) as (values " ++ valuesClause(batchedIds.map(_.value)) ++ fr0")" ++
               fr"""
                        select nodeid, nodeconfigid, begindate, enddate, configuration
                        from nodeconfigurations
@@ -199,11 +207,11 @@ class FindExpectedReportsJdbcRepository(
   override def findCurrentNodeIdsForRule(ruleId: RuleId, nodeIds: Set[NodeId]): IOResult[Set[NodeId]] = {
     if (nodeIds.isEmpty) Set.empty[NodeId].succeed
     else {
-      transactIOResult(s"Error when getting nodes for rule '${ruleId.serialize}' from expected reports")(xa => sql"""
-        select distinct nodeid from nodeconfigurations
-        where enddate is null and configuration like ${"%" + ruleId.serialize + "%"}
-        and nodeid in (${nodeIds.map(id => s"'${id}'").mkString(",")})
-      """.query[NodeId].to[Set].transact(xa))
+      transactIOResult(s"Error when getting nodes for rule '${ruleId.serialize}' from expected reports")(xa => {
+        (fr"""select distinct nodeid from nodeconfigurations
+              where enddate is null and configuration like ${"%" + ruleId.serialize + "%"} and""" ++
+        in(fr"nodeid", nodeIds)).query[NodeId].to[Set].transact(xa)
+      })
     }
   }
 
@@ -214,11 +222,11 @@ class FindExpectedReportsJdbcRepository(
   override def findCurrentNodeIdsForDirective(directiveId: DirectiveId, nodeIds: Set[NodeId]): IOResult[Set[NodeId]] = {
     if (nodeIds.isEmpty) Set.empty[NodeId].succeed
     else {
-      transactIOResult(s"Error when getting nodes for directive '${directiveId.serialize}' from expected reports")(xa => sql"""
-        select distinct nodeid from nodeconfigurations
-        where enddate is null and configuration like ${"%" + directiveId.serialize + "%"}
-        and nodeid in (${nodeIds.map(id => s"'${id}'").mkString(",")})
-      """.query[NodeId].to[Set].transact(xa))
+      transactIOResult(s"Error when getting nodes for directive '${directiveId.serialize}' from expected reports")(xa => {
+        (fr"""select distinct nodeid from nodeconfigurations
+              where enddate is null and configuration like ${"%" + directiveId.serialize + "%"} and""" ++
+        in(fr"nodeid", nodeIds)).query[NodeId].to[Set].transact(xa)
+      })
     }
   }
   override def findCurrentNodeIdsForDirective(directiveId: DirectiveId):                       IOResult[Set[NodeId]] = {
@@ -239,8 +247,8 @@ class FindExpectedReportsJdbcRepository(
         .foreach(batchedNodesId) { (ids: Set[NodeId]) =>
           transactIOResult(s"Error when querying NodeConfigIdInfo") { xa =>
             (for {
-              entries <- query[(NodeId, String)](s"""select node_id, config_ids from nodes_info
-                                              where ${in("node_id", ids.map(_.value))}""").to[Vector]
+              entries <- (fr"select node_id, config_ids from nodes_info where" ++
+                         in(fr"node_id", ids)).query[(NodeId, String)].to[Vector]
             } yield {
               val res = entries.map { case (nodeId, config) => (nodeId, NodeConfigIdSerializer.unserialize(config)) }.toMap
               ids.map(n => (n, res.get(n)))
@@ -282,9 +290,9 @@ class UpdateExpectedReportsJdbcRepository(
         val batchedConfigs:               List[List[NodeExpectedReports]]                                                   = neConfigs.grouped(jdbcMaxBatchSize).toList
         val resultingNodeExpectedReports: Either[Throwable, List[Free[connection.ConnectionOp, List[NodeExpectedReports]]]] = {
           batchedConfigs.traverse { (conf: Seq[NodeExpectedReports]) =>
-            val confString = conf.map(x => s"('${x.nodeId.value}')")
-
-            val withFrag = Fragment.const(s"with tempnodeid (id) as (values ${confString.mkString(",")})")
+            // node ids are bound as parameters (VALUES list) to prevent SQL injection
+            val withFrag = fr0"with tempnodeid (id) as (values " ++
+              pgInClause.valuesClause(conf.map(_.nodeId.value)) ++ fr0")"
             type A = Either[(NodeId, NodeConfigId, DateTime), NodeExpectedReports]
             val getConfigs: Either[Throwable, List[A]] = transactRunEither(xa => {
               (

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -467,15 +467,18 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
       interval: Interval,
       limit:    Option[Int]
   ): Box[Seq[ResultRepairedReport]] = {
-    val l = limit match {
-      case Some(i) if (i > 0) => s"limit ${i}"
-      case _                  => ""
+    val limitFr = limit match {
+      case Some(i) if (i > 0) => fr"limit ${i}"
+      case _                  => Fragment.empty
     }
-    transactRunBox(xa => query[ResultRepairedReport](s"""
-      ${typedQuery} and eventtype='${Reports.RESULT_REPAIRED}' and ruleid='${ruleId.serialize}'
-      and executionTimeStamp >  '${new Timestamp(interval.getStartMillis)}'::timestamp
-      and executionTimeStamp <= '${new Timestamp(interval.getEndMillis)}'::timestamp order by executionTimeStamp asc ${l}
-    """).to[Vector].transact(xa))
+    // typedQuery is a trusted constant; all runtime values are bound as parameters to prevent SQL injection
+    val start   = new DateTime(interval.getStartMillis)
+    val end     = new DateTime(interval.getEndMillis)
+    val q       = Fragment.const(typedQuery) ++
+      fr"and eventtype = ${Reports.RESULT_REPAIRED} and ruleid = ${ruleId}" ++
+      fr"and executionTimeStamp >  ${start} and executionTimeStamp <= ${end}" ++
+      fr"order by executionTimeStamp asc" ++ limitFr
+    transactRunBox(xa => q.query[ResultRepairedReport].to[Vector].transact(xa))
   }
 
   override def getReportsByKindBetween(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -188,8 +188,10 @@ class InventoryHistoryJdbcRepository(
 
   // delete all facts which have a delete event older than given data
   def deleteFactIfDeleteEventBefore(date: DateTime): IOResult[Vector[NodeId]] = {
+    // the date is stored as an ISO-8601 UTC string (see DateFormaterService.serialize), so cast it to
+    // timestamptz and compare instants: this is independent of the JVM/PostgreSQL session time zone.
     val q = sql"""delete from nodefacts
-           where to_timestamp(deleteEvent->>'date', 'YYYY-MM-DDTHH:MI:SS"Z"') < ${date}
+           where (deleteEvent->>'date')::timestamptz < ${date}
            returning nodeid"""
 
     transactIOResult(
@@ -200,11 +202,11 @@ class InventoryHistoryJdbcRepository(
   }
 
   // delete all facts which were created before given data (whatever node current status)
-  // Postgresql has a "returning id" clause, but it does not seems to be supported by JDBC. It
-  // would have been good for logs
+  // the "returning nodeid" clause gives back the list of deleted node ids (useful for logs)
   def deleteFactCreatedBefore(date: DateTime): IOResult[Vector[NodeId]] = {
+    // see deleteFactIfDeleteEventBefore: compare instants via timestamptz to stay time-zone independent
     val q = sql"""delete from nodefacts
-         where to_timestamp(acceptRefuseEvent->>'date', 'YYYY-MM-DDTHH:MI:SS"Z"') < ${date}
+         where (acceptRefuseEvent->>'date')::timestamptz < ${date}
          returning nodeid"""
 
     transactIOResult(

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateNodeAcceptationInventories.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateNodeAcceptationInventories.scala
@@ -269,7 +269,9 @@ trait TestMigrateNodeAcceptationInventories extends Specification with AfterAll 
     (testFactLog.get(nodeId, d).either.runNow must beRight)
   }
 
-  // THIS IS SKIPPED, see at the end of block
+  // All dates below use explicit offsets and all comparisons are instant-based (see
+  // InventoryHistoryJdbcRepository delete queries and DateFormaterService.serialize which stores UTC),
+  // so this whole spec is deterministic whatever the machine/JVM time zone.
   "A full migration" should {
 
     // init; copy test data in src/test/resources/historical-inventories to testDir.
@@ -290,8 +292,8 @@ trait TestMigrateNodeAcceptationInventories extends Specification with AfterAll 
 
     "ignore deleted nodes too old, even with old file format, without error" in {
       val ids = testFactLog.getIds.runNow
-      (ids must contain(be_!=(NodeId("0afa1d13-d125-4c91-9d71-24c47dc867e9")))) and
-      (ids must contain(be_!=(NodeId("fb0096f4-a928-454d-9776-e8079d48cdd8"))))
+      (ids must not(contain(be_==(NodeId("0afa1d13-d125-4c91-9d71-24c47dc867e9"))))) and
+      (ids must not(contain(be_==(NodeId("fb0096f4-a928-454d-9776-e8079d48cdd8")))))
     }
 
     "migrate deleted node when its event date is less than MAX_KEEP_DELETED" in {
@@ -301,8 +303,6 @@ trait TestMigrateNodeAcceptationInventories extends Specification with AfterAll 
     "historical directory is empty" in {
       File(fileLog.rootDir).list.toList === Nil
     }
-
-    skipped("The migration is a 8.0 one, running it in another timezone will make it fail")
   }
 
   "If a new log is provided latter on, for ex after a reboot, then node history is updated" >> {


### PR DESCRIPTION
https://issues.rudder.io/issues/29257

Add fragments where there was string concatenation and the transformation looked safe and not too hard. 

Alse, we had a test failing on some time zone. The cause seems to be the incorrect usage of `to_timestamp` with a date format that is not understood by PG as an UTC one. Using `::timestamptz` should make it works everywhere. 

At least here, all PG tests pass. 