### PR TITLE
Fixes #29222: Export Group compliance by Node to CSV

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/groups/global-compliance-by-node-id.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/global-compliance-by-node-id.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/global/byNode'

--- a/webapp/sources/api-doc/code_samples/curl/groups/targeted-compliance-by-node-id.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/targeted-compliance-by-node-id.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316/compliance/targeted/byNode'

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -323,6 +323,10 @@ paths:
     $ref: paths/groups/global-compliance-by-rule-id.yml
   "/groups/{targetOrNodeGroupId}/compliance/targeted/byRule":
     $ref: paths/groups/targeted-compliance-by-rule-id.yml
+  "/groups/{targetOrNodeGroupId}/compliance/global/byNode":
+    $ref: paths/groups/global-compliance-by-node-id.yml
+  "/groups/{targetOrNodeGroupId}/compliance/targeted/byNode":
+    $ref: paths/groups/targeted-compliance-by-node-id.yml
   "/directives":
     $ref: paths/directives/all.yml
   "/directives/{directiveId}":

--- a/webapp/sources/api-doc/paths/groups/global-compliance-by-node-id.yml
+++ b/webapp/sources/api-doc/paths/groups/global-compliance-by-node-id.yml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2026 Normation SAS
+get:
+  summary: Global compliance details of a group by node
+  description: Get compliance results for all rules that apply to a node within the group, sorted by node
+  operationId: getGlobalNodeGroupComplianceByNodeId
+  parameters:
+    - in: query
+      name: format
+      schema:
+        type: string
+        enum:
+          - csv
+          - json
+        default: json
+      description: format of export
+      style: form
+      explode: false
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getGlobalNodeGroupComplianceByNodeId
+              data:
+                type: object
+                required:
+                  - nodes
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/group-node-compliance.yml
+        text/plain:
+          schema:
+            type: string
+          example: |
+                "Node","Rule","Directive","Block","Component","Value","Status","Message"
+                "node1.localhost","R1","25. Testing blocks","","directive-techniqueWithBlocks-component-r1-n1","directive-techniqueWithBlocks-component-value-r1-n1","successAlreadyOK",""
+                "node1.localhost","R2","directive 99f4ef91-537b-4e03-97bc-e65b447514cc","","99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1","99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1","successRepaired",""
+                "node1.localhost","R3","directive2","","directive2-component-r3-n1","directive2-component-value-r3-n1","error",""
+
+    "500":
+      description: Group id does not exist
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - action
+              - result
+              - errorDetails
+            properties:
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getGlobalNodeGroupComplianceByNodeId
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - error
+              errorDetails:
+                type: string
+                description: Details of the error
+                example: "Node group with id 'myGroupId' not found"
+  tags:
+    - Groups
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/groups/global-compliance-by-node-id.sh
+
+

--- a/webapp/sources/api-doc/paths/groups/global-compliance-by-rule-id.yml
+++ b/webapp/sources/api-doc/paths/groups/global-compliance-by-rule-id.yml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2013-2026 Normation SAS
 get:
   summary: Global compliance details of a group by rule
-  description: Get global compliance of a group with all rules that apply to a node within the group, sorted by rule
+  description: Get compliance results for all rules that apply to a node within the group, sorted by rule
   operationId: getGlobalNodeGroupComplianceByRuleId
   parameters:
     - in: query

--- a/webapp/sources/api-doc/paths/groups/targeted-compliance-by-node-id.yml
+++ b/webapp/sources/api-doc/paths/groups/targeted-compliance-by-node-id.yml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2026 Normation SAS
+get:
+  summary: Targeted compliance details of a group by node
+  description: Get compliance results for rules that explicitly target the group, sorted by node
+  operationId: getTargetedNodeGroupComplianceByNodeId
+  parameters:
+    - in: query
+      name: format
+      schema:
+        type: string
+        enum:
+          - csv
+          - json
+        default: json
+      description: format of export
+      style: form
+      explode: false
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getTargetedNodeGroupComplianceByNodeId
+              data:
+                type: object
+                required:
+                  - nodes
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/group-node-compliance.yml
+        text/plain:
+          schema:
+            type: string
+          example: |
+                "Node","Rule","Directive","Block","Component","Value","Status","Message"
+                "node1.localhost","R3","directive2","","directive2-component-r3-n1","directive2-component-value-r3-n1","error",""
+
+
+    "500":
+      description: Group id does not exist
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - action
+              - result
+              - errorDetails
+            properties:
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getTargetedNodeGroupComplianceByNodeId
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - error
+              errorDetails:
+                type: string
+                description: Details of the error
+                example: "Node group with id 'myGroupId' not found"
+
+  tags:
+    - Groups
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/groups/targeted-compliance-by-node-id.sh
+
+

--- a/webapp/sources/api-doc/paths/groups/targeted-compliance-by-rule-id.yml
+++ b/webapp/sources/api-doc/paths/groups/targeted-compliance-by-rule-id.yml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2013-2026 Normation SAS
 get:
   summary: Targeted compliance details of a group by rule
-  description: Get targeted compliance of a group with only rules that explicitly include the group, sorted by rule
+  description: Get compliance results for rules that explicitly target the group, sorted by rule
   operationId: getTargetedNodeGroupComplianceByRuleId
   parameters:
     - in: query

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -403,6 +403,22 @@ object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
     override def dataContainer: Option[String]          = Some("rules")
     val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
   }
+  case object GetGlobalNodeGroupComplianceByNodeId
+      extends GroupApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Get a node group's global compliance by rule"
+    val (action, path) = GET / "groups" / "{id}" / "compliance" / "global" / "byNode"
+    override def dataContainer: Option[String]          = Some("nodes")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+  case object GetTargetedNodeGroupComplianceByNodeId
+      extends GroupApi with GeneralApi with OneParam with StartsAtVersion24 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Get a node group's targeted compliance by rule"
+    val (action, path) = GET / "groups" / "{id}" / "compliance" / "targeted" / "byNode"
+    override def dataContainer: Option[String]          = Some("nodes")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
 
   def endpoints: List[GroupApi] = values.toList.sortBy(_.z)
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -464,8 +464,8 @@ object CsvCompliance {
   val csvFormat: CSVFormat = CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).setRecordSeparator("\n").get()
 
   private def recurseComponent(
-      component: ByRuleComponentCompliance,
-      block:     List[ComponentField]
+      component:        ByRuleComponentCompliance,
+      blockAccumulator: List[ComponentField]
   ): Seq[RuleComponentResult] = {
 
     component match {
@@ -474,7 +474,7 @@ object CsvCompliance {
           node.values.flatMap { value =>
             value.messages.map { report =>
               (
-                BlockField(block),
+                BlockField(blockAccumulator),
                 ComponentField(component),
                 NodeField(node),
                 ValueField(value),
@@ -485,13 +485,13 @@ object CsvCompliance {
           }
         }
       case component: ByRuleBlockCompliance =>
-        component.subComponents.flatMap(c => recurseComponent(c, block ::: (ComponentField(component) :: Nil)))
+        component.subComponents.flatMap(c => recurseComponent(c, blockAccumulator ::: (ComponentField(component) :: Nil)))
     }
   }
 
   private def recurseComponent(
-      component: ByRuleByNodeByDirectiveByComponentCompliance,
-      block:     List[ComponentField]
+      component:        ByRuleByNodeByDirectiveByComponentCompliance,
+      blockAccumulator: List[ComponentField]
   ): Seq[DirectiveComponentResult] = {
 
     component match {
@@ -499,7 +499,7 @@ object CsvCompliance {
         component.values.flatMap { value =>
           value.messages.map { report =>
             (
-              BlockField(block),
+              BlockField(blockAccumulator),
               ComponentField(component.componentName),
               ValueField(value),
               StatusField(report),
@@ -508,7 +508,36 @@ object CsvCompliance {
           }
         }
       case component: ByRuleByNodeByDirectiveByBlockCompliance =>
-        component.subComponents.flatMap(c => recurseComponent(c, block ::: (ComponentField(component.componentName) :: Nil)))
+        component.subComponents.flatMap(c =>
+          recurseComponent(c, blockAccumulator ::: (ComponentField(component.componentName) :: Nil))
+        )
+    }
+  }
+
+  private def recurseComponent(
+      component:        ComponentStatusReport,
+      blockAccumulator: List[ComponentField]
+  )(using ruleField: RuleField, directiveField: DirectiveField): Seq[NodeComplianceByRuleCsv] = {
+
+    component match {
+      case component: ValueStatusReport =>
+        component.componentValues.flatMap(value => {
+          value.messages.map { report =>
+            NodeComplianceByRuleCsv(
+              ruleField,
+              directiveField,
+              BlockField(blockAccumulator),
+              ComponentField(component.componentName),
+              ValueField(value),
+              StatusField(report),
+              MessageField(report)
+            )
+          }
+        })
+      case component: BlockStatusReport =>
+        component.subComponents.flatMap(c =>
+          recurseComponent(c, blockAccumulator ::: (ComponentField(component.componentName) :: Nil))
+        )
     }
   }
 
@@ -700,6 +729,44 @@ object CsvCompliance {
     }
   }
 
+  case class NodeGroupComplianceByNodeCsv(
+      node:      NodeField,
+      rule:      RuleField,
+      directive: DirectiveField,
+      block:     BlockField,
+      component: ComponentField,
+      value:     ValueField,
+      status:    StatusField,
+      message:   MessageField
+  ) derives Csv
+
+  object NodeGroupComplianceByNodeCsv {
+
+    given (using node: NodeField): Transformer[NodeComplianceByRuleCsv, NodeGroupComplianceByNodeCsv] = {
+      Transformer
+        .define[NodeComplianceByRuleCsv, NodeGroupComplianceByNodeCsv]
+        .withFieldConst(_.node, node)
+        .buildTransformer
+    }
+
+    given Transformer[Seq[ByNodeGroupNodeCompliance], Seq[NodeGroupComplianceByNodeCsv]] = {
+      (nodes: Seq[ByNodeGroupNodeCompliance]) =>
+        for {
+          node          <- nodes
+          rule          <- node.rules
+          directive     <- rule.directives
+          component     <- directive.components
+          ruleField      = RuleField(rule.name)
+          directiveField = DirectiveField(directive.name)
+          c             <- recurseComponent(component, Nil)(using ruleField, directiveField)
+        } yield {
+          given NodeField = NodeField(node.name)
+
+          c.transformInto[NodeGroupComplianceByNodeCsv]
+        }
+    }
+  }
+
   case class NodeComplianceByRuleCsv(
       rule:      RuleField,
       directive: DirectiveField,
@@ -711,42 +778,15 @@ object CsvCompliance {
   ) derives Csv
   object NodeComplianceByRuleCsv {
 
-    private def recurseComponent(
-        component: ComponentStatusReport,
-        block:     List[ComponentField]
-    )(using ruleField: RuleField, directiveField: DirectiveField): Seq[NodeComplianceByRuleCsv] = {
-
-      component match {
-        case component: ValueStatusReport =>
-          component.componentValues.flatMap(value => {
-            value.messages.map { report =>
-              NodeComplianceByRuleCsv(
-                ruleField,
-                directiveField,
-                BlockField(block),
-                ComponentField(component.componentName),
-                ValueField(value),
-                StatusField(report),
-                MessageField(report)
-              )
-            }
-          })
-        case component: BlockStatusReport =>
-          component.subComponents.flatMap(c => recurseComponent(c, block ::: (ComponentField(component.componentName) :: Nil)))
-      }
-    }
-
     given Transformer[Seq[ByNodeRuleCompliance], Seq[NodeComplianceByRuleCsv]] = { (rules: Seq[ByNodeRuleCompliance]) =>
-      rules.flatMap(rule => {
-        rule.directives.flatMap(directive => {
-          directive.components.flatMap(component => {
-            given RuleField      = RuleField(rule.name)
-            given DirectiveField = DirectiveField(directive.name)
-
-            recurseComponent(component, Nil)
-          })
-        })
-      })
+      for {
+        rule          <- rules
+        directive     <- rule.directives
+        ruleField      = RuleField(rule.name)
+        directiveField = DirectiveField(directive.name)
+        component     <- directive.components
+        c             <- recurseComponent(component, Nil)(using ruleField, directiveField)
+      } yield c
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -1119,7 +1119,7 @@ class ComplianceAPIService(
           case GroupTarget(nodeGroupId) =>
             nodeGroupRepo
               .getNodeGroupOpt(nodeGroupId)
-              .notOptional(s"Node group with id '${nodeGroupId.serialize}' not found'")
+              .notOptional(s"Node group with id '${nodeGroupId.serialize}' not found")
               .map(g => (g._1.id.serialize, g._1.name, g._1.serverList))
           case t: NonGroupRuleTarget =>
             nodeGroupRepo

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -64,6 +64,7 @@ import com.normation.rudder.rest.RudderJsonRequest.*
 import com.normation.rudder.rest.data.ComplianceApiData
 import com.normation.rudder.rest.data.ComplianceFormat
 import com.normation.rudder.rest.data.ComplianceUtils
+import com.normation.rudder.rest.data.CsvCompliance.NodeGroupComplianceByNodeCsv
 import com.normation.rudder.rest.data.CsvCompliance.NodeGroupComplianceByRuleCsv
 import com.normation.rudder.rest.syntax.*
 import com.normation.rudder.services.queries.CmdbQueryParser
@@ -118,6 +119,8 @@ class GroupsApi(
       case API.GetTargetedNodeGroupComplianceId       => GetTargetedNodeGroupComplianceId
       case API.GetGlobalNodeGroupComplianceByRuleId   => GetGlobalNodeGroupComplianceByRuleId
       case API.GetTargetedNodeGroupComplianceByRuleId => GetTargetedNodeGroupComplianceByRuleId
+      case API.GetGlobalNodeGroupComplianceByNodeId   => GetGlobalNodeGroupComplianceByNodeId
+      case API.GetTargetedNodeGroupComplianceByNodeId => GetTargetedNodeGroupComplianceByNodeId
     }
   }
 
@@ -570,6 +573,38 @@ class GroupsApi(
     }
   }
 
+  private def getNodeGroupComplianceByNodeId(groupId: String, req: Req, params: DefaultParams, isGlobalCompliance: Boolean)(using
+      qc:     QueryContext,
+      schema: OneParam
+  ): LiftResponse = {
+    (for {
+      level     <- ComplianceUtils.extractComplianceLevel(req.params)
+      precision <- ComplianceUtils.extractPercentPrecision(req.params)
+      format    <- ComplianceUtils.extractComplianceFormat(req.params)
+      target    <- ComplianceUtils
+                     .parseSimpleTargetOrNodeGroupId(groupId)
+                     .toIO
+      group     <- complianceService.getNodeGroupCompliance(target, level, isGlobalCompliance)
+    } yield (level, precision, format, group)).toLiftResponseGeneric(params, schema, IdTrace.Const(None)) {
+      (level, precision, format, group) =>
+        format match {
+          case ComplianceFormat.CSV  =>
+            PlainTextResponse(group.nodes.transformInto[Seq[NodeGroupComplianceByNodeCsv]].toCsv)
+          case ComplianceFormat.JSON =>
+            given l: Int                 = level.getOrElse(10)
+            given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+            given f: Boolean             = params.prettify
+
+            val complianceJson = group
+              .transformInto[ComplianceApiData.JsonByNodeGroupCompliance.ByNodeGroupComplianceApi]
+              .nodes
+              .getOrElse(Seq.empty)
+              .toList
+            RudderJsonResponse.successList(RudderJsonResponse.toResponseSchema(schema), complianceJson)
+        }
+    }
+  }
+
   object GetGlobalNodeGroupComplianceByRuleId extends LiftApiModule {
     override val schema: OneParam = API.GetGlobalNodeGroupComplianceByRuleId
 
@@ -606,6 +641,43 @@ class GroupsApi(
       getNodeGroupComplianceByRuleId(groupId, req, params, isGlobalCompliance = false)
     }
 
+  }
+
+  object GetGlobalNodeGroupComplianceByNodeId extends LiftApiModule {
+    override val schema: OneParam = API.GetGlobalNodeGroupComplianceByNodeId
+
+    override def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        groupId:    String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+      given OneParam = schema
+
+      getNodeGroupComplianceByNodeId(groupId, req, params, isGlobalCompliance = true)
+    }
+
+  }
+
+  object GetTargetedNodeGroupComplianceByNodeId extends LiftApiModule {
+    override val schema: OneParam = API.GetTargetedNodeGroupComplianceByNodeId
+
+    override def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        groupId:    String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+      given OneParam = schema
+
+      getNodeGroupComplianceByNodeId(groupId, req, params, isGlobalCompliance = false)
+    }
   }
 
   // Extracts reason from the request and provide an (implicit ChangeContext)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -4004,6 +4004,268 @@ response:
   content: |
     "Rule","Directive","Block","Component","Node","Value","Status","Message"
     "R3","directive2","","directive2-component-r3-n1","node1.localhost","directive2-component-value-r3-n1","error",""
+---
+description: Get a node group's global compliance by node in JSON format
+method: GET
+url: /api/latest/groups/g3/compliance/global/byNode
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGlobalNodeGroupComplianceByNodeId",
+      "result" : "success",
+      "data" : {
+        "nodes" : [
+          {
+            "id" : "n1",
+            "name" : "node1.localhost",
+            "mode" : "full-compliance",
+            "compliance" : 66.66,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "successAlreadyOK" : 33.33,
+              "successRepaired" : 33.33,
+              "error" : 33.34
+            },
+            "rules" : [
+              {
+                "id" : "r1",
+                "name" : "R1",
+                "compliance" : 100.0,
+                "policyMode" : "audit",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive-techniqueWithBlocks",
+                    "name" : "25. Testing blocks",
+                    "compliance" : 100.0,
+                    "policyMode" : "audit",
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive-techniqueWithBlocks-component-r1-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
+                            "reports" : [
+                              {
+                                "status" : "successAlreadyOK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r2",
+                "name" : "R2",
+                "compliance" : 100.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "name" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "compliance" : 100.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                            "reports" : [
+                              {
+                                "status" : "successRepaired"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "directive2-component-value-r3-n1",
+                            "reports" : [
+                              {
+                                "status" : "error"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's global compliance by node for a nonexistent group
+method: GET
+url: /api/latest/groups/myGroup/compliance/global/byNode
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "getGlobalNodeGroupComplianceByNodeId",
+      "result" : "error",
+      "errorDetails" : "Node group with id 'myGroup' not found"
+    }
+---
+description: Get a node group's targeted compliance by node in JSON format
+method: GET
+url: /api/latest/groups/g3/compliance/targeted/byNode
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getTargetedNodeGroupComplianceByNodeId",
+      "result" : "success",
+      "data" : {
+        "nodes" : [
+          {
+            "id" : "n1",
+            "name" : "node1.localhost",
+            "mode" : "full-compliance",
+            "compliance" : 0.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "values" : [
+                          {
+                            "value" : "directive2-component-value-r3-n1",
+                            "reports" : [
+                              {
+                                "status" : "error"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's targeted compliance by node for a nonexistent group
+method: GET
+url: /api/latest/groups/myGroup/compliance/targeted/byNode
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "getTargetedNodeGroupComplianceByNodeId",
+      "result" : "error",
+      "errorDetails" : "Node group with id 'myGroup' not found"
+    }
+---
+description: Get a node group's global compliance by node in CSV format
+method: GET
+url: /api/latest/groups/g3/compliance/global/byNode
+params:
+  format: csv
+response:
+  code: 200
+  type: text
+  content: |
+    "Node","Rule","Directive","Block","Component","Value","Status","Message"
+    "node1.localhost","R1","25. Testing blocks","","directive-techniqueWithBlocks-component-r1-n1","directive-techniqueWithBlocks-component-value-r1-n1","successAlreadyOK",""
+    "node1.localhost","R2","directive 99f4ef91-537b-4e03-97bc-e65b447514cc","","99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1","99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1","successRepaired",""
+    "node1.localhost","R3","directive2","","directive2-component-r3-n1","directive2-component-value-r3-n1","error",""
+---
+description: Get a node group's targeted compliance by node in CSV format
+method: GET
+url: /api/latest/groups/g3/compliance/targeted/byNode
+params:
+  format: csv
+response:
+  code: 200
+  type: text
+  content: |
+    "Node","Rule","Directive","Block","Component","Value","Status","Message"
+    "node1.localhost","R3","directive2","","directive2-component-r3-n1","directive2-component-value-r3-n1","error",""
 
 #
 # API GROUPSINTERNAL

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ApiCalls.elm
@@ -92,3 +92,29 @@ getTargetedGroupComplianceByRuleCSV filename model =
         , timeout = Nothing
         , tracker = Nothing
         }
+
+
+getGlobalGroupComplianceByNodeCSV : String -> Model -> Cmd Msg
+getGlobalGroupComplianceByNodeCSV filename model =
+    request
+        { method = "GET"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = getUrl model [ "groups", model.groupId.value, "compliance", "global", "byNode" ] [ Url.Builder.string "format" "csv" ]
+        , body = emptyBody
+        , expect = expectString (RuleComplianceCsvExported filename)
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+getTargetedGroupComplianceByNodeCSV : String -> Model -> Cmd Msg
+getTargetedGroupComplianceByNodeCSV filename model =
+    request
+        { method = "GET"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = getUrl model [ "groups", model.groupId.value, "compliance", "targeted", "byNode" ] [ Url.Builder.string "format" "csv" ]
+        , body = emptyBody
+        , expect = expectString (RuleComplianceCsvExported filename)
+        , timeout = Nothing
+        , tracker = Nothing
+        }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
@@ -127,4 +127,5 @@ type Msg
     | LoadCompliance ComplianceScope
     | ExportCsv (Cmd Msg)
     | ExportGroupComplianceByRule GroupId ComplianceScope Date.Date
+    | ExportGroupComplianceByNode GroupId ComplianceScope Date.Date
     | RuleComplianceCsvExported String (Result Error String)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
@@ -487,7 +487,7 @@ filtersView model =
                     ExportGroupComplianceByRule model.groupId complianceScope
 
                 NodesView ->
-                    \_ -> Ignore
+                    ExportGroupComplianceByNode model.groupId complianceScope
     in
     div [ class "table-header extra-filters" ]
         [ div [ class "d-inline-flex align-items-baseline pb-3 w-25" ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
@@ -260,6 +260,32 @@ update msg model =
             in
             ( model, cmd )
 
+        ExportGroupComplianceByNode groupId complianceScope date ->
+            let
+                timeStr =
+                    date |> Date.format "yyyy-MM-dd"
+
+                scope =
+                    case complianceScope of
+                        GlobalCompliance ->
+                            "global"
+
+                        TargetedCompliance ->
+                            "targeted"
+
+                filename =
+                    "rudder_group_" ++ groupId.value ++ "_" ++ scope ++ "_compliance_by_node" ++ timeStr ++ ".csv"
+
+                cmd =
+                    case complianceScope of
+                        GlobalCompliance ->
+                            getGlobalGroupComplianceByNodeCSV filename model
+
+                        TargetedCompliance ->
+                            getTargetedGroupComplianceByNodeCSV filename model
+            in
+            ( model, cmd )
+
         RuleComplianceCsvExported filename result ->
             case result of
                 Ok content ->


### PR DESCRIPTION
https://issues.rudder.io/issues/29222

This PR aims to add an "Export to CSV" button to for both the "global" and "targeted" scopes in a Group's node compliance tab.

global : 
<img width="1132" height="454" alt="image" src="https://github.com/user-attachments/assets/14fb6d55-ed12-458c-bd77-05144519d802" />

targeted : 
<img width="1132" height="454" alt="image" src="https://github.com/user-attachments/assets/34b4c2ca-43af-42c6-a26a-d04539a2d2bf" />

commit history : 
1. implement new endpoints, i.e. `GET /groups/{groupId}/compliance/global/byNode` and `GET /groups/{groupId}/compliance/targeted/byNode` with a "format" query parameter for both, and add API tests for both the json and csv formats
2. add export button in elm in the "node compliance" tab of a group, for both the "global" and "targeted" scopes
3. update API documentation