### PR TITLE
Fixes #29231: Add recent activity tab in group detail page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
@@ -1,0 +1,176 @@
+port module GroupRecentActivity exposing (..)
+
+import Activity.ApiCalls exposing (getActivities, processApiError)
+import Activity.DataTypes exposing (Activity, ActivityMsg(..), BodyParameters, ContextPath(..), Search, string2Search)
+import Activity.HtmlParserAdapter exposing (toHtml, toString)
+import Browser
+import Dict
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (class)
+import List.Nonempty as NonEmptyList
+import Ordering
+import Rudder.Table exposing (ColumnName(..), buildConfig, buildCustomizations, buildOptions, updateData)
+import Time exposing (Zone)
+import TimeZone
+import Utils.DateUtils exposing (posixToString)
+
+
+
+-- PORTS / SUBSCRIPTIONS
+
+
+port copy : String -> Cmd msg
+
+
+port errorNotification : String -> Cmd msg
+
+
+port initTooltips : String -> Cmd msg
+
+
+port clearTooltips : String -> Cmd msg
+
+
+type GroupId
+    = GroupId String
+
+
+type alias Model =
+    { groupId : GroupId
+    , activityTable : Rudder.Table.Model Activity Msg
+    , contextPath : ContextPath
+    , zone : Zone
+    }
+
+
+type Msg
+    = CallApi (Model -> Cmd Msg)
+    | RudderTableMsg (Rudder.Table.Msg Msg)
+    | ActivityMessage ActivityMsg
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.none
+
+
+
+-- default to global compliance
+
+
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
+
+table : Model -> Html Msg
+table model =
+    div [ class "main-table" ] [ Html.map RudderTableMsg (Rudder.Table.view model.activityTable) ]
+
+
+view : Model -> Html Msg
+view model =
+    table model
+
+
+initTable : Zone -> Rudder.Table.Model Activity Msg
+initTable timezone =
+    let
+        columns : NonEmptyList.Nonempty (Rudder.Table.Column Activity Msg)
+        columns =
+            NonEmptyList.Nonempty
+                { name = ColumnName "Id", renderHtml = .id >> String.fromInt >> text, ordering = Ordering.byField .id }
+                [ { name = ColumnName "Actor", renderHtml = .actor >> text, ordering = Ordering.byField .actor }
+                , { name = ColumnName "Description"
+                  , renderHtml = .description >> toHtml
+                  , ordering = Ordering.byField (.description >> toString)
+                  }
+                , { name = ColumnName "Date", renderHtml = .date >> posixToString timezone >> text, ordering = Ordering.byField (.date >> Time.posixToMillis) }
+                ]
+
+        config =
+            buildConfig.newConfig columns
+                |> buildConfig.withOptions
+                    (buildOptions.newOptions
+                        |> buildOptions.withCustomizations
+                            (buildCustomizations.newCustomizations
+                                |> buildCustomizations.withTableContainerAttrs [ class "table-container" ]
+                                |> buildCustomizations.withTableAttrs [ class "no-footer dataTable" ]
+                            )
+                    )
+    in
+    Rudder.Table.init config []
+
+
+init :
+    { groupId : String
+    , contextPath : String
+    , timeZone : String
+    }
+    -> ( Model, Cmd Msg )
+init flags =
+    let
+        initTimeZone =
+            Dict.get flags.timeZone TimeZone.zones
+                |> Maybe.withDefault (\() -> Time.utc)
+
+        zone =
+            initTimeZone ()
+
+        initModel =
+            Model (GroupId flags.groupId) (initTable zone) (ContextPath flags.contextPath) zone
+
+        bodyParameters : BodyParameters
+        bodyParameters =
+            { search = string2Search flags.groupId
+
+            -- Keep only groups activity filtering on event log types
+            , filterTypes = [ "NodeGroupAdded", "NodeGroupDeleted", "NodeGroupModified" ]
+            }
+
+        initActions =
+            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath) ]
+    in
+    ( initModel, Cmd.batch initActions )
+
+
+
+--
+-- update loop --
+--
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        CallApi call ->
+            ( model, call model )
+
+        RudderTableMsg m ->
+            let
+                ( activityTable, tableMsg, _ ) =
+                    Rudder.Table.update m model.activityTable
+            in
+            ( { model | activityTable = activityTable }, tableMsg )
+
+        ActivityMessage a ->
+            case a of
+                GetActivities res ->
+                    case res of
+                        -- Update table data
+                        Ok ( _, activities ) ->
+                            let
+                                updatedTable =
+                                    updateData activities model.activityTable
+                            in
+                            ( { model | activityTable = updatedTable }, Cmd.none )
+
+                        Err err ->
+                            ( model, processApiError "Getting activities list" err errorNotification )
+
+                CopyToClipboard s ->
+                    ( model, copy s )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -186,17 +186,20 @@ class NodeGroupForm(
 
     (nodeGroup match {
       case Left(target)                     =>
-        showFormTarget(target, allowCloning = false)(html) ++ showRelatedRulesTree(target) ++ showGroupCompliance(target.target)
+        showFormTarget(target, allowCloning = false)(html) ++ showRelatedRulesTree(target) ++ showGroupCompliance(
+          target.target
+        )
       case Right(group) if (group.isSystem) =>
         showFormTarget(GroupTarget(group.id), Some(group))(html) ++ showRelatedRulesTree(
           GroupTarget(group.id)
         ) ++ showGroupCompliance(
           group.id.uid.value
-        )
+        ) ++ showGroupRecentActivity(group.id.uid.value)
       case Right(group)                     =>
-        showFormNodeGroup(group)(html) ++ showRelatedRulesTree(GroupTarget(group.id)) ++ showGroupCompliance(
-          group.id.uid.value
-        )
+        showFormNodeGroup(group)(html) ++
+        showRelatedRulesTree(GroupTarget(group.id)) ++
+        showGroupCompliance(group.id.uid.value) ++
+        showGroupRecentActivity(group.id.uid.value)
     })
   }
 
@@ -267,6 +270,36 @@ class NodeGroupForm(
                  |$$("#complianceLinkTab").on("click", function (){
                  |  app.ports.loadCompliance.send(null);
                  |});
+                 |""".stripMargin)
+      )
+    )
+  }
+
+  private def showGroupRecentActivity(targetOrGroupIdStr: String): NodeSeq = {
+    Script(
+      OnLoad(
+        JsRaw(s"""
+                 |var main = document.getElementById("groupRecentActivityApp")
+                 |var initValues = {
+                 |  groupId : "${targetOrGroupIdStr}",
+                 |  contextPath : contextPath,
+                 |  timeZone :  localStorage.getItem('timeZone') ?? 'UTC'
+                 |};
+                 |var app = Elm.GroupRecentActivity.init({node: main, flags: initValues});
+                 |app.ports.errorNotification.subscribe(function(str) {
+                 |  createErrorNotification(str)
+                 |});
+                 |// Initialize tooltips
+                 |app.ports.initTooltips.subscribe(function(msg) {
+                 |  setTimeout(function(){
+                 |    initBsTooltips();
+                 |  }, 400);
+                 |});
+                 |// Clear tooltips
+                 |app.ports.clearTooltips.subscribe(function(msg) {
+                 |  removeBsTooltips();
+                 |});
+                 |
                  |""".stripMargin)
       )
     )
@@ -431,6 +464,9 @@ class NodeGroupForm(
                            </li>
                            <li class="nav-item">
                              <button id="complianceLinkTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#groupComplianceTab" type="button" role="tab" aria-controls="groupComplianceTab" aria-selected="false">Compliance</button>
+                           </li>
+                           <li class="nav-item">
+                             <button id="recentActivityLinkTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#groupRecentActivityTab" type="button" role="tab" aria-controls="groupRecentActivityTab" aria-selected="false">Recent activity</button>
                            </li>
                          </ul>
     & "group-rudderid" #> <div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -5,6 +5,7 @@
   <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-groups.css"/>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-groupcompliance.js"></script>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-grouprelatedrules.js"></script>
+    <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-grouprecentactivity.js"></script>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-groups.js"></script>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-nodeproperties.js"></script>
   <script data-lift="with-nonce">

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -68,6 +68,9 @@
       <li class="nav-item">
         <button id="complianceLinkTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#groupComplianceTab" type="button" role="tab" aria-controls="groupComplianceTab" aria-selected="false">Compliance</button>
       </li>
+      <li class="nav-item">
+          <button id="recentActivityLinkTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#groupRecentActivityTab" type="button" role="tab" aria-controls="groupRecentActivityTab" aria-selected="false">Recent activity</button>
+      </li>
     </ul>
   </div>
   <div class="main-details">
@@ -109,6 +112,9 @@
       </div>
       <div id="groupComplianceTab" class="tab-pane main-form">
         <div id="groupComplianceApp"></div>
+      </div>
+      <div id="groupRecentActivityTab" class="tab-pane main-form">
+        <div id="groupRecentActivityApp"></div>
       </div>
       <div id="groupCriteriaTab" class="tab-pane main-form">
       <group-static></group-static>


### PR DESCRIPTION
https://issues.rudder.io/issues/29231

Depend on https://github.com/Normation/rudder/pull/7304

Recent activity tab on group detail page.
<img width="2303" height="574" alt="Screenshot From 2026-07-17 11-43-54" src="https://github.com/user-attachments/assets/face206c-18ca-47ed-996c-37801a2903c7" />

