### PR TITLE
Fixes #29272: Rudder 9.1.3 : Technique action menu opens mostly hidden by left pane

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
@@ -69,11 +69,9 @@
 .rudder-template ul.dropdown-menu {
   padding: 0;
   min-width: 170px;
-  margin-left: -75px;
 }
 .rudder-template ul.dropdown-menu.show {
-  right: -4px !important;
-  left: auto !important;
+  left: 0px !important;
 }
 
 .btn.btn-outline-success{


### PR DESCRIPTION
https://issues.rudder.io/issues/29272

## before
<img width="981" height="398" alt="image" src="https://github.com/user-attachments/assets/13443969-8db0-40ff-93ab-6245c1c849ec" />

## after
<img width="877" height="355" alt="image" src="https://github.com/user-attachments/assets/9786cbde-7834-4f84-a503-109155ec7852" />
