### PR TITLE
Fixes #29303: Bump to Rust 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.97.0
+      - uses: dtolnay/rust-toolchain@1.97.1
 
       - name: rudder-module-template tests
         run: make cargo-test PACKAGE=rudder-module-template

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ edition = "2024"
 homepage = "https://www.rudder.io"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/Normation/rudder"
+rust-version = "1.97.1"
 
 [profile.dev]
 # Disabling debug information speeds up builds a bunch,

--- a/policies/Dockerfile
+++ b/policies/Dockerfile
@@ -1,5 +1,5 @@
 # Debian trixie has a broken PowerShell dependency
-FROM rust:1.97.0-bookworm
+FROM rust:1.97.1-bookworm
 LABEL ci=rudder/policies/Dockerfile
 
 ARG USER_ID=1000

--- a/policies/agent.Dockerfile
+++ b/policies/agent.Dockerfile
@@ -1,5 +1,5 @@
 # bookwork to be compatible with both old and new APT APIs
-FROM rust:1.97.0-bookworm
+FROM rust:1.97.1-bookworm
 LABEL ci=rudder/policies/agent.Dockerfile
 
 ARG USER_ID=1000

--- a/relay/sources/relayd/Dockerfile
+++ b/relay/sources/relayd/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97.0-trixie
+FROM rust:1.97.1-trixie
 LABEL ci=rudder/relay/sources/relayd/Dockerfile
 
 ARG USER_ID=1000

--- a/relay/sources/rudder-package/Dockerfile
+++ b/relay/sources/rudder-package/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97.0-trixie
+FROM rust:1.97.1-trixie
 LABEL ci=rudder/relay/sources/rudder-package/Dockerfile
 
 ARG USER_ID=1000

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 targets = [ "x86_64-pc-windows-gnu" ]
 components = ["rustfmt", "clippy"]

--- a/sbom/Dockerfile
+++ b/sbom/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97.0-trixie
+FROM rust:1.97.1-trixie
 LABEL ci=rudder/policies/Dockerfile
 
 ARG USER_ID=1000


### PR DESCRIPTION
https://issues.rudder.io/issues/29303

better without miscompilation https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/
also add an epxlicit MSRV to state we only target the current version.