### PR TITLE
Fixes #29305: Target computation must take into account tenant

### DIFF
--- a/.claude/skills/rudder-scala/600-security-in-depth.md
+++ b/.claude/skills/rudder-scala/600-security-in-depth.md
@@ -33,6 +33,34 @@ type class to read/update it (see `HasSecurityTag[ActiveTechnique]` in
 - filter by scope in the repository/persistence layer (the right place to enforce —
   e.g. tenant-filtering proxy repositories), not only in the UI.
 
+### Node-id sets: always resolve against QueryContext-filtered facts
+
+Group `serverList`s (and anything derived from them: rule targets, campaign targets…)
+are **not** tenant-filtered and can also contain deleted nodes. Any node-id set
+returned to a user must therefore be **intersected with the facts visible in the
+caller's `QueryContext`**:
+
+- To resolve `RuleTarget`s into node ids, use `RuleTarget.getNodeIdsChunk` /
+  `RoNodeGroupRepository.getNodeIdsChunk` / `FullNodeGroupCategory.getNodeIds`. They
+  take a `NodeAndServerIds` (opaque pair of visible node ids + policy server ids,
+  `domain.nodes`): get it from `nodeFactRepository.getNodeAndServerIds()(qc)` (cheap,
+  policy servers are cached in the repository) or build it with
+  `NodeAndServerIds.fromFacts(snapshot)` from a generation snapshot — the helper
+  restricts its result to `.nodeIds`, so the qc does the tenant filtering.
+  **Get it once per request, before any loop on rules**, and **don't hand-roll target
+  resolution** (a `Set`-based duplicate of this helper existed until 9.1 and leaked
+  group members across tenants because it skipped that intersection; a
+  `Map[NodeId, Boolean]`-shaped API existed too and made every caller rebuild a full
+  map per rule — that's why there is only one implementation now).
+- A cache or repository populated under `QueryContext.systemQC` (e.g. score caches)
+  serves data for **all** tenants: its *read* methods must take `(implicit qc:
+  QueryContext)` and filter to qc-visible nodes before returning — in the
+  repository, not in each API handler (see `AggregatedBenchmarkScoreRepository` in
+  the security-benchmarks plugin).
+- Symmetrically, **maintenance/write paths** (cleaning caches, computing the node set
+  a policy applies to) must use `QueryContext.systemQC`, not the actor's qc — or a
+  tenant-limited actor would silently drop data of nodes they can't see.
+
 ## Lift snippets: get `QueryContext` safely (ADR 28452)
 
 A Lift snippet that needs the authenticated user / their tenants must obtain its

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeAndServerIds.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeAndServerIds.scala
@@ -1,0 +1,72 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.domain.nodes
+
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.facts.nodes.CoreNodeFact
+
+/*
+ * The set of node ids visible in the caller's context along with the ids of the
+ * policy servers (root and relays) among them. This is the information needed to
+ * resolve rule targets into node ids (see RuleTarget.getNodeIdsChunk), and the two
+ * sets are almost always used together.
+ *
+ * It is an opaque, zero-cost pair: build it with the named-argument `apply`, with
+ * `fromFacts` on a facts map (QueryContext-filtered repository view or generation
+ * snapshot), or get it directly from `NodeFactRepository.getNodeAndServerIds()`.
+ */
+opaque type NodeAndServerIds = (Set[NodeId], Set[NodeId])
+
+object NodeAndServerIds {
+
+  // prefer named arguments at call sites: both sets have the same type
+  def apply(nodeIds: Set[NodeId], serverIds: Set[NodeId]): NodeAndServerIds = (nodeIds, serverIds)
+
+  // build from a facts map: nodeFactRepository.getAll()(qc), a generation snapshot, ...
+  def fromFacts(facts: IterableOnce[(NodeId, CoreNodeFact)]): NodeAndServerIds = {
+    facts.iterator.foldLeft((Set.empty[NodeId], Set.empty[NodeId])) {
+      case ((nodes, servers), (id, fact)) =>
+        (nodes + id, if (fact.rudderSettings.isPolicyServer) servers + id else servers)
+    }
+  }
+
+  extension (x: NodeAndServerIds) {
+    def nodeIds:   Set[NodeId] = x._1
+    def serverIds: Set[NodeId] = x._2
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -41,6 +41,7 @@ import cats.syntax.bifunctor.*
 import cats.syntax.traverse.*
 import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.tenants.HasSecurityTag
@@ -49,7 +50,6 @@ import io.scalaland.chimney.Iso
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.syntax.*
 import net.liftweb.common.*
-import scala.collection.MapView
 import scala.util.matching.Regex
 import zio.Chunk
 import zio.interop.catz.chunkStdInstances
@@ -306,88 +306,38 @@ object RuleTarget extends Loggable {
 
   /**
    * Return all node ids that match the set of target.
-   * allNodes pair is: (nodeid, isPolicyServer)
-   */
-  def getNodeIds(
-      targets:          Set[RuleTarget],
-      allNodes:         Map[NodeId, Boolean /* isPolicyServer */ ],
-      groups:           Map[NodeGroupId, Set[NodeId]],
-      allNodesAreThere: Boolean = true // if we are working on a subset of node, set to false
-  ): Set[NodeId] = {
-
-    targets.toList.traverse {
-      case AllTarget                    => Left(allNodes.keySet.toSet)
-      case AllTargetExceptPolicyServers => Right(allNodes.collect { case (k, isPolicyServer) if (!isPolicyServer) => k }.toSet)
-      case AllPolicyServers             => Right(allNodes.collect { case (k, isPolicyServer) if (isPolicyServer) => k }.toSet)
-      case PolicyServerTarget(nodeId)   =>
-        if (allNodesAreThere) {
-          Right(Set(nodeId))
-        } else {
-          // nodeId may not be in allNodes
-          allNodes.keySet.contains(nodeId) match {
-            case true => Right(Set(nodeId))
-            case _    => Right(Set.empty)
-          }
-        }
-
-      // here, if we don't find the group, we consider it's an error in the
-      // target recording, but don't fail, just log it.
-      case GroupTarget(groupId)         =>
-        Right(groups.getOrElse(groupId, Set.empty))
-
-      case TargetIntersection(targets) =>
-        val nodeSets     = targets.map(t => getNodeIds(Set(t), allNodes, groups, allNodesAreThere))
-        // Compute the intersection of the sets of Nodes
-        val intersection = nodeSets.foldLeft(allNodes.keySet.toSet) {
-          case (currentIntersection, nodes) => currentIntersection.intersect(nodes)
-        }
-        Right(intersection)
-
-      case TargetUnion(targets) =>
-        val nodeSets = targets.map(t => getNodeIds(Set(t), allNodes, groups, allNodesAreThere))
-        // Compute the union of the sets of Nodes
-        val union    = nodeSets.foldLeft(Set[NodeId]()) { case (currentUnion, nodes) => currentUnion.union(nodes) }
-        Right(union)
-
-      case TargetExclusion(included, excluded) =>
-        // Compute the included Nodes
-        val includedNodes = getNodeIds(Set(included), allNodes, groups, allNodesAreThere)
-        // Compute the excluded Nodes
-        val excludedNodes = getNodeIds(Set(excluded), allNodes, groups, allNodesAreThere)
-        // Remove excluded nodes from included nodes
-        val result        = includedNodes -- excludedNodes
-        Right(result)
-    }.map(_.toSet.flatten).merge
-  }
-
-  /**
-   * Return all node ids that match the set of target.
-   * allNodes pair is: (nodeid, isPolicyServer)
+   * nodeAndServerIds carries the node ids the caller is allowed to see (they MUST
+   * already be filtered with the caller's QueryContext for the result to be
+   * tenant-safe - see NodeFactRepository.getNodeAndServerIds).
+   *
+   * Items in the returned chunk are unique.
    */
   def getNodeIdsChunk(
-      targets:  Set[RuleTarget],
-      allNodes: MapView[NodeId, Boolean /* isPolicyServer */ ],
-      groups:   Map[NodeGroupId, Chunk[NodeId]]
+      targets:          Set[RuleTarget],
+      groups:           Map[NodeGroupId, Chunk[NodeId]],
+      nodeAndServerIds: NodeAndServerIds
   ): Chunk[NodeId] = {
-    val result = getNodeIdsChunkRec(Chunk.fromIterable(targets), allNodes.toMap, groups)
-
-    // we always must intersect with the keySet of nodes, because sometime node ids in groups is a super set
-    // of the given allNodes, for ex!
-    // - for static group where some of the nodes were deleted,
-    // - when we have tenants (Rudder 8.1+=
-    Chunk.fromIterable(result.toSet.intersect(allNodes.keySet))
+    val result = getNodeIdsChunkRec(Chunk.fromIterable(targets), groups, nodeAndServerIds)
+    /*
+     * The result is always restricted to nodeAndServerIds.nodeIds, because node ids in
+     * groups can be a super set of it, for ex:
+     * - for static group where some of the nodes were deleted,
+     * - when the visible nodes are restricted to what the caller is allowed to see
+     *   (tenants, Rudder 8.1+).
+     */
+    Chunk.fromIterable(result.toSet.intersect(nodeAndServerIds.nodeIds))
   }
 
-  def getNodeIdsChunkRec(
-      targets:  Chunk[RuleTarget],
-      allNodes: Map[NodeId, Boolean /* isPolicyServer */ ],
-      groups:   Map[NodeGroupId, Chunk[NodeId]]
+  private def getNodeIdsChunkRec(
+      targets:          Chunk[RuleTarget],
+      groups:           Map[NodeGroupId, Chunk[NodeId]],
+      nodeAndServerIds: NodeAndServerIds
   ): Chunk[NodeId] = {
 
     targets.traverse {
-      case AllTarget                    => Left(Chunk.fromIterable(allNodes.keys))
-      case AllTargetExceptPolicyServers => Right(allNodes.collect { case (k, isPolicyServer) if (!isPolicyServer) => k })
-      case AllPolicyServers             => Right(allNodes.collect { case (k, isPolicyServer) if (isPolicyServer) => k })
+      case AllTarget                    => Left(Chunk.fromIterable(nodeAndServerIds.nodeIds))
+      case AllTargetExceptPolicyServers => Right(nodeAndServerIds.nodeIds -- nodeAndServerIds.serverIds)
+      case AllPolicyServers             => Right(nodeAndServerIds.serverIds)
       case PolicyServerTarget(nodeId)   => Right(Set(nodeId))
 
       // here, if we don't find the group, we consider it's an error in the
@@ -395,24 +345,24 @@ object RuleTarget extends Loggable {
       case GroupTarget(groupId) => Right(groups.getOrElse(groupId, Chunk.empty))
 
       case TargetIntersection(targets) =>
-        val nodeSets     = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups))
+        val nodeSets     = targets.map(t => getNodeIdsChunkRec(Chunk(t), groups, nodeAndServerIds))
         // Compute the intersection of the sets of Nodes
-        val intersection = nodeSets.foldLeft(Chunk.fromIterable(allNodes.keys)) {
+        val intersection = nodeSets.foldLeft(Chunk.fromIterable(nodeAndServerIds.nodeIds)) {
           case (currentIntersection, nodes) => currentIntersection.intersect(nodes)
         }
         Right(intersection)
 
       case TargetUnion(targets) =>
-        val nodeSets = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups))
+        val nodeSets = targets.map(t => getNodeIdsChunkRec(Chunk(t), groups, nodeAndServerIds))
         // Compute the union of the sets of Nodes
         val union    = nodeSets.foldLeft(Chunk[NodeId]()) { case (currentUnion, nodes) => currentUnion ++ nodes }
         Right(union)
 
       case TargetExclusion(included, excluded) =>
         // Compute the included Nodes
-        val includedNodes = getNodeIdsChunkRec(Chunk(included), allNodes, groups)
+        val includedNodes = getNodeIdsChunkRec(Chunk(included), groups, nodeAndServerIds)
         // Compute the excluded Nodes
-        val excludedNodes = getNodeIdsChunkRec(Chunk(excluded), allNodes, groups)
+        val excludedNodes = getNodeIdsChunkRec(Chunk(excluded), groups, nodeAndServerIds)
         // Remove excluded nodes from included nodes
         val result        = includedNodes.filterNot(id => excludedNodes.contains(id))
         Right(result)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -42,6 +42,7 @@ import com.normation.inventory.domain.*
 import com.normation.inventory.services.core.ReadOnlySoftwareDAO
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.logger.NodeLoggerPure
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.tenants.*
 import com.normation.zio.*
@@ -127,6 +128,24 @@ trait NodeFactRepository {
    * This should be made fast, because it's typically used in license check.
    */
   def getNumberOfManagedNodes(): IOResult[Int]
+
+  /*
+   * Get the ids of the policy servers (root and relays) among accepted nodes,
+   * restricted to what the query context allows to see.
+   */
+  def getPolicyServers()(implicit qc: QueryContext): IOResult[Set[NodeId]] = {
+    getAll()(using qc, SelectNodeStatus.Accepted).map(_.collect {
+      case (id, n) if n.rudderSettings.isPolicyServer => id
+    }.toSet)
+  }
+
+  /*
+   * Get the accepted node ids and policy server visible in the query context.
+   * Used for target resolution.
+   */
+  def getNodeAndServerIds()(implicit qc: QueryContext): IOResult[NodeAndServerIds] = {
+    getAll()(using qc, SelectNodeStatus.Accepted).map(NodeAndServerIds.fromFacts(_))
+  }
 
   /*
    * Get node on given status
@@ -440,15 +459,26 @@ class CoreNodeFactRepository(
 
   // number of accepted, enabled nodes
   private def countEnabled(nodes: Map[NodeId, CoreNodeFact]) = nodes.count(_._2.rudderSettings.state.isEnabled)
-  private val enabledNodes:         Ref[Int]  = (for {
+  // accepted policy servers (root and relays) - there are always very few of them
+  private def collectPolicyServers(nodes: Map[NodeId, CoreNodeFact]) = {
+    nodes.collect { case (id, n) if n.rudderSettings.isPolicyServer => id }.toSet
+  }
+  private val enabledNodes: Ref[Int] = (for {
     n <- acceptedNodes.get
     r <- Ref.make(countEnabled(n))
   } yield r).runNow
-  private def updateEnabledCount(): UIO[Unit] = {
+  private val policyServers: Ref[Set[NodeId]] = (for {
+    n <- acceptedNodes.get
+    r <- Ref.make(collectPolicyServers(n))
+  } yield r).runNow
+
+  // refresh the caches derived from accepted nodes; must be called after any mutation of acceptedNodes
+  private def updateDerivedCaches(): UIO[Unit] = {
     for {
       n <- acceptedNodes.get
-      r <- enabledNodes.set(countEnabled(n))
-    } yield r
+      _ <- enabledNodes.set(countEnabled(n))
+      _ <- policyServers.set(collectPolicyServers(n))
+    } yield ()
   }
 
   // debug log
@@ -534,6 +564,21 @@ class CoreNodeFactRepository(
   }
 
   override def getNumberOfManagedNodes(): IOResult[Int] = enabledNodes.get
+
+  override def getNodeAndServerIds()(implicit qc: QueryContext): IOResult[NodeAndServerIds] = {
+    for {
+      nodes   <- getAll()(using qc, SelectNodeStatus.Accepted).map(_.keys.toSet)
+      servers <- getPolicyServers()
+    } yield NodeAndServerIds(nodeIds = nodes, serverIds = servers)
+  }
+
+  override def getPolicyServers()(implicit qc: QueryContext): IOResult[Set[NodeId]] = {
+    for {
+      ids     <- policyServers.get
+      // there are very few policy servers: filtering them by visibility is cheap
+      visible <- ZIO.filter(ids)(id => getOnRef(acceptedNodes, id).map(_.isDefined))
+    } yield visible
+  }
 
   override def get(
       nodeId: NodeId
@@ -732,8 +777,8 @@ class CoreNodeFactRepository(
                                    _ <- runCallbacks(es)
                                  } yield es
                                }
-        // update number of active nodes
-        _                   <- updateEnabledCount()
+        // update number of active nodes and policy servers
+        _                   <- updateDerivedCaches()
       } yield es
     )
   }
@@ -829,6 +874,7 @@ class CoreNodeFactRepository(
                               ).succeed
                           }
             } yield e
+          _ <- updateDerivedCaches()
           _ <- runCallbacks(e)
         } yield e
       )
@@ -850,6 +896,7 @@ class CoreNodeFactRepository(
                    }
                  case None    => NodeFactChangeEventCC(NodeFactChangeEvent.Noop(nodeId, SelectFacts.all), cc).succeed
                }
+        _   <- updateDerivedCaches()
         _   <- runCallbacks(e)
       } yield e
     )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -47,7 +47,6 @@ import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
 import com.normation.utils.Utils
 import com.unboundid.ldif.LDIFChangeRecord
-import scala.collection.MapView
 import scala.collection.immutable.SortedMap
 import zio.Chunk
 
@@ -166,13 +165,20 @@ final case class FullNodeGroupCategory(
     targetInfos.map(t => (t.target.target, t)).toMap ++ subCategories.flatMap(_.allTargets)
   )
 
+  // group content in the shape needed by RuleTarget.getNodeIdsChunk, precomputed once
+  // since getNodeIds is typically called for each rule in a loop
+  lazy val allGroupsNodeIds: Map[NodeGroupId, Chunk[NodeId]] = {
+    allGroups.view.mapValues(g => Chunk.fromIterable(g.nodeGroup.serverList)).toMap
+  }
+
   /**
    * Return all node ids that match the set of target.
+   * See RuleTarget.getNodeIdsChunk: the result is restricted to nodeAndServerIds.nodeIds,
+   * which must be consistent with the caller's context (QueryContext-filtered facts, or
+   * the node snapshot of the current generation).
    */
-  def getNodeIds(targets: Set[RuleTarget], arePolicyServers: Map[NodeId, Boolean]): Set[NodeId] = {
-    val groups = allGroups.view.mapValues(_.nodeGroup.serverList.toSet)
-
-    RuleTarget.getNodeIds(targets, arePolicyServers, groups.toMap)
+  def getNodeIds(targets: Set[RuleTarget], nodeAndServerIds: NodeAndServerIds): Set[NodeId] = {
+    RuleTarget.getNodeIdsChunk(targets, allGroupsNodeIds, nodeAndServerIds).toSet
   }
 
   /**
@@ -188,7 +194,11 @@ final case class FullNodeGroupCategory(
             // here, we don't need all node info, just the current node
             // It's because we only do set analysis on node info, not things like "find all
             // the node with that policy server" in target.
-            getNodeIds(Set(t), Map(node.id -> node.rudderSettings.isPolicyServer)).contains(node.id)
+            val ids = NodeAndServerIds(
+              nodeIds = Set(node.id),
+              serverIds = if (node.rudderSettings.isPolicyServer) Set(node.id) else Set.empty
+            )
+            getNodeIds(Set(t), ids).contains(node.id)
           case FullOtherTarget(t)             =>
             t match {
               case AllTarget                    => true
@@ -364,22 +374,16 @@ object RoNodeGroupRepository {
 
   /**
    * Return all node ids that match the set of target.
+   * See RuleTarget.getNodeIdsChunk: the result is restricted to nodeAndServerIds.nodeIds,
+   * so tenant-safety requires it to be built from QueryContext-filtered facts (see
+   * NodeFactRepository.getNodeAndServerIds).
    */
-  def getNodeIds(
-      allGroups:    Map[NodeGroupId, Set[NodeId]],
-      targets:      Set[RuleTarget],
-      allNodeFacts: MapView[NodeId, CoreNodeFact]
-  ): Set[NodeId] = {
-    val allNodes = allNodeFacts.mapValues(x => (x.rudderSettings.isPolicyServer)).toMap
-    RuleTarget.getNodeIds(targets, allNodes, allGroups)
-  }
-
   def getNodeIdsChunk(
-      allGroups:        Map[NodeGroupId, Chunk[NodeId]],
       targets:          Set[RuleTarget],
-      arePolicyServers: MapView[NodeId, Boolean]
+      allGroups:        Map[NodeGroupId, Chunk[NodeId]],
+      nodeAndServerIds: NodeAndServerIds
   ): Chunk[NodeId] = {
-    RuleTarget.getNodeIdsChunk(targets, arePolicyServers, allGroups)
+    RuleTarget.getNodeIdsChunk(targets, allGroups, nodeAndServerIds)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleApplicationStatusService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleApplicationStatusService.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.services.policies
 
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.FullNodeGroupCategory
@@ -47,7 +48,7 @@ trait RuleApplicationStatusService {
       rule:             Rule,
       groupLib:         FullNodeGroupCategory,
       directiveLib:     FullActiveTechniqueCategory,
-      arePolicyServers: Map[NodeId, Boolean],      // we need both all nodes and if they are policy server
+      nodeAndServerIds: NodeAndServerIds,          // the nodes visible in the caller's context, see NodeFactRepository.getNodeAndServerIds
       appliedOnNodes:   Option[Set[NodeId]] = None // Optional parameter: list of node target of this rule
       // exists because it is already computed in the API call
   ): ApplicationStatus
@@ -64,14 +65,14 @@ class RuleApplicationStatusServiceImpl extends RuleApplicationStatusService {
       rule:             Rule,
       groupLib:         FullNodeGroupCategory,
       directiveLib:     FullActiveTechniqueCategory,
-      arePolicyServers: Map[NodeId, Boolean],
+      nodeAndServerIds: NodeAndServerIds,
       appliedOnNodes:   Option[Set[NodeId]] = None // Optional parameter: list of node target of this rule
       // exists because it is already computed in the API call
   ): ApplicationStatus = {
 
     if (rule.isEnabled) {
       val isAllTargetsEnabled = rule.targets.flatMap(groupLib.allTargets.get(_)).filter(!_.isEnabled).isEmpty
-      val nodesList           = appliedOnNodes.getOrElse(groupLib.getNodeIds(rule.targets, arePolicyServers))
+      val nodesList           = appliedOnNodes.getOrElse(groupLib.getNodeIds(rule.targets, nodeAndServerIds))
       if (nodesList.nonEmpty) {
         if (isAllTargetsEnabled) {
           val disabled = (rule.directiveIds

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
@@ -41,6 +41,7 @@ import com.normation.cfclerk.domain.*
 import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.PolicyGenerationLoggerPure
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
@@ -54,7 +55,7 @@ trait RuleValService {
       rule:             Rule,
       directiveLib:     FullActiveTechniqueCategory,
       groupLib:         FullNodeGroupCategory,
-      arePolicyServers: Map[NodeId, Boolean]
+      nodeAndServerIds: NodeAndServerIds
   ): IOResult[RuleVal]
 
   def lookupNodeParameterization(
@@ -197,27 +198,23 @@ class RuleValServiceImpl(
     }
   }
 
-  def getTargetedNodes(rule: Rule, groupLib: FullNodeGroupCategory, arePolicyServers: Map[NodeId, Boolean]): Set[NodeId] = {
-    val wantedNodeIds = groupLib.getNodeIds(rule.targets, arePolicyServers)
-    val nodeIds       = wantedNodeIds.intersect(arePolicyServers.keySet)
-    if (nodeIds.size != wantedNodeIds.size) {
-      // ignored nodes are filtered-out early during generation, so we don't have access to their node info here,
-      // they are just missing from allNodeInfos map.
-      logger.debug(
-        s"Some nodes are in the target of rule '${rule.name}' (${rule.id.serialize}) but are not present " +
-        s"in the system. These nodes are likely in state `ignored`: ${(wantedNodeIds -- nodeIds).map(_.value).mkString(", ")}"
-      )
-    }
-    nodeIds
+  // Nodes in the target but not in nodeAndServerIds.nodeIds (deleted, `ignored` state,
+  // filtered-out early during generation) are silently excluded by the resolution.
+  def getTargetedNodes(
+      rule:             Rule,
+      groupLib:         FullNodeGroupCategory,
+      nodeAndServerIds: NodeAndServerIds
+  ): Set[NodeId] = {
+    groupLib.getNodeIds(rule.targets, nodeAndServerIds)
   }
 
   override def buildRuleVal(
       rule:             Rule,
       directiveLib:     FullActiveTechniqueCategory,
       groupLib:         FullNodeGroupCategory,
-      arePolicyServers: Map[NodeId, Boolean]
+      nodeAndServerIds: NodeAndServerIds
   ): IOResult[RuleVal] = {
-    val nodeIds = getTargetedNodes(rule, groupLib, arePolicyServers)
+    val nodeIds = getTargetedNodes(rule, groupLib, nodeAndServerIds)
 
     for {
       drafts <- rule.directiveIds.toList.accumulate {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
@@ -44,6 +44,7 @@ import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.logger.PolicyGenerationLogger
 import com.normation.rudder.domain.logger.PolicyGenerationLoggerPure
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.policies.AppliedStatus
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.Rule
@@ -148,12 +149,12 @@ class FetchAllInfoServiceImpl(
       rules:            Seq[Rule],
       groupLib:         FullNodeGroupCategory,
       directiveLib:     FullActiveTechniqueCategory,
-      arePolicyServers: Map[NodeId, Boolean]
+      nodeAndServerIds: NodeAndServerIds
   ): Set[RuleId] = {
     rules
       .filter(r => {
         ruleApplicationStatusService
-          .isApplied(r, groupLib, directiveLib, arePolicyServers) match {
+          .isApplied(r, groupLib, directiveLib, nodeAndServerIds) match {
           case _: AppliedStatus => true
           case _ => false
         }
@@ -209,13 +210,13 @@ class FetchAllInfoServiceImpl(
       rules:            List[Rule],
       directiveLib:     FullActiveTechniqueCategory,
       allGroups:        FullNodeGroupCategory,
-      arePolicyServers: Map[NodeId, Boolean]
+      nodeAndServerIds: NodeAndServerIds
   ): IOResult[Seq[RuleVal]] = {
 
     val appliedRules = rules.filter(r => activeRuleIds.contains(r.id))
     for {
       rawRuleVals <- appliedRules.accumulate { rule =>
-                       ruleValService.buildRuleVal(rule, directiveLib, allGroups, arePolicyServers)
+                       ruleValService.buildRuleVal(rule, directiveLib, allGroups, nodeAndServerIds)
                      }.chainError("Could not find configuration vals")
     } yield rawRuleVals
   }
@@ -295,14 +296,14 @@ class FetchAllInfoServiceImpl(
       ///// - number of rules: any rule without target or with only target with no node can be skipped
 
       ruleValTime0                             <- currentTimeMillis
-      arePolicyServers                          = nodeFacts.view.mapValues(_.rudderSettings.isPolicyServer).toMap
-      activeRuleIds                             = getAppliedRuleIds(allRules, groupLib, directiveLib, arePolicyServers)
+      nodeAndServerIds                          = NodeAndServerIds.fromFacts(nodeFacts)
+      activeRuleIds                             = getAppliedRuleIds(allRules, groupLib, directiveLib, nodeAndServerIds)
       ruleVals                                 <- buildRuleVals(
                                                     activeRuleIds,
                                                     allRules.toList,
                                                     directiveLib,
                                                     groupLib,
-                                                    arePolicyServers
+                                                    nodeAndServerIds
                                                   ).chainError("Cannot build Rule vals")
       ruleValTime1                             <- currentTimeMillis
       timeRuleVal                               = ruleValTime1 - ruleValTime0

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -7,6 +7,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.inventory.domain.UndefinedKey
 import com.normation.inventory.domain.Version
 import com.normation.rudder.domain.nodes.Node
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
@@ -20,6 +21,7 @@ import net.liftweb.common.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.*
+import zio.Chunk
 import zio.json.*
 
 @RunWith(classOf[JUnitRunner])
@@ -202,30 +204,56 @@ class RuleTargetTest extends Specification with Loggable with JsonSpecMatcher {
 
   val allTargets: Set[RuleTarget] = (groupTargets.map(_._1) ++ (allComposite.map(_._1)) ++ allTargetExclusions.map(_._1))
 
+  val allIds: NodeAndServerIds = NodeAndServerIds(nodeIds = allNodeIds, serverIds = Set())
+
   " Nodes from Rule targets" should {
     "Be found correctly on simple rule targets" in {
       groupTargets.forall {
         case (gt, g) =>
-          fngc.getNodeIds(Set(gt), nodeArePolicyServers) === g.serverList
+          fngc.getNodeIds(Set(gt), allIds) === g.serverList
       }
     }
     "Be found correctly on group targets union" in {
       unionTargets.forall {
         case (gt, g) =>
-          fngc.getNodeIds(Set(gt), nodeArePolicyServers) === g
+          fngc.getNodeIds(Set(gt), allIds) === g
       }
     }
     "Be found correctly on group targets intersection" in {
       interTargets.forall {
         case (gt, g) =>
-          fngc.getNodeIds(Set(gt), nodeArePolicyServers) === g
+          fngc.getNodeIds(Set(gt), allIds) === g
       }
     }
     "Be found correctly on group targets exclusion " in {
       allTargetExclusions.forall {
         case (target, resultNodes) =>
-          fngc.getNodeIds(Set(target), nodeArePolicyServers) === resultNodes
+          fngc.getNodeIds(Set(target), allIds) === resultNodes
       }
+    }
+    "Resolve policy-server related special targets from the serverIds set" in {
+      val root   = NodeId("root")
+      val withPs = NodeAndServerIds(nodeIds = allNodeIds, serverIds = Set(root))
+      (fngc.getNodeIds(Set(AllPolicyServers), withPs) === Set(root)) and
+      (fngc.getNodeIds(Set(AllTargetExceptPolicyServers), withPs) === (allNodeIds - root)) and
+      (fngc.getNodeIds(Set(PolicyServerTarget(root)), withPs) === Set(root))
+    }
+    "Never contain node ids absent from allNodes (deleted nodes)" in {
+      val ghost  = NodeId("deleted-node")
+      val groups = Map(g4.id -> Chunk.fromIterable(g4.serverList + ghost))
+      RuleTarget.getNodeIdsChunk(Set(GroupTarget(g4.id)), groups, allIds).toSet === g4.serverList
+    }
+    "Be restricted to allNodes when it is a tenant-filtered subset" in {
+      val visible   = NodeAndServerIds(nodeIds = Set(NodeId("1"), NodeId("3")), serverIds = Set())
+      val visiblePs = NodeAndServerIds(nodeIds = visible.nodeIds, serverIds = Set(NodeId("root")))
+      val groups    = groupTargets.map { case (_, g) => (g.id, Chunk.fromIterable(g.serverList)) }.toMap
+      (RuleTarget.getNodeIdsChunk(Set(GroupTarget(g4.id)), groups, visible).toSet === Set(
+        NodeId("1"),
+        NodeId("3")
+      )) and
+      (RuleTarget
+        .getNodeIdsChunk(Set(PolicyServerTarget(NodeId("root"))), groups, visiblePs) === Chunk
+        .empty[NodeId])
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.services.policies
 import com.normation.GitVersion
 import com.normation.cfclerk.domain.*
 import com.normation.inventory.domain.AgentType
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
@@ -197,7 +198,9 @@ class RuleValServiceTest extends Specification {
   // Ok, now I can test
   "The RuleValService, with one directive, one Meta-technique " should {
 
-    val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, Map()).runNow
+    val ruleVal = ruleValService
+      .buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, NodeAndServerIds(Set(), Set()))
+      .runNow
 
     val directivesVals = ruleVal.parsedPolicyDrafts
 
@@ -233,7 +236,9 @@ class RuleValServiceTest extends Specification {
   }
 
   "The cardinality computed " should {
-    val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, Map()).runNow
+    val ruleVal = ruleValService
+      .buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, NodeAndServerIds(Set(), Set()))
+      .runNow
     val draft   = ruleVal.parsedPolicyDrafts.head
     // false PolicyVars for that draft
     val vars    = PolicyVars(draft.id, draft.policyMode, draft.originalVariables, draft.originalVariables, draft.trackerVariable)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.services.policies
 import ch.qos.logback.classic.Logger
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.appconfig.FeatureSwitch
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
@@ -212,7 +213,7 @@ class TestBuildNodeConfiguration extends Specification {
     val t1           = System.currentTimeMillis()
     val ruleVal      = {
       ruleValService
-        .buildRuleVal(rule, directiveLib, groupLib, allNodes.view.mapValues(_.rudderSettings.isPolicyServer).toMap)
+        .buildRuleVal(rule, directiveLib, groupLib, NodeAndServerIds.fromFacts(allNodes))
         .runNow
     }
     val ruleVals     = Seq(ruleVal)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -47,7 +47,6 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.queries.*
 import com.normation.rudder.domain.queries.CriterionComposition.*
 import com.normation.rudder.facts.nodes.*
-import com.normation.rudder.services.queries.TestNodeFactAlgebra.*
 import com.normation.rudder.services.servers.InstanceId
 import com.normation.rudder.services.servers.InstanceIdService
 import com.normation.rudder.tenants.*
@@ -1560,6 +1559,7 @@ class TestNodeFactQueryProcessor {
 
 @RunWith(classOf[ZTestJUnitRunner])
 class TestNodeFactAlgebra extends ZIOSpecDefault {
+  import com.normation.rudder.services.queries.TestNodeFactAlgebra.*
 
   override def spec: Spec[TestEnvironment & Scope, Any] = {
     // testing the values of the boolean algebra

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -138,17 +138,17 @@ class RuleInternalApiService(
       t2        <- currentTimeMillis
       allGroups <- readGroup.getAllNodeIdsChunk()
       t3        <- currentTimeMillis
-      nodes     <- readNodes.getAll()
+      ids       <- readNodes.getNodeAndServerIds()
       t4        <- currentTimeMillis
       nodesIds  <- RoNodeGroupRepository
-                     .getNodeIdsChunk(allGroups, rule.targets, nodes.mapValues(_.rudderSettings.isPolicyServer))
+                     .getNodeIdsChunk(rule.targets, allGroups, ids)
                      .size
                      .succeed
       t5        <- currentTimeMillis
 
       _ <- TimingDebugLoggerPure.trace(s"GetRuleNodesAndDirectives - readRule in ${t2 - t1} ms")
       _ <- TimingDebugLoggerPure.trace(s"GetRuleNodesAndDirectives - getAllNodeIdsChunk in ${t3 - t2} ms")
-      _ <- TimingDebugLoggerPure.trace(s"GetRuleNodesAndDirectives - readNodes.getAll() in ${t4 - t3} ms")
+      _ <- TimingDebugLoggerPure.trace(s"GetRuleNodesAndDirectives - readNodes.getNodeAndServerIds() in ${t4 - t3} ms")
       _ <- TimingDebugLoggerPure.trace(s"GetRuleNodesAndDirectives - getNodeIdsChunk in ${t5 - t4} ms")
 
     } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -43,6 +43,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.domain.logger.TimingDebugLogger
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies.AllPolicyServers
@@ -640,29 +641,31 @@ class ComplianceAPIService(
     val computedLevel = level.getOrElse(10)
 
     for {
-      t1            <- currentTimeMillis
+      t1              <- currentTimeMillis
       // this can be optimized, as directive only happen for level=2
-      rules         <- if (computedLevel >= 2) {
-                         rulesRepo.getAll()
-                       } else {
-                         Seq().succeed
-                       }
-      ruleIds        = rules.map(_.id).toSet
-      t2            <- currentTimeMillis
-      _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - getAllRules in ${t2 - t1} ms")
-      nodeFacts     <- nodeFactRepos.getAll()
-      t3            <- currentTimeMillis
-      _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - nodeFactRepo.getAll() in ${t3 - t2} ms")
-      compliance    <- getGlobalComplianceMode
-      t4            <- currentTimeMillis
-      _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - getGlobalComplianceMode in ${t4 - t3} ms")
-      reportsByNode <- reportingService
-                         .findDirectiveNodeStatusReports(
-                           nodeFacts.keySet.toSet,
-                           directives.map(_.id).toSet
-                         )
-      t5            <- currentTimeMillis
-      _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - findRuleNodeStatusReports in ${t5 - t4} ms")
+      rules           <- if (computedLevel >= 2) {
+                           rulesRepo.getAll()
+                         } else {
+                           Seq().succeed
+                         }
+      ruleIds          = rules.map(_.id).toSet
+      t2              <- currentTimeMillis
+      _               <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - getAllRules in ${t2 - t1} ms")
+      nodeFacts       <- nodeFactRepos.getAll()
+      // compute it once per request, before the loops on rules
+      nodeAndServerIds = NodeAndServerIds.fromFacts(nodeFacts)
+      t3              <- currentTimeMillis
+      _               <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - nodeFactRepo.getAll() in ${t3 - t2} ms")
+      compliance      <- getGlobalComplianceMode
+      t4              <- currentTimeMillis
+      _               <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - getGlobalComplianceMode in ${t4 - t3} ms")
+      reportsByNode   <- reportingService
+                           .findDirectiveNodeStatusReports(
+                             nodeFacts.keySet.toSet,
+                             directives.map(_.id).toSet
+                           )
+      t5              <- currentTimeMillis
+      _               <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - findRuleNodeStatusReports in ${t5 - t4} ms")
 
       allGroups <- nodeGroupRepo.getAllNodeIdsChunk()
       t6        <- currentTimeMillis
@@ -714,7 +717,7 @@ class ComplianceAPIService(
                   // if rule cannot be found in "rules" it means the level prevent from returning rule details, so : no compliance
                   rules.find(_.id == ruleId).map { rule =>
                     val nodeIds = RoNodeGroupRepository
-                      .getNodeIdsChunk(allGroups, rule.targets, nodeFacts.mapValues(_.rudderSettings.isPolicyServer))
+                      .getNodeIdsChunk(rule.targets, allGroups, nodeAndServerIds)
                       .toSet
 
                     def defaultMode                   = (
@@ -812,11 +815,15 @@ class ComplianceAPIService(
       _                <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - get directive overrides and rules infos in ${t8 - t7} ms")
       globalPolicyMode <- getGlobalPolicyMode
 
+      // compute it once per request, before the loops on rules
+      nodeAndServerIds = NodeAndServerIds.fromFacts(nodeFacts)
+      nodeSettings     = nodeFacts.mapValues(_.rudderSettings).toMap
+
       nodeAndPolicyModeByRules = rules.map { rule =>
                                    val nodeIds = RoNodeGroupRepository.getNodeIdsChunk(
-                                     allGroups,
                                      rule.targets,
-                                     nodeFacts.mapValues(_.rudderSettings.isPolicyServer)
+                                     allGroups,
+                                     nodeAndServerIds
                                    )
                                    (
                                      rule.id,
@@ -826,7 +833,7 @@ class ComplianceAPIService(
                                          rule,
                                          directives,
                                          nodeIds.toSet,
-                                         nodeFacts.mapValues(_.rudderSettings).toMap,
+                                         nodeSettings,
                                          globalPolicyMode
                                        )
                                      )
@@ -1241,13 +1248,18 @@ class ComplianceAPIService(
 
       globalPolicyMode <- getGlobalPolicyMode
 
+      nodeAndServerIds = NodeAndServerIds(
+                           nodeIds = nodeSettings.keySet,
+                           serverIds = nodeSettings.collect { case (id, s) if s.isPolicyServer => id }.toSet
+                         )
+
       // A map for constant time access for the set of targeted nodes and policy mode:  a Map[RuleId, (Chunk[NodeId], Option[PolicyMode])]
       // The set is reused to directly compute the policy mode of the rule
-      allRuleInfos = {
+      allRuleInfos     = {
         rules
           .map(r => {
             val targetedNodeIds =
-              RoNodeGroupRepository.getNodeIdsChunk(allGroups, r.targets, nodeSettings.view.mapValues(_.isPolicyServer))
+              RoNodeGroupRepository.getNodeIdsChunk(r.targets, allGroups, nodeAndServerIds)
             val policyMode      =
               getRulePolicyMode(r, directiveLib.allDirectives, targetedNodeIds.toSet, nodeSettings, globalPolicyMode)
             (r.id, (targetedNodeIds, policyMode))
@@ -1256,23 +1268,14 @@ class ComplianceAPIService(
       }
 
       filteredRules = rules.flatMap { rule =>
-                        // we must filter out rule not in allRuleInfo, else latter on, we will try to get info on them and get https://issues.rudder.io/issues/24945
+                        // we must filter out rule not in allRuleInfo, else later on, we will try to get info on them and get https://issues.rudder.io/issues/24945
                         allRuleInfos.get(rule.id) match {
                           case None                        => None
                           case Some((nodeIds, policyMode)) =>
-                            val targetedNodeIds = {
-                              // TODO: allGroups CAN be empty when parsed is "non-group target". We don't even need the call to getAllNodeIdsChunk()
-                              RoNodeGroupRepository.getNodeIdsChunk(
-                                allGroups,
-                                rule.targets,
-                                nodeSettings.view.mapValues(_.isPolicyServer)
-                              )
-                            }
-
                             val isRuleTargetingGroup =
                               RuleTarget.merge(rule.targets).includes(target)
 
-                            if ((isGlobalCompliance || isRuleTargetingGroup) && targetedNodeIds.exists(serverList.contains))
+                            if ((isGlobalCompliance || isRuleTargetingGroup) && nodeIds.exists(serverList.contains))
                               Some((rule.id, (rule, nodeIds, policyMode)))
                             else None
                         }
@@ -1363,17 +1366,16 @@ class ComplianceAPIService(
 
         globalPolicyMode <- getGlobalPolicyMode
 
+        // compute it once per request, before the loops on rules
+        nodeAndServerIds = NodeAndServerIds.fromFacts(nodeFacts)
+
         // A map for constant time access for the set of targeted nodes and policy mode:  a Map[RuleId, (Chunk[NodeId], Option[PolicyMode])]
         // The set is reused to directly compute the policy mode of the rule
         allRuleInfos      = {
           rules
             .map(r => {
               val targetedNodeIds = {
-                RoNodeGroupRepository.getNodeIdsChunk(
-                  allGroups,
-                  r.targets,
-                  nodeFacts.mapValues(_.rudderSettings.isPolicyServer)
-                )
+                RoNodeGroupRepository.getNodeIdsChunk(r.targets, allGroups, nodeAndServerIds)
               }
               val policyMode      =
                 getRulePolicyMode(r, directiveLib.allDirectives, targetedNodeIds.toSet, nodeSettings, globalPolicyMode)
@@ -1503,10 +1505,15 @@ class ComplianceAPIService(
       val nodeInfos: Map[NodeId, (String, RudderSettings)] =
         nodeFacts.view.mapValues(info => (info.fqdn, info.rudderSettings)).toMap
 
+      val nodeAndServerIds = NodeAndServerIds(
+        nodeIds = nodeInfos.keySet,
+        serverIds = nodeInfos.collect { case (id, (_, s)) if s.isPolicyServer => id }.toSet
+      )
+
       val nodeAndPolicyModeByRules = rules
         .map(rule => {
           val nodeIds    =
-            RoNodeGroupRepository.getNodeIdsChunk(allGroups, rule.targets, nodeInfos.view.mapValues(_._2.isPolicyServer)).toSet
+            RoNodeGroupRepository.getNodeIdsChunk(rule.targets, allGroups, nodeAndServerIds).toSet
           val policyMode = {
             getRulePolicyMode(
               rule,

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.domain.logger.ConfigurationLoggerPure
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.facts.nodes.*
 import com.normation.rudder.repository.*
@@ -339,7 +340,8 @@ class RuleApiService14(
       globalMode   <- getGlobalPolicyMode()
 
     } yield {
-      val status = getRuleApplicationStatus(change.newRule, groupLib, directiveLib, nodesLib, globalMode)
+      val ids    = NodeAndServerIds.fromFacts(nodesLib)
+      val status = getRuleApplicationStatus(change.newRule, groupLib, directiveLib, ids, nodesLib, globalMode)
 
       val optCrId = if (workflow.needExternalValidation()) Some(id) else None
       JRRule.fromRule(change.newRule, optCrId, Some(status.policyMode.name), Some(status.applicationStatusDetails))
@@ -347,22 +349,22 @@ class RuleApiService14(
   }
 
   def getRuleApplicationStatus(
-      rule:         Rule,
-      groupLib:     FullNodeGroupCategory,
-      directiveLib: FullActiveTechniqueCategory,
-      nodesLib:     MapView[NodeId, CoreNodeFact],
-      globalMode:   GlobalPolicyMode
+      rule:             Rule,
+      groupLib:         FullNodeGroupCategory,
+      directiveLib:     FullActiveTechniqueCategory,
+      nodeAndServerIds: NodeAndServerIds, // compute it once per request (from nodesLib), before loops on rules
+      nodesLib:         MapView[NodeId, CoreNodeFact],
+      globalMode:       GlobalPolicyMode
   ): RuleApplicationStatus = {
     val directives               =
       rule.directiveIds.flatMap(directiveLib.allDirectives.get(_)).map { case (a, d) => (a.toActiveTechnique(), d) }
-    val arePolicyServers         = nodesLib.mapValues(_.rudderSettings.isPolicyServer).toMap
-    val nodesIds                 = groupLib.getNodeIds(rule.targets, arePolicyServers)
+    val nodesIds                 = groupLib.getNodeIds(rule.targets, nodeAndServerIds)
     // for performance reason, it's necessary to keep the .view.filterKeys, as it is 10 times
     // faster than traditional groupLib.getNodeIds(rule.targets, nodesLib).flatMap(nodesLib.get)
     val nodes                    = nodesLib.filterKeys(x => nodesIds.contains(x)).values
     val allTargets               = rule.targets.flatMap(groupLib.allTargets.get).map(_.toTargetInfo)
     val policyMode               = ComputePolicyMode.ruleMode(globalMode, directives.map(_._2), nodes.map(_.rudderSettings.policyMode))
-    val applicationStatus        = applicationService.isApplied(rule, groupLib, directiveLib, arePolicyServers, Some(nodesIds))
+    val applicationStatus        = applicationService.isApplied(rule, groupLib, directiveLib, nodeAndServerIds, Some(nodesIds))
     val applicationStatusDetails = ApplicationStatus.details(rule, applicationStatus, allTargets, directives, nodes.isEmpty)
     RuleApplicationStatus(policyMode, applicationStatusDetails)
   }
@@ -376,10 +378,11 @@ class RuleApiService14(
       globalMode   <- getGlobalPolicyMode()
 
     } yield {
+      val ids = NodeAndServerIds.fromFacts(nodesLib)
       for {
         rule <- rules.sortBy(_.id.serialize)
       } yield {
-        val status = getRuleApplicationStatus(rule, groupLib, directiveLib, nodesLib, globalMode)
+        val status = getRuleApplicationStatus(rule, groupLib, directiveLib, ids, nodesLib, globalMode)
         JRRule.fromRule(rule, None, Some(status.policyMode.name), Some(status.applicationStatusDetails))
       }
     }
@@ -457,7 +460,8 @@ class RuleApiService14(
       nodesLib     <- nodeFactRepos.getAll()(using cc.toQC)
       globalMode   <- getGlobalPolicyMode()
     } yield {
-      val status = getRuleApplicationStatus(change.newRule, groupLib, directiveLib, nodesLib, globalMode)
+      val ids    = NodeAndServerIds.fromFacts(nodesLib)
+      val status = getRuleApplicationStatus(change.newRule, groupLib, directiveLib, ids, nodesLib, globalMode)
       asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
       JRRule.fromRule(change.newRule, None, Some(status.policyMode.name), Some(status.applicationStatusDetails))
     }).chainError(s"Error when creating new rule")
@@ -472,7 +476,8 @@ class RuleApiService14(
       nodesLib     <- nodeFactRepos.getAll()
       globalMode   <- getGlobalPolicyMode()
     } yield {
-      val status = getRuleApplicationStatus(rule, groupLib, directiveLib, nodesLib, globalMode)
+      val ids    = NodeAndServerIds.fromFacts(nodesLib)
+      val status = getRuleApplicationStatus(rule, groupLib, directiveLib, ids, nodesLib, globalMode)
       JRRule.fromRule(rule, None, Some(status.policyMode.name), Some(status.applicationStatusDetails))
     }
 
@@ -508,7 +513,8 @@ class RuleApiService14(
          nodesLib     <- nodeFactRepos.getAll()
          globalMode   <- getGlobalPolicyMode()
        } yield {
-         val status = getRuleApplicationStatus(rule, groupLib, directiveLib, nodesLib, globalMode)
+         val ids    = NodeAndServerIds.fromFacts(nodesLib)
+         val status = getRuleApplicationStatus(rule, groupLib, directiveLib, ids, nodesLib, globalMode)
          asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
          JRRule.fromRule(rule, None, Some(status.policyMode.name), Some(status.applicationStatusDetails))
        }
@@ -600,10 +606,11 @@ class RuleApiService14(
       groupLib         <- readGroup.getFullGroupLibrary()
       nodesLib         <- nodeFactRepos.getAll()
       globalMode       <- getGlobalPolicyMode()
+      ids               = NodeAndServerIds.fromFacts(nodesLib)
       rulesMap          = (for {
                             rule <- rules.sortBy(_.id.serialize)
                           } yield {
-                            val status = getRuleApplicationStatus(rule, groupLib, directiveLib, nodesLib, globalMode)
+                            val status = getRuleApplicationStatus(rule, groupLib, directiveLib, ids, nodesLib, globalMode)
                             (rule, Some(status.policyMode.name), Some(status.applicationStatusDetails))
                           }).groupBy(_._1.categoryId.value)
       missingCatContent = getMissingCategories(root, rules.toList)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -149,8 +149,7 @@ class NodeGroupForm(
       setIds = target match {
                  case Right(nodeGroup_) => nodeGroup_.serverList
                  case Left(target)      =>
-                   val allNodes = nodes.mapValues(_.rudderSettings.kind.isPolicyServer)
-                   RuleTarget.getNodeIds(Set(target), allNodes.toMap, Map())
+                   RuleTarget.getNodeIdsChunk(Set(target), Map(), NodeAndServerIds.fromFacts(nodes)).toSet
                }
     } yield {
       nodes.filterKeys(id => setIds.contains(id)).map(_._2).toSeq

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -43,6 +43,7 @@ import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.logger.TimingDebugLogger
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.repository.*
@@ -471,13 +472,13 @@ class RuleGrid(
       globalMode:    GlobalPolicyMode
   ): List[Line] = {
 
-    val arePolicyServers = nodeFacts.mapValues(_.rudderSettings.isPolicyServer).toMap
+    val nodeAndServerIds = NodeAndServerIds.fromFacts(nodeFacts)
 
     // we compute beforehand the compliance, so that we have a single big query
     // to the database
 
     rules.map { rule =>
-      val nodes                     = groupsLib.getNodeIds(rule.targets, arePolicyServers)
+      val nodes                     = groupsLib.getNodeIds(rule.targets, nodeAndServerIds)
       val (policyMode, explanation) = getRulePolicyMode(rule, nodes, nodeFacts, directivesLib, globalMode).tuple
 
       val trackerVariables: Box[Seq[DirectiveStatus]] = {
@@ -529,7 +530,7 @@ class RuleGrid(
               rule,
               groupsLib,
               directivesLib,
-              arePolicyServers,
+              nodeAndServerIds,
               None
             )
           }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.web.components.popup
 
 import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.servers.Srv
@@ -52,6 +53,7 @@ import net.liftweb.util.ClearClearable
 import net.liftweb.util.Helpers.*
 import scala.xml.NodeSeq
 import scala.xml.Text
+import zio.Chunk
 
 object ExpectedPolicyPopup {
 
@@ -117,10 +119,13 @@ class ExpectedPolicyPopup(
       groupTargets  = dynGroups.getOrElse(nodeSrv.id, Seq())
       rules        <- ruleRepository.getAll(includeSystem = false).toBox
     } yield {
-      val pendingNode = Map((nodeSrv.id, nodeSrv.isPolicyServer))
-      val groups      = groupTargets.map(x => (x, Set(nodeSrv.id))).toMap
+      val pendingNode = NodeAndServerIds(
+        nodeIds = Set(nodeSrv.id),
+        serverIds = if (nodeSrv.isPolicyServer) Set(nodeSrv.id) else Set.empty
+      )
+      val groups      = groupTargets.map(x => (x, Chunk(nodeSrv.id))).toMap
 
-      rules.filter(r => RuleTarget.getNodeIds(r.targets, pendingNode, groups, allNodesAreThere = false).nonEmpty)
+      rules.filter(r => RuleTarget.getNodeIdsChunk(r.targets, groups, pendingNode).nonEmpty)
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29305

Correct root cause of security-benchmark https://issues.rudder.io/issues/29246 (https://github.com/Normation/rudder-plugins-private/pull/1437). 
The main problem was that `target` (for rules, benchmarks, system updates...) was not tenant-aware. 
Looking at correcting `getNodeIdsChunk` show some other problems: 
- we have duplicate code (`getNodeIdsChunk` and `getNodeIds` that do almost the same thing, but diverged, 
- we compute again and again and again the set of policy servers for a bunch of bad reason: not out of loops, because we use a `MapView` that is realised thousands of time, etc. 

So the correction: 
- delete `getNodeIds`, Set-based, so with very poor performance, 
- Create an opaque type for `(allNodeIds, policyserverId)` : `NodeAndServerIds` so that we know what is what, 
- add in `NodeFactRepository` a method to directly get policy server ID and the set of NodeId with the correct query context. It returns the previous opaque type. That's addressing the root cause of the problem  
- the set of policy server is stored in a cache, because they almost never change and are few . It is updated along with the node count (added in delete method that was missing), 
- use everywhere that `NodeAndServerIds` in place of a map of `nodeId -> isPolicyServer`. 
- where possible, compute the list of target out of a loop to avoid computing it again and again, 
- for all the method like `getNodeIdsChunk`, always use the parameter order `target, groups, nodeAndServerIds` because we had a bit of everything, and it was hard to follow. 


Everything else are just ripples of these changes. 