### PR TITLE
Fixes #29260: Bump rudder-elm-library version to 0.2.5

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/elm-git.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/elm-git.json
@@ -1,7 +1,7 @@
 {
     "git-dependencies": {
         "direct": {
-            "https://github.com/Normation/rudder-elm-library.git": "0.2.4"
+            "https://github.com/Normation/rudder-elm-library.git": "0.2.5"
         },
         "indirect": {}
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/29260