### PR TITLE
Fixes #29316: Replace string template with a fastparse native implementation

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -70,9 +70,8 @@ import com.normation.rudder.services.policies.NodeConfiguration
 import com.normation.rudder.services.policies.ParameterEntry
 import com.normation.rudder.services.policies.Policy
 import com.normation.rudder.services.policies.PolicyId
-import com.normation.templates.FillTemplatesService
-import com.normation.templates.FillTemplateThreadUnsafe
 import com.normation.templates.FillTemplateTimer
+import com.normation.templates.PolicyTemplateService
 import com.normation.templates.STVariable
 import com.normation.zio.*
 import java.nio.charset.Charset
@@ -250,7 +249,7 @@ class PolicyWriterServiceImpl(
     pathComputer:               PathComputer,
     logNodeConfig:              NodeConfigurationLogger,
     prepareTemplate:            PrepareTemplateVariables,
-    fillTemplates:              FillTemplatesService,
+    templateService:            PolicyTemplateService,
     writeAllAgentSpecificFiles: WriteAllAgentSpecificFiles,
     HOOKS_D:                    String,
     HOOKS_IGNORE_SUFFIXES:      List[String],
@@ -528,7 +527,7 @@ class PolicyWriterServiceImpl(
                                                                    templates             <- readTemplateFromFileSystem(templateToRead.toSeq)
                                                                    resources             <- readResourcesFromFileSystem(fileToRead.toSeq)
                                                                    // Clearing cache
-                                                                   _                     <- IOResult.attempt(fillTemplates.clearCache())
+                                                                   _                     <- templateService.clearCache()
                                                                    readTemplateTime2     <- currentTimeMillis
                                                                    _                     <-
                                                                      timingLogger.debug(s"Paths computed and templates read in ${readTemplateTime2 - readTemplateTime1} ms")
@@ -641,7 +640,7 @@ class PolicyWriterServiceImpl(
       parametersWrittenTime <- currentTimeMillis
       _                     <- timingLogger.debug(s"Parameters written in ${parametersWrittenTime - propertiesWrittenTime} ms")
 
-      _              <- IOResult.attempt(fillTemplates.clearCache())
+      _              <- templateService.clearCache()
       /// perhaps that should be a post-hook somehow ?
       // and perhaps we should have an AgentSpecific global pre/post write
       preMvHooksName  = "policy-generation-node-ready"
@@ -790,19 +789,12 @@ class PolicyWriterServiceImpl(
       )
     }).groupMap(_._1)(_._2)
 
-    import org.antlr.stringtemplate.StringTemplate
-    import com.normation.stringtemplate.language.NormationAmpersandTemplateLexer
-
-    // now process by template, which are not thread safe but here, accessed sequentially
+    // now process by template, which may not be thread safe (StringTemplate engine) but here, accessed sequentially
     parallelSequence(byTemplate.toSeq) {
       case (content, seqInfos) =>
         for {
           t0     <- currentTimeNanos
-          parsed <-
-            IOResult
-              .attempt(s"Error when trying to parse template '${seqInfos.head.destination}'") { // head ok because of groupBy
-                new StringTemplate(content, classOf[NormationAmpersandTemplateLexer])
-              }
+          parsed <- templateService.parse(seqInfos.head.destination, content) // head ok because of groupBy
           t1     <- currentTimeNanos
           _      <- fillTimer.get.update(_ + t1 - t0)
           _      <- ZIO.foreachDiscard(seqInfos) { info =>
@@ -812,7 +804,7 @@ class PolicyWriterServiceImpl(
                           for {
                             _      <- PolicyGenerationLoggerPure.trace(s"Create policies file ${info.newFolder} ${info.destination}")
                             t0     <- currentTimeNanos
-                            filled <- FillTemplateThreadUnsafe.fill(
+                            filled <- templateService.fill(
                                         info.destination,
                                         parsed,
                                         info.envVars,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariableTest.scala
@@ -52,7 +52,6 @@ import com.normation.rudder.services.policies.IfVarClass
 import com.normation.rudder.services.policies.NodeRunHook
 import com.normation.rudder.services.policies.PolicyId
 import com.normation.rudder.services.policies.write.BuildBundleSequence.*
-import com.normation.templates.FillTemplatesService
 import org.junit.runner.*
 import org.specs2.mutable.*
 import org.specs2.runner.*
@@ -104,8 +103,6 @@ class PrepareTemplateVariableTest extends Specification {
         else None
       )
   }
-
-  val fillTemplate = new FillTemplatesService()
 
   // Ok, now I can test
   "Preparing the string for writing usebundle of directives" should {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -78,7 +78,10 @@ import com.normation.rudder.services.policies.ParameterForConfiguration
 import com.normation.rudder.services.policies.Policy
 import com.normation.rudder.services.policies.TestNodeConfiguration
 import com.normation.rudder.services.policies.write.PolicyWriterServiceImpl.filepaths
+import com.normation.templates.FastparsePolicyTemplateService
 import com.normation.templates.FillTemplatesService
+import com.normation.templates.PolicyTemplateEngine
+import com.normation.templates.StringTemplatePolicyTemplateService
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import io.scalaland.chimney.syntax.*
@@ -113,7 +116,7 @@ import zio.syntax.*
  * To see values for gitRoot, ptLib, etc, see at the end
  * of that file.
  */
-class TestSystemData {
+class TestSystemData(engine: PolicyTemplateEngine = PolicyTemplateEngine.StringTemplate) {
   // make tests more similar than default rudder install
   val hookIgnore: List[String] = """.swp, ~, .bak,
  .cfnew   , .cfsaved  , .cfedited, .cfdisabled, .cfmoved,
@@ -156,12 +159,17 @@ class TestSystemData {
       rootGeneratedPromisesDir.getAbsolutePath
     )
 
+    val templateService = engine match {
+      case PolicyTemplateEngine.StringTemplate => new StringTemplatePolicyTemplateService(new FillTemplatesService())
+      case PolicyTemplateEngine.Fastparse      => new FastparsePolicyTemplateService()
+    }
+
     val promiseWriter = new PolicyWriterServiceImpl(
       techniqueRepository,
       pathComputer,
       logNodeConfig,
       prepareTemplateVariable,
-      new FillTemplatesService(),
+      templateService,
       writeAllAgentSpecificFiles,
       "/we-don-t-want-hooks-here",
       hookIgnore,
@@ -269,7 +277,10 @@ final private case class RegexFileContent(regex: List[String]) extends LinesCont
 
 trait TechniquesTest extends Specification with Loggable with BoxSpecMatcher with ContentMatchers with AfterAll with BoxMatchers {
 
-  val testSystemData = new TestSystemData()
+  // the template engine under test; override in a subclass to run the same examples with another engine
+  def templateEngine: PolicyTemplateEngine = PolicyTemplateEngine.StringTemplate
+
+  val testSystemData = new TestSystemData(templateEngine)
   import testSystemData.*
   import testSystemData.data.*
 
@@ -604,6 +615,20 @@ class WriteSystemTechniquesTest extends TechniquesTest {
       compareWith(rootPath.getParentFile / cfeNode.id.value, "node-gen-var-def-override", Nil)
     }
   }
+}
+
+/*
+ * The same examples as WriteSystemTechniquesTest, but with the fastparse template
+ * engine: the generated policies must be identical to the expected ones.
+ */
+@RunWith(classOf[JUnitRunner])
+class WriteSystemTechniquesFastparseTest extends WriteSystemTechniquesTest {
+  override def templateEngine: PolicyTemplateEngine = PolicyTemplateEngine.Fastparse
+}
+
+@RunWith(classOf[JUnitRunner])
+class WriteSystemTechniques500FastparseTest extends WriteSystemTechniques500Test {
+  override def templateEngine: PolicyTemplateEngine = PolicyTemplateEngine.Fastparse
 }
 
 @RunWith(classOf[JUnitRunner])

--- a/webapp/sources/rudder/rudder-templates/pom.xml
+++ b/webapp/sources/rudder/rudder-templates/pom.xml
@@ -69,5 +69,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>3.2.1</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.lihaoyi</groupId>
+      <artifactId>fastparse_${scala-binary-version}</artifactId>
+      <version>${fastparse-version}</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/AmpersandTemplate.scala
+++ b/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/AmpersandTemplate.scala
@@ -1,0 +1,517 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.templates
+
+import com.normation.errors.*
+import org.apache.commons.lang3.Strings
+import scala.util.control.NonFatal
+
+/*
+ * A minimal template engine implementing the subset of the ampersand-delimited
+ * StringTemplate language actually used by Rudder policy templates (".st" files):
+ *
+ *   - variable expansion:  &VAR& and &VAR.property&
+ *   - conditionals:        &if(X)& ... &else& ... &endif&  and  &if(!X)&
+ *                          (presence / boolean / non-empty-list test only)
+ *   - parallel iteration:  &LIST1, LIST2 : { p1, p2 | body }; separator=", "&
+ *                          with implicit iterator &it& when no parameter is
+ *                          declared, and counters &i& (1-based) / &i0& (0-based)
+ *   - escapes in text:     \& for a literal '&', \\ for '\'
+ *   - comments:            &! ... !&
+ *
+ * A template is parsed once into an immutable AST (thread safe, cacheable and
+ * shareable without locks), then rendering is a pure function of the AST and
+ * the variable values. This is the replacement for the mutable, synchronized
+ * StringTemplate instances.
+ *
+ * All layout rules of the ST3 ampersand lexer/writer are reproduced (whitespace
+ * skip after the subtemplate '|', newline handling around conditional markers,
+ * auto-indent, empty-expression line elision): the output is byte-identical to
+ * StringTemplate 3 on all Rudder templates (see WriteSystemTechniquesFastparseTest).
+ */
+
+sealed trait TemplateAst
+object TemplateAst {
+  final case class Txt(text: String) extends TemplateAst
+
+  // parse-time marker for '&!...!&', resolved by post-processing (a comment starting
+  // its line swallows the following newline in ST3); it never survives parsing
+  case object Comment extends TemplateAst
+
+  /*
+   * On expressions, two ST3 layout behaviors are pre-computed at parse time:
+   * - `indent` ("auto-indent"): when an expression starts a line after only whitespace, that
+   *   whitespace is removed from the text and re-applied to each line of a non-empty expansion;
+   * - `trailingNewline` (empty-line elision): when an expression is alone on its line, the
+   *   following newline is moved onto it and only emitted if the expansion is not empty,
+   *   so that an empty expansion removes its whole line.
+   */
+  final case class Ref(
+      name:            String,
+      prop:            Option[String],
+      separator:       Option[String] = None,
+      indent:          Option[String] = None,
+      trailingNewline: Option[String] = None
+  ) extends TemplateAst
+  final case class Cond(
+      name:            String,
+      negated:         Boolean,
+      thenBody:        Seq[TemplateAst],
+      elseBody:        Seq[TemplateAst],
+      trailingNewline: Option[String] = None
+  ) extends TemplateAst
+  final case class Loop(
+      attrs:           Seq[String],
+      params:          Seq[String],
+      body:            Seq[TemplateAst],
+      separator:       Option[String],
+      indent:          Option[String] = None,
+      trailingNewline: Option[String] = None
+  ) extends TemplateAst
+}
+
+final case class ParsedTemplate(parts: Seq[TemplateAst])
+
+object AmpersandTemplate {
+  import TemplateAst.*
+
+  def parse(content: String): PureResult[ParsedTemplate] = Parser.parse(content)
+
+  /*
+   * Fill a parsed template with the same variable semantics as
+   * FillTemplateThreadUnsafe.fill: system variables that may be empty and are
+   * empty are absent (conditionals on them are false, their expansion is empty),
+   * a mandatory empty variable is an error, a single value is a scalar and
+   * multiple values are a list.
+   * Returns (filled content, file name): when `replaceId` is defined (multi-policy
+   * techniques), its (from, to) pair is available as a template variable and
+   * substituted in the returned file name.
+   */
+  def fill(
+      template:     ParsedTemplate,
+      templateName: String,
+      variables:    Seq[STVariable],
+      replaceId:    Option[(String, String)]
+  ): PureResult[(String, String)] = {
+    val mandatoryEmpty = variables.collect { case v if !v.mayBeEmpty && v.values.isEmpty => v.name }
+    if (mandatoryEmpty.nonEmpty) {
+      Left(
+        Unexpected(s"Mandatory variables ${mandatoryEmpty.mkString("'", "', '", "'")} are empty, can not write ${templateName}")
+      )
+    } else {
+      val scope = variables.foldLeft(Map.empty[String, Any]) {
+        case (m, v) =>
+          if (v.isSystem && v.mayBeEmpty && (v.values.isEmpty || (v.values.sizeIs == 1 && v.values.head == ""))) m
+          else if (v.values.sizeIs == 1) m + (v.name -> v.values.head)
+          else m + (v.name                           -> v.values)
+      }
+      replaceId match {
+        case None             => Right((render(template.parts, scope), templateName))
+        case Some((from, to)) =>
+          Right((render(template.parts, scope + (from -> to)), Strings.CS.replace(templateName, from, to)))
+      }
+    }
+  }
+
+  /*
+   * Pure rendering of a template given variable values. A value can be a Seq or
+   * an Array (list variable), a Boolean (conditions), or anything else rendered
+   * with its toString. An absent variable renders as empty and is false in
+   * conditions, like a null attribute in StringTemplate.
+   */
+  def render(parts: Seq[TemplateAst], scope: Map[String, Any]): String = {
+    val sb = new java.lang.StringBuilder(1024)
+    append(sb, parts, scope)
+    sb.toString
+  }
+
+  private val builtins = List("i", "i0")
+
+  private def append(sb: java.lang.StringBuilder, parts: Seq[TemplateAst], scope: Map[String, Any]): Unit = {
+    parts.foreach {
+      case Comment => ()
+
+      case Txt(t) =>
+        sb.append(t): Unit
+
+      case Ref(name, prop, sep, indent, trailingNl) =>
+        exprOut(sb, indent, trailingNl) { out =>
+          resolve(scope, name).foreach { v =>
+            prop match {
+              case None    => appendValue(out, v, sep)
+              case Some(p) => Option(property(v, p)).foreach(appendValue(out, _, sep))
+            }
+          }
+        }
+
+      case Cond(name, negated, thenBody, elseBody, trailingNl) =>
+        exprOut(sb, None, trailingNl) { out =>
+          append(out, if (truthy(resolve(scope, name)) != negated) thenBody else elseBody, scope)
+        }
+
+      case Loop(attrs, params, body, separator, indent, trailingNl) =>
+        exprOut(sb, indent, trailingNl) { out =>
+          val lists = attrs.map(a => asList(resolve(scope, a)))
+          val names = if (params.isEmpty) List("it") else params
+          val len   = lists.map(_.size).max
+          var i     = 0
+          while (i < len) {
+            if (i > 0) separator.foreach(s => out.append(s): Unit)
+            val bound =
+              names.iterator.zip(lists.iterator).flatMap { case (n, l) => l.lift(i).filter(_ != null).map(n -> _) }.toMap
+            append(out, body, scope -- names -- builtins ++ bound + ("i" -> (i + 1)) + ("i0" -> i))
+            i += 1
+          }
+        }
+    }
+  }
+
+  /*
+   * Write an expression expansion with ST3 layout semantics: an empty expansion emits
+   * nothing at all (not even its line's indentation or newline); a non-empty one is
+   * lazily indented (the indentation is only written before a non-newline character,
+   * like ST3's AutoIndentWriter does) then followed by the moved trailing newline.
+   */
+  private def exprOut(sb: java.lang.StringBuilder, indent: Option[String], trailingNl: Option[String])(
+      write: java.lang.StringBuilder => Unit
+  ): Unit = {
+    if (indent.isEmpty && trailingNl.isEmpty) write(sb)
+    else {
+      val out = new java.lang.StringBuilder(64)
+      write(out)
+      if (out.length > 0) {
+        indent match {
+          case None      => sb.append(out): Unit
+          case Some(ind) =>
+            var pending = true
+            var i       = 0
+            while (i < out.length) {
+              val c = out.charAt(i)
+              if (c == '\n' || c == '\r') {
+                sb.append(c): Unit
+                pending = true
+              } else {
+                if (pending) { sb.append(ind): Unit; pending = false }
+                sb.append(c): Unit
+              }
+              i += 1
+            }
+        }
+        trailingNl.foreach(s => sb.append(s): Unit)
+      }
+    }
+  }
+
+  private def resolve(scope: Map[String, Any], name: String): Option[Any] = scope.get(name).filter(_ != null)
+
+  // a multi-valued reference concatenates its non-null values, with the separator between them if any
+  private def appendValue(sb: java.lang.StringBuilder, v: Any, sep: Option[String]): Unit = {
+    def list(l: Seq[Any]): Unit = {
+      var first = true
+      l.foreach { e =>
+        if (e != null) {
+          if (!first) sep.foreach(s => sb.append(s): Unit)
+          appendValue(sb, e, sep)
+          first = false
+        }
+      }
+    }
+    v match {
+      case s: Seq[?]   => list(s.asInstanceOf[Seq[Any]])
+      case a: Array[?] => list(scala.collection.immutable.ArraySeq.unsafeWrapArray(a).asInstanceOf[Seq[Any]])
+      case other => sb.append(other.toString): Unit
+    }
+  }
+
+  // same truth table as ST3: null is false, a Boolean is itself, a list is its non-emptiness, anything else is true
+  private def truthy(v: Option[Any]): Boolean = v match {
+    case None              => false
+    case Some(b: Boolean)  => b
+    case Some(s: Seq[?])   => s.nonEmpty
+    case Some(a: Array[?]) => a.nonEmpty
+    case Some(_)           => true
+  }
+
+  private def asList(v: Option[Any]): Seq[Any] = v match {
+    case None              => Nil
+    case Some(s: Seq[?])   => s.asInstanceOf[Seq[Any]]
+    case Some(a: Array[?]) => scala.collection.immutable.ArraySeq.unsafeWrapArray(a).asInstanceOf[Seq[Any]]
+    case Some(other)       => other :: Nil
+  }
+
+  // property access on a map or an object accessor (only used as &parameter.escapedValue& & co)
+  private def property(v: Any, prop: String): Any = {
+    try {
+      v match {
+        case m: java.util.Map[?, ?]        => m.get(prop)
+        case m: scala.collection.Map[?, ?] => m.asInstanceOf[scala.collection.Map[String, Any]].getOrElse(prop, null)
+        case other => other.getClass.getMethod(prop).invoke(other)
+      }
+    } catch { case NonFatal(_) => null }
+  }
+
+  private object Parser {
+    import fastparse.*
+    import fastparse.NoWhitespace.*
+
+    def parse(content: String): PureResult[ParsedTemplate] = {
+      fastparse.parse(content, { case given P[?] => template }) match {
+        case Parsed.Success(parts, _) => Right(ParsedTemplate(parts))
+        case f: Parsed.Failure => Left(Inconsistency(s"Error when parsing template: ${f.trace().longMsg}"))
+      }
+    }
+
+    private val keywords = Set("if", "elseif", "else", "endif")
+
+    /*
+     * ST3 auto-indent, lexer side: when an expression is only preceded by whitespace on its
+     * line, that whitespace is moved from the literal text to the expression (see `indented`
+     * in the renderer), except for conditional markers where ST3 simply discards it.
+     * `atLineStart` tells if the first part of the list starts on a fresh line.
+     */
+    private def extractIndents(parts: Seq[TemplateAst], atLineStart: Boolean): Seq[TemplateAst] = {
+      def lineStartIndent(t: String, isFirst: Boolean): Option[(String, String)] = {
+        val idx = t.lastIndexOf('\n')
+        val ind = t.substring(idx + 1)
+        if (ind.nonEmpty && ind.forall(c => c == ' ' || c == '\t') && (idx >= 0 || (isFirst && atLineStart))) {
+          Some((t.substring(0, idx + 1), ind))
+        } else None
+      }
+
+      val res = scala.collection.mutable.ArrayBuffer[TemplateAst]()
+      parts.foreach { p =>
+        (res.lastOption, p) match {
+          case (Some(Txt(t)), (_: Ref | _: Loop | _: Cond)) =>
+            lineStartIndent(t, res.sizeIs == 1) match {
+              case Some((remaining, ind)) =>
+                res.dropRightInPlace(1)
+                if (remaining.nonEmpty) res += Txt(remaining)
+                res += (p match {
+                  case r: Ref  => r.copy(indent = Some(ind))
+                  case l: Loop => l.copy(indent = Some(ind))
+                  case other => other // conditional: the indentation is discarded
+                })
+              case None                   => res += p
+            }
+          case _                                            => res += p
+        }
+      }
+      res.toSeq
+    }
+
+    /*
+     * ST3 empty-line elision (from StringTemplate.write): when an expression chunk alone on
+     * its line writes nothing, the following newline is skipped. The newline is moved onto
+     * the expression at parse time and the renderer emits it only for a non-empty expansion.
+     * Line starts are determined on the original parts (matching ST3's chunk list).
+     */
+    private def elideEmptyExprLines(parts: Seq[TemplateAst], atLineStart: Boolean): Seq[TemplateAst] = {
+      val res  = scala.collection.mutable.ArrayBuffer[TemplateAst]()
+      val v    = parts.toVector
+      var drop = 0
+      var i    = 0
+      while (i < v.length) {
+        val p         = v(i) match {
+          case Txt(t) => Txt(t.substring(drop))
+          case other  => other
+        }
+        drop = 0
+        val lineStart = {
+          if (i == 0) atLineStart
+          else {
+            v(i - 1) match {
+              case Txt(t) => t.endsWith("\n")
+              case _      => false
+            }
+          }
+        }
+        val nextNl    = v.lift(i + 1) match {
+          case Some(Txt(t)) if t.startsWith("\r\n") => Some("\r\n")
+          case Some(Txt(t)) if t.startsWith("\n")   => Some("\n")
+          case _                                    => None
+        }
+        p match {
+          case r: Ref if lineStart && nextNl.isDefined  =>
+            res += r.copy(trailingNewline = nextNl)
+            drop = nextNl.get.length
+          case l: Loop if lineStart && nextNl.isDefined =>
+            res += l.copy(trailingNewline = nextNl)
+            drop = nextNl.get.length
+          case c: Cond if lineStart && nextNl.isDefined =>
+            res += c.copy(trailingNewline = nextNl)
+            drop = nextNl.get.length
+          case Txt(t) if t.isEmpty => () // fully consumed by the previous expression
+          case other               => res += other
+        }
+        i += 1
+      }
+      res.toSeq
+    }
+
+    /*
+     * Remove the Comment markers: as in the ST3 lexer, a comment starting its line also
+     * swallows the following newline (its whole line disappears). Adjacent texts are
+     * merged so that the other layout passes see through removed comments.
+     */
+    private def resolveComments(parts: Seq[TemplateAst], atLineStart: Boolean): Seq[TemplateAst] = {
+      val res    = scala.collection.mutable.ArrayBuffer[TemplateAst]()
+      var dropNl = false
+      parts.foreach {
+        case Comment =>
+          val lineStart = res.lastOption match {
+            case Some(Txt(t)) => t.endsWith("\n")
+            case Some(_)      => false
+            case None         => atLineStart
+          }
+          if (lineStart) dropNl = true
+        case Txt(t)  =>
+          val t2 = if (dropNl) t.replaceFirst("^\\r?\\n", "") else t
+          dropNl = false
+          if (t2.nonEmpty) {
+            res.lastOption match {
+              case Some(Txt(prev)) => res(res.size - 1) = Txt(prev + t2)
+              case _               => res += Txt(t2)
+            }
+          }
+        case other   =>
+          dropNl = false
+          res += other
+      }
+      res.toSeq
+    }
+
+    private def postProcess(parts: Seq[TemplateAst], atLineStart: Boolean): Seq[TemplateAst] =
+      elideEmptyExprLines(extractIndents(resolveComments(parts, atLineStart), atLineStart), atLineStart)
+
+    private def template[A: P]: P[Seq[TemplateAst]] =
+      P(parts(inSub = false) ~ End).map(postProcess(_, atLineStart = true))
+
+    private def parts[A: P](inSub: Boolean): P[Seq[TemplateAst]] = P(part(inSub).rep).map(_.flatten)
+
+    private def part[A: P](inSub: Boolean): P[Seq[TemplateAst]] = P(
+      comment.map(_ => Seq(Comment))
+      | cond(inSub)
+      | expression.map(Seq(_))
+      | escapedChar.map(c => Seq(Txt(c)))
+      | (if (inSub) braced else Fail)
+      | text(inSub).map(t => Seq(Txt(t)))
+    )
+
+    // a run of literal text; inside a subtemplate braces are matched separately to find its end
+    private def text[A: P](inSub: Boolean): P[String] = P(
+      CharsWhile(c => c != '&' && c != '\\' && !(inSub && (c == '{' || c == '}'))).!
+    )
+
+    // \& is a literal '&', \\ a literal '\', any other backslash is kept verbatim (as in the ST ampersand lexer)
+    private def escapedChar[A: P]: P[String] = P("\\" ~ AnyChar.!).map {
+      case "&"   => "&"
+      case "\\"  => "\\"
+      case other => "\\" + other
+    }
+
+    private def comment[A: P]: P[Unit] = P("&!" ~ (!"!&" ~ AnyChar).rep ~ "!&")
+
+    // balanced braces inside a subtemplate body are plain text (e.g. cfengine lists)
+    private def braced[A: P]: P[Seq[TemplateAst]] =
+      P("{" ~ parts(inSub = true) ~ "}").map(inner => (Txt("{") +: inner) :+ Txt("}"))
+
+    private def ws[A:    P]: P[Unit]   = P(CharsWhileIn(" \t", 0))
+    private def eol[A:   P]: P[Unit]   = P("\r".? ~ "\n")
+    private def name[A:  P]: P[String] = P(CharsWhileIn("a-zA-Z0-9_").!)
+    private def ident[A: P]: P[String] = name.filter(n => !keywords(n))
+
+    private def quoted[A:    P]: P[String] = P("\"" ~ CharsWhile(_ != '"', 0).! ~ "\"")
+    private def separator[A: P]: P[String] = P(ws ~ ";" ~ ws ~ "separator" ~ ws ~ "=" ~ ws ~ quoted)
+
+    private def cond[A: P](inSub: Boolean): P[Seq[TemplateAst]] = P(
+      "&if" ~ ws ~ "(" ~ ws ~ "!".!.? ~ ws ~ name ~ ws ~ ")&" ~ eol.!.? ~ parts(inSub) ~
+      ("&else&" ~ eol.!.? ~ parts(inSub)).? ~ "&endif&" ~ eol.!.?
+    ).map {
+      case (neg, n, thenNl, thenBody, elseBranch, endifNl) =>
+        val (elseNl, elseBody) = elseBranch.map { case (nl, b) => (nl, b) }.getOrElse((None, Nil))
+
+        def body(parts: Seq[TemplateAst], nl: Option[String]): Seq[TemplateAst] = {
+          val atLineStart = nl.isDefined
+          elideEmptyExprLines(dropLastNewline(extractIndents(resolveComments(parts, atLineStart), atLineStart)), atLineStart)
+        }
+
+        // '&endif&' is at column 1 when directly preceded by a newline (or an empty body starting a line)
+        val lastBranch  = if (elseBranch.isDefined) (elseBody, elseNl) else (thenBody, thenNl)
+        val endifAtCol1 = lastBranch._1.lastOption match {
+          case Some(Txt(t)) => t.endsWith("\n")
+          case Some(_)      => false
+          case None         => lastBranch._2.isDefined
+        }
+        val c           = Cond(n, neg.isDefined, body(thenBody, thenNl), body(elseBody, elseNl))
+        endifNl match {
+          // ST3 only swallows the newline after '&endif&' when the marker starts its line
+          case Some(nl) if !endifAtCol1 => Seq(c, Txt(nl))
+          case _                        => Seq(c)
+        }
+    }
+
+    // ST3 drops the newline (and the indentation of the marker) just before '&else&' / '&endif&'
+    private def dropLastNewline(parts: Seq[TemplateAst]): Seq[TemplateAst] = parts.lastOption match {
+      case Some(Txt(t)) =>
+        val stripped = t.replaceFirst("\\r?\\n[ \\t]*$", "")
+        if (stripped.isEmpty) parts.init else parts.init :+ Txt(stripped)
+      case _            => parts
+    }
+
+    // like the ST3 action parser, whitespace is tolerated between the tokens of an expression
+    private def expression[A: P]: P[TemplateAst] = P(loop | ref)
+
+    // '&LIST;separator=","&' (no subtemplate) joins the values with the separator
+    private def ref[A: P]: P[TemplateAst] = P("&" ~ ws ~ ident ~ (ws ~ "." ~ ws ~ ident).? ~ separator.? ~ ws ~ "&").map {
+      case (n, p, sep) => Ref(n, p, sep)
+    }
+
+    private def loop[A: P]: P[TemplateAst] = P(
+      "&" ~ ws ~ ident.rep(1, sep = ws ~ "," ~ ws) ~ ws ~ ":" ~ ws ~ subtemplate ~ separator.? ~ ws ~ "&"
+    ).map { case (attrs, (params, body), sep) => Loop(attrs, params, body, sep) }
+
+    private def subtemplate[A: P]: P[(Seq[String], Seq[TemplateAst])] = P(
+      // ST3 skips a single whitespace character right after the parameters' '|'
+      "{" ~ (ws ~ ident.rep(1, sep = ws ~ "," ~ ws) ~ ws ~ "|" ~ ("\r\n" | CharIn(" \t\n")).!.?).? ~ parts(inSub = true) ~ "}"
+    ).map {
+      case (paramsAndNl, body) =>
+        val (params, nl) = paramsAndNl.map { case (ps, nl) => (ps, nl) }.getOrElse((Nil, None))
+        (params, postProcess(body, atLineStart = nl.exists(_.contains("\n"))))
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/PolicyTemplateService.scala
+++ b/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/PolicyTemplateService.scala
@@ -1,0 +1,179 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.templates
+
+import com.normation.errors.*
+import com.normation.stringtemplate.language.NormationAmpersandTemplateLexer
+import com.normation.zio.currentTimeNanos
+import enumeratum.Enum
+import enumeratum.EnumEntry
+import org.antlr.stringtemplate.StringTemplate
+import zio.*
+import zio.syntax.*
+
+/*
+ * The engine used to fill policy templates (".st" files) during policy generation:
+ * - StringTemplate: the historical engine, based on the (mutable, synchronized)
+ *   StringTemplate 3 library with the ampersand lexer;
+ * - Fastparse: the new in-house engine (see AmpersandTemplate), an immutable AST
+ *   parsed with fastparse and rendered as a pure function.
+ * Both accept the same template syntax; the choice is done once at service init
+ * with the `rudder.policy.template.engine` property in rudder-web.properties.
+ */
+sealed abstract class PolicyTemplateEngine(override val entryName: String) extends EnumEntry
+
+object PolicyTemplateEngine extends Enum[PolicyTemplateEngine] {
+  case object StringTemplate extends PolicyTemplateEngine("string-template")
+  case object Fastparse      extends PolicyTemplateEngine("rudder-fastparse")
+
+  val values: IndexedSeq[PolicyTemplateEngine] = findValues
+
+  def default: PolicyTemplateEngine = StringTemplate
+
+  def parse(s: String): PureResult[PolicyTemplateEngine] = {
+    withNameInsensitiveOption(s.trim).toRight(
+      Inconsistency(
+        s"Value '${s}' is not a valid policy template engine, expected values are: ${values.map(_.entryName).mkString("'", "', '", "'")}"
+      )
+    )
+  }
+}
+
+/*
+ * A template parsed by one of the engines, ready to be filled.
+ * BEWARE: the StringTemplate case holds a MUTABLE, NON THREAD SAFE template: a
+ * given instance must not be filled concurrently (PolicyWriterService guarantees
+ * that by grouping templates by content and filling each group sequentially).
+ * The Fastparse case is immutable and free of such constraint.
+ */
+sealed trait PreparedTemplate
+object PreparedTemplate {
+  final case class StringTemplateInstance(template: StringTemplate) extends PreparedTemplate
+  final case class FastparseTemplate(template: ParsedTemplate)      extends PreparedTemplate
+}
+
+/*
+ * The service used by policy generation to parse and fill policy templates,
+ * one implementation per PolicyTemplateEngine.
+ */
+trait PolicyTemplateService {
+  def engine: PolicyTemplateEngine
+
+  /* parse template content; `name` is only used in error messages */
+  def parse(name: String, content: String): IOResult[PreparedTemplate]
+
+  /*
+   * Fill the template with the given variables and return (filled content, file name),
+   * where the file name is `templateName` with the multi-policy tag substituted when
+   * `replaceId` is defined.
+   */
+  def fill(
+      templateName: String,
+      template:     PreparedTemplate,
+      variables:    Seq[STVariable],
+      timer:        FillTemplateTimer,
+      replaceId:    Option[(String, String)]
+  ): IOResult[(String, String)]
+
+  def clearCache(): IOResult[Unit]
+}
+
+class StringTemplatePolicyTemplateService(fillTemplates: FillTemplatesService) extends PolicyTemplateService {
+  override val engine: PolicyTemplateEngine = PolicyTemplateEngine.StringTemplate
+
+  override def parse(name: String, content: String): IOResult[PreparedTemplate] = {
+    IOResult.attempt(s"Error when trying to parse template '${name}'") {
+      PreparedTemplate.StringTemplateInstance(new StringTemplate(content, classOf[NormationAmpersandTemplateLexer]))
+    }
+  }
+
+  override def fill(
+      templateName: String,
+      template:     PreparedTemplate,
+      variables:    Seq[STVariable],
+      timer:        FillTemplateTimer,
+      replaceId:    Option[(String, String)]
+  ): IOResult[(String, String)] = {
+    template match {
+      case PreparedTemplate.StringTemplateInstance(st) =>
+        FillTemplateThreadUnsafe.fill(templateName, st, variables, timer, replaceId)
+      case other                                       =>
+        Unexpected(s"Template '${templateName}' was not parsed by the '${engine.entryName}' engine, this is a bug").fail
+    }
+  }
+
+  override def clearCache(): IOResult[Unit] = fillTemplates.clearCache()
+}
+
+class FastparsePolicyTemplateService extends PolicyTemplateService {
+  override val engine: PolicyTemplateEngine = PolicyTemplateEngine.Fastparse
+
+  override def parse(name: String, content: String): IOResult[PreparedTemplate] = {
+    AmpersandTemplate
+      .parse(content)
+      .map(PreparedTemplate.FastparseTemplate.apply)
+      .toIO
+      .chainError(
+        s"Error when trying to parse template '${name}'"
+      )
+  }
+
+  override def fill(
+      templateName: String,
+      template:     PreparedTemplate,
+      variables:    Seq[STVariable],
+      timer:        FillTemplateTimer,
+      replaceId:    Option[(String, String)]
+  ): IOResult[(String, String)] = {
+    template match {
+      case PreparedTemplate.FastparseTemplate(ast) =>
+        (for {
+          t0     <- currentTimeNanos
+          result <- AmpersandTemplate.fill(ast, templateName, variables, replaceId).toIO
+          t1     <- currentTimeNanos
+          // rendering is one pure step: variable handling and stringification are not distinguishable
+          _      <- timer.fill.update(_ + t1 - t0)
+        } yield result).chainError(s"Error with template '${templateName}'").uninterruptible
+      case other                                   =>
+        Unexpected(s"Template '${templateName}' was not parsed by the '${engine.entryName}' engine, this is a bug").fail
+    }
+  }
+
+  // the immutable ASTs are parsed per generation by the policy writer, there is no cache to clear
+  override def clearCache(): IOResult[Unit] = ZIO.unit
+}

--- a/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/AmpersandTemplateTest.scala
+++ b/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/AmpersandTemplateTest.scala
@@ -1,0 +1,196 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.templates
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import scala.collection.immutable.ArraySeq
+
+final case class TestParameter(parameterName: String, escapedValue: String)
+
+@RunWith(classOf[JUnitRunner])
+class AmpersandTemplateTest extends Specification {
+
+  private def fill(template: String, vars: (String, Any)*): String = {
+    AmpersandTemplate.parse(template) match {
+      case Right(parsed) => AmpersandTemplate.render(parsed.parts, vars.toMap)
+      case Left(err)     => throw new RuntimeException(err.fullMsg)
+    }
+  }
+
+  "variable expansion" should {
+    "replace a simple variable" in {
+      fill("Hello, &name&", "name" -> "World") === "Hello, World"
+    }
+    "render an absent variable as empty" in {
+      fill("Hello, &name&!") === "Hello, !"
+    }
+    "concatenate the values of a list variable" in {
+      fill("&list&", "list" -> Seq("a", "b", "c")) === "abc"
+    }
+    "join the values of a list variable with a separator when given" in {
+      // seen in the wild: clientlist.st '&CLIENTSFOLDERS;separator=":"&'
+      (fill("""&list;separator=":"&""", "list" -> Seq("a", "b", "c")) === "a:b:c") and
+      (fill("""&v;separator=":"&""", "v" -> "a") === "a")
+    }
+    "access a property of an object" in {
+      fill("&parameter.escapedValue&", "parameter" -> TestParameter("p", "v")) === "v"
+    }
+    "tolerate whitespace inside expressions like the ST3 action parser" in {
+      // seen in the wild: rpmPackageInstallationData.st (2011) starts its loop with '& RPM_PACKAGE_REDACTION, ...'
+      (fill("& name &", "name" -> "World") === "World") and
+      (fill("& parameter . escapedValue &", "parameter" -> TestParameter("p", "v")) === "v") and
+      (fill("& l1, l2 :{ a, b |&a&:&b&;}&", "l1" -> Seq("x"), "l2" -> Seq("y")) === "x:y;")
+    }
+    "access a property of a map" in {
+      val m = new java.util.HashMap[String, String]()
+      m.put("escapedValue", "v")
+      fill("&parameter.escapedValue&", "parameter" -> m) === "v"
+    }
+  }
+
+  "escapes and comments" should {
+    "unescape ampersand and keep other backslashes" in {
+      fill("""cf-agent -f failsafe.cf \&\& cf-agent 2>\&1 a\b c\\d""") === """cf-agent -f failsafe.cf && cf-agent 2>&1 a\b c\d"""
+    }
+    "skip comments" in {
+      fill("a&! some comment !&b") === "ab"
+    }
+    "swallow the newline after a comment starting its line, keep it otherwise" in {
+      (fill("a\n&! full line comment !&\nb") === "a\nb") and
+      (fill("a &! inline comment !&\nb") === "a \nb")
+    }
+  }
+
+  "conditionals" should {
+    "use the value of a boolean variable" in {
+      fill("&if(X)&yes&endif&no", "X" -> true) === "yesno"
+      fill("&if(X)&yes&endif&no", "X" -> false) === "no"
+    }
+    "support negation and else" in {
+      fill("&if(!X)&no&else&yes&endif&", "X" -> true) === "yes"
+      fill("&if(!X)&no&else&yes&endif&") === "no"
+    }
+    "be false on absent variable, true on any string" in {
+      fill("&if(X)&yes&endif&", "X" -> "anything") === "yes"
+      fill("&if(X)&yes&endif&") === ""
+    }
+    "test emptiness of list variables" in {
+      fill("&if(X)&yes&endif&", "X" -> Seq("a")) === "yes"
+      fill("&if(X)&yes&endif&", "X" -> Seq()) === ""
+    }
+    "swallow the newlines around the condition markers like ST3" in {
+      fill("&if(X)&\nyes\n&else&\nno\n&endif&\nend", "X" -> true) === "yesend"
+      fill("&if(X)&\nyes\n&else&\nno\n&endif&\nend", "X" -> false) === "noend"
+    }
+  }
+
+  "iteration" should {
+    "iterate in parallel up to the longest list, missing values empty" in {
+      // same case as TemplateTest.arrayTest on ST3
+      fill("&list1,list2:{ n,p |&n&:&p&}&", "list1" -> Seq("chi", "fou", "mi"), "list2" -> Seq("bar", "bazz")) ===
+      "chi:barfou:bazzmi:"
+    }
+    "apply separator between iterations" in {
+      fill("""&l:{x |<&x&>}; separator=", "&""", "l" -> Seq("a", "b")) === "<a>, <b>"
+    }
+    "bind the implicit iterator when no parameter is declared" in {
+      fill("""&l: { [&it&] }&""", "l" -> Seq("a", "b")) === " [a]  [b] "
+    }
+    "provide 1-based &i& and 0-based &i0&" in {
+      fill("""&l:{x |&i&/&i0&:&x& }&""", "l" -> Seq("a", "b")) === "1/0:a 2/1:b "
+    }
+    "iterate once on a scalar value" in {
+      fill("""&l:{x |[&x&]}&""", "l" -> "a") === "[a]"
+    }
+    "not iterate on an absent variable" in {
+      fill("""&l:{x |[&x&]}&""") === ""
+    }
+    "see outer variables from the loop body and restore builtins" in {
+      fill("""&l:{x |&x&=&out&;}&""", "l" -> Seq("a", "b"), "out" -> "o") === "a=o;b=o;"
+    }
+    "keep balanced braces in the body as text, skipping the single space after the pipe" in {
+      fill("""&l:{x | or => { "c_&x&" };}&""", "l" -> Seq("a")) === """or => { "c_a" };"""
+    }
+  }
+
+  "auto-indent" should {
+    "re-apply the line indentation to each line of a multi-line expansion" in {
+      fill("  vars:\n      &V&\nend", "V" -> "a\nb") === "  vars:\n      a\n      b\nend"
+    }
+    "elide the whole line, indentation and newline included, for an empty expansion" in {
+      fill("  vars:\n      &V&\nend") === "  vars:\nend"
+    }
+    "re-indent each line produced by an indented loop" in {
+      fill("  vars:\n      &l:{x |\"&x&\",\n}&\nend", "l" -> Seq("a", "b")) === "  vars:\n      \"a\",\n      \"b\",\n\nend"
+    }
+    "not treat mid-line whitespace as indentation" in {
+      fill("key: &V&", "V" -> "a\nb") === "key: a\nb"
+    }
+  }
+
+  "STVariable fill" should {
+    val parsed = AmpersandTemplate.parse("&if(SYS)&sys=&SYS&&endif&-&V&").toOption.get
+
+    "treat an empty may-be-empty system variable as absent" in {
+      val vars = List(
+        STVariable("SYS", mayBeEmpty = true, values = ArraySeq(""), isSystem = true),
+        STVariable("V", mayBeEmpty = false, values = ArraySeq("v"), isSystem = false)
+      )
+      AmpersandTemplate.fill(parsed, "test", vars, None) must beRight(("-v", "test"))
+    }
+    "error on a mandatory empty variable" in {
+      val vars = List(STVariable("V", mayBeEmpty = false, values = ArraySeq.empty[Any], isSystem = false))
+      AmpersandTemplate.fill(parsed, "test", vars, None) must beLeft
+    }
+    "substitute the multi-policy tag in content and file name with replaceId" in {
+      val t = AmpersandTemplate.parse("id=&RudderUniqueID&").toOption.get
+      AmpersandTemplate.fill(t, "technique_RudderUniqueID.cf", Nil, Some(("RudderUniqueID", "d1"))) must
+      beRight(("id=d1", "technique_d1.cf"))
+    }
+  }
+
+  "PolicyTemplateEngine" should {
+    "parse valid names case-insensitively and reject unknown ones" in {
+      (PolicyTemplateEngine.parse("string-template") must beRight(PolicyTemplateEngine.StringTemplate)) and
+      (PolicyTemplateEngine.parse("Rudder-Fastparse") must beRight(PolicyTemplateEngine.Fastparse)) and
+      (PolicyTemplateEngine.parse("jinja") must beLeft)
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/StringTemplateDifferentialTest.scala
+++ b/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/StringTemplateDifferentialTest.scala
@@ -1,0 +1,243 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.templates
+
+import com.normation.stringtemplate.language.NormationAmpersandTemplateLexer
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.antlr.stringtemplate.StringTemplate
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Differential test between StringTemplate 3 and AmpersandTemplate: every .st
+ * file of the rudder-techniques repository is filled by both engines with the
+ * same synthetic variable values (derived from the variables each template
+ * references), in two passes (conditions all satisfied / all unsatisfied), and
+ * the outputs must be identical up to whitespace (each line trimmed, blank
+ * lines ignored - ST3 auto-indentation and newline-swallowing rules are pure
+ * layout).
+ *
+ * The rudder-techniques repository is located by the RUDDER_TECHNIQUES_DIR env
+ * variable, defaulting to a checkout next to the rudder repository; the test is
+ * skipped when not found.
+ */
+@RunWith(classOf[JUnitRunner])
+class StringTemplateDifferentialTest extends Specification {
+
+  // all corpora of real templates: the rudder-techniques repository (located by env
+  // variable, with a default for a checkout next to the rudder one) and the test
+  // techniques of rudder-core (which contain older syntax, e.g. '& VAR ...&')
+  val templateRoots: List[Path] = List(
+    Paths.get(sys.env.getOrElse("RUDDER_TECHNIQUES_DIR", "../../../../../rudder-techniques")),
+    Paths.get("../rudder-core/src/test/resources/configuration-repository/techniques")
+  ).map(_.toAbsolutePath.normalize).filter(Files.isDirectory(_))
+
+  args(skipAll = templateRoots.isEmpty)
+
+  def stFiles(root: Path): List[Path] = {
+    Files
+      .walk(root)
+      .iterator()
+      .asScala
+      .filter(f => f.toString.endsWith(".st") && Files.isRegularFile(f))
+      .toList
+      .sortBy(_.toString)
+  }
+
+  // what a template references, to generate matching synthetic values
+  final case class Usage(refs: Set[String], props: Map[String, Set[String]], conds: Set[String], loopAttrs: Set[String])
+
+  def usageOf(parts: Seq[TemplateAst]): Usage = {
+    import scala.collection.mutable
+    val refs      = mutable.Set[String]()
+    val props     = mutable.Map[String, mutable.Set[String]]()
+    val conds     = mutable.Set[String]()
+    val loopAttrs = mutable.Set[String]()
+
+    // bound maps a loop parameter to the list variable it iterates (empty for builtins),
+    // so that property access on a parameter is attributed to the iterated variable
+    def go(parts: Seq[TemplateAst], bound: Map[String, String]): Unit = parts.foreach {
+      case _: TemplateAst.Txt => ()
+      case TemplateAst.Comment => ()
+      case r: TemplateAst.Ref  =>
+        bound.get(r.name) match {
+          case Some(owner) => r.prop.foreach(pp => if (owner.nonEmpty) props.getOrElseUpdate(owner, mutable.Set()) += pp)
+          case None        =>
+            refs += r.name
+            r.prop.foreach(pp => props.getOrElseUpdate(r.name, mutable.Set()) += pp)
+        }
+      case c: TemplateAst.Cond =>
+        if (!bound.contains(c.name)) conds += c.name
+        go(c.thenBody, bound)
+        go(c.elseBody, bound)
+      case l: TemplateAst.Loop =>
+        l.attrs.foreach(a => if (!bound.contains(a)) loopAttrs += a)
+        val names = if (l.params.isEmpty) List("it") else l.params.toList
+        go(l.body, bound ++ names.zip(l.attrs))
+    }
+
+    go(parts, Map("i" -> "", "i0" -> ""))
+    Usage(refs.toSet, props.view.mapValues(_.toSet).toMap, conds.toSet, loopAttrs.toSet)
+  }
+
+  def valuesFor(u: Usage, condsSatisfied: Boolean): Map[String, Any] = {
+    (u.refs ++ u.conds ++ u.loopAttrs).flatMap { n =>
+      def obj(i: Int): java.util.HashMap[String, String] = {
+        val m = new java.util.HashMap[String, String]()
+        u.props(n).foreach(p => m.put(p, s"${n}_${p}_${i}"))
+        m
+      }
+      if (u.conds(n) && !condsSatisfied) None
+      else if (u.props.contains(n) && u.loopAttrs(n)) Some(n -> Seq(obj(1), obj(2), obj(3)))
+      else if (u.props.contains(n)) Some(n -> obj(1))
+      else if (u.loopAttrs(n)) Some(n -> Seq(s"${n}_1", s"${n}_2", s"${n}_3"))
+      else if (u.conds(n) && !u.refs(n)) Some(n -> java.lang.Boolean.TRUE)
+      else Some(n                               -> s"${n}_value")
+    }.toMap
+  }
+
+  var stNanos:  Long = 0L
+  var newNanos: Long = 0L
+
+  def fillSt3(content: String, values: Map[String, Any]): String = {
+    val t0  = System.nanoTime()
+    val st  = new StringTemplate(content, classOf[NormationAmpersandTemplateLexer])
+    values.foreach {
+      case (n, v) =>
+        v match {
+          // production code passes multi-values as a raw array, see FillTemplateThreadUnsafe
+          case s: Seq[?] => st.setAttribute(n, s.asInstanceOf[Seq[Any]].toArray)
+          case other => st.setAttribute(n, other)
+        }
+    }
+    val res = st.toString
+    stNanos += System.nanoTime() - t0
+    res
+  }
+
+  def fillNew(content: String, values: Map[String, Any]): Either[String, String] = {
+    val t0  = System.nanoTime()
+    val res = AmpersandTemplate.parse(content).map(p => AmpersandTemplate.render(p.parts, values))
+    newNanos += System.nanoTime() - t0
+    res.left.map(_.fullMsg)
+  }
+
+  def normalize(s: String): String = s.linesIterator.map(_.trim).filterNot(_.isEmpty).mkString("\n")
+
+  def firstDiff(a: String, b: String): String = {
+    val la = a.linesIterator.toVector
+    val lb = b.linesIterator.toVector
+    val i  = la.zipAll(lb, "<missing line>", "<missing line>").indexWhere(p => p._1 != p._2)
+    s"line ${i + 1}:\n  st3: ${la.applyOrElse(i, (_: Int) => "<missing line>")}\n  new: ${lb.applyOrElse(i, (_: Int) => "<missing line>")}"
+  }
+
+  def check(root: Path, file: Path): List[String] = {
+    val name    = root.relativize(file).toString
+    val content = Files.readString(file, StandardCharsets.UTF_8)
+    AmpersandTemplate.parse(content) match {
+      case Left(err)     => List(s"$name: parse error: ${err.fullMsg}")
+      case Right(parsed) =>
+        val u = usageOf(parsed.parts)
+        List(true, false).flatMap { condsSatisfied =>
+          val values = valuesFor(u, condsSatisfied)
+          val st3    = normalize(fillSt3(content, values))
+          fillNew(content, values) match {
+            case Left(err)  => List(s"$name: render error: $err")
+            case Right(out) =>
+              val newOut = normalize(out)
+              if (st3 == newOut) Nil
+              else List(s"$name (conditions ${if (condsSatisfied) "satisfied" else "unsatisfied"}): ${firstDiff(st3, newOut)}")
+          }
+        }
+    }
+  }
+
+  "all known .st templates" should {
+    "render identically (up to whitespace) with ST3 and AmpersandTemplate" in {
+      val files    = templateRoots.map(r => (r, stFiles(r)))
+      val failures = files.flatMap { case (root, fs) => fs.flatMap(check(root, _)) }
+      println(
+        s"[differential] ${files.map(_._2.size).sum} templates x 2 passes; ST3 fill: ${stNanos / 1000000} ms, new engine parse+render: ${newNanos / 1000000} ms"
+      )
+      failures aka s"${failures.size} mismatch(es):\n${failures.mkString("\n\n")}" must beEmpty
+    }
+
+    // indicative hot-path timing: in production the template is parsed once and cached,
+    // then filled for every (node, directive), so only the fill part matters
+    "print an indicative fill-time comparison on the biggest template" in {
+      val file    = templateRoots.flatMap(stFiles).maxBy(Files.size)
+      val content = Files.readString(file, StandardCharsets.UTF_8)
+      val values  = valuesFor(usageOf(AmpersandTemplate.parse(content).toOption.get.parts), condsSatisfied = true)
+      val n       = 1000
+
+      def time(warmupAndRun: () => Unit): Long = {
+        (0 until n).foreach(_ => warmupAndRun())
+        val t0 = System.nanoTime()
+        (0 until n).foreach(_ => warmupAndRun())
+        System.nanoTime() - t0
+      }
+
+      val source  = new StringTemplate(content, classOf[NormationAmpersandTemplateLexer])
+      val st3Time = time { () =>
+        val t = source.getInstanceOf()
+        values.foreach {
+          case (k, v) =>
+            v match {
+              case s: Seq[?] => t.setAttribute(k, s.asInstanceOf[Seq[Any]].toArray)
+              case other => t.setAttribute(k, other)
+            }
+        }
+        t.toString: Unit
+      }
+
+      val parsed  = AmpersandTemplate.parse(content).toOption.get
+      val newTime = time(() => AmpersandTemplate.render(parsed.parts, values): Unit)
+
+      println(
+        s"[bench] ${file.getFileName} (${Files.size(file)} bytes), $n fills: " +
+        s"ST3 ${st3Time / 1000000} ms, new engine ${newTime / 1000000} ms (x${"%.1f".format(st3Time.toDouble / newTime)})"
+      )
+      ok
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -347,6 +347,15 @@ rudder.policy.distribution.port.https=443
 #
 rudder.generated.policies.group.owner=rudder-policy-reader
 
+#
+# Engine used to fill the policy templates (".st" files) during policy generation.
+# Both engines accept the same template syntax:
+# - 'string-template':  the historical engine, based on the StringTemplate 3 library (default)
+# - 'rudder-fastparse': the new in-house engine (faster, thread safe), experimental for now
+# A change requires a webapp restart.
+#
+#rudder.policy.template.engine=string-template
+
 # - 'rudder.dir.backup' is the directory path where previous configuration of each node are stored
 # CAUTION: For performance and consistency, it is necessary that the rudder.dir.backup is on the same
 # filesystem as /var/rudder/share/ , otherwise the policies change for nodes is non-atomic (move becomes

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -137,7 +137,11 @@ import com.normation.rudder.web.components.administration.PolicyBackup
 import com.normation.rudder.web.components.administration.RudderCompanyAccount
 import com.normation.rudder.web.model.*
 import com.normation.rudder.web.services.*
+import com.normation.templates.FastparsePolicyTemplateService
 import com.normation.templates.FillTemplatesService
+import com.normation.templates.PolicyTemplateEngine
+import com.normation.templates.PolicyTemplateService
+import com.normation.templates.StringTemplatePolicyTemplateService
 import com.normation.utils.CronParser.*
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.StringUuidGeneratorImpl
@@ -708,6 +712,23 @@ object RudderParsedProperties {
       logger.error(s"Error when parsing cron for 'rudder.git.gc', it will be disabled: ${err.fullMsg}")
       None
     case Right(opt) => opt
+  }
+
+  val RUDDER_POLICY_TEMPLATE_ENGINE: PolicyTemplateEngine = {
+    try {
+      PolicyTemplateEngine.parse(config.getString("rudder.policy.template.engine")) match {
+        case Right(engine) => engine
+        case Left(err)     =>
+          logger.warn(
+            s"Ignoring invalid value for property 'rudder.policy.template.engine': ${err.fullMsg}. " +
+            s"Defaulting to '${PolicyTemplateEngine.default.entryName}'"
+          )
+          PolicyTemplateEngine.default
+      }
+    } catch {
+      // missing key: this is an optional property, use default without a log
+      case ex: Exception => PolicyTemplateEngine.default
+    }
   }
 
   val RUDDER_INVENTORIES_CLEAN_CRON: Option[CronExpr] = (
@@ -3292,6 +3313,13 @@ object RudderConfigInit {
       () => configService.cfengine_outputs_ttl().toBox,
       () => configService.rudder_report_protocol_default().toBox
     )
+    lazy val policyTemplateService: PolicyTemplateService = {
+      ApplicationLogger.info(s"Policy template engine: '${RUDDER_POLICY_TEMPLATE_ENGINE.entryName}'")
+      RUDDER_POLICY_TEMPLATE_ENGINE match {
+        case PolicyTemplateEngine.StringTemplate => new StringTemplatePolicyTemplateService(new FillTemplatesService())
+        case PolicyTemplateEngine.Fastparse      => new FastparsePolicyTemplateService()
+      }
+    }
     lazy val rudderCf3PromisesFileWriterService = {
       val nodeConfigurationLogger = NodeConfigurationLogger.make(RUDDER_DEBUG_NODE_CONFIGURATION_PATH).runNow
 
@@ -3305,7 +3333,7 @@ object RudderConfigInit {
           new BuildBundleSequence(systemVariableSpecService, writeAllAgentSpecificFiles),
           agentRegister
         ),
-        new FillTemplatesService(),
+        policyTemplateService,
         writeAllAgentSpecificFiles,
         HOOKS_D,
         HOOKS_IGNORE_SUFFIXES,


### PR DESCRIPTION
https://issues.rudder.io/issues/29316

Replace StringTemplate by our own fastparse parser. 

The parser is the hardest, biggest and most uninteresting part (from a rudder architecture PoV) of the change. 
It was claude-fable generated based on our good coverture of policy generation tests. I don't think I would have been able to implement it without weeks of tedious work. Happy it was done in a couple hours. The result is actually pretty nice and it looks like the king of things the bot really excel to do (one file, no big architecture choices, can be compared to other output...). 

It gives byte-for-byte to the string template one on our test corpus which is rather extensive and at least tests all system technique for 9.2 since they were updated for https://github.com/Normation/rudder/pull/7169. 

I kepted the two implementations for now, and they can be configured with a `rudder-web.properties` option:
```
rudder.policy.template.engine=string-template | rudder-fastparse
```
And for now, I let string template being the default. If we are happy with result in alpha, we can change it for beta. 

# Code evolution

The main changes are rather trivial appart the parser by itself (the arch
- create a trait `PolicyTemplateService` for the parsing logic API to isolate string template 
- update `PolicyWriterService` to use the trait 
- create an implementation for string template and for fastparse of the traint, 
- create the feature switch that given what user chose init in `RudderConfig` the string template or fastparse implementation, 

For tests: 
- add a "fastparse" version of our policy writing tests, 
- create a differential test to compare between string template and our parser output of our template cases,

Everything is green. 

# Security relief

We can remove string template (at least in 9.2 not use it), an outdated, not maintained, huge dependency that is a security liability for years now, Just that is a resounding success. 

# Safety - no more mutable template

We had several really sad bugs in the past due to string template being mutable, reusing templates, etc. For example, at some point in time, we had variable from one directive used in an other when load was heavy.  
With an immutable, FT-minded parser, we can't have that anymore by construction. 

# Performance improvements

In addition to the security and safety improvment, we seems to have a nice side effect of: 
- around 30x speed-up in pur template reading/filling, 
- around 1.3x (30%) improvment on policy writing. 

The second one is amazing if it holds in more complex set-up than my tiny env (120 nodes and not that many directives), and on servers that don't have an nvme disk. 

The policy writing should be massively dominated by actually writing the policies on disk. Here, we saw that there was so much contention due to string template not being thread-safe (so we needed mutex) that we win a lot. 

