### PR TITLE
Fixes #29345: Use processActivityApiError instead of processApiError

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
@@ -1,6 +1,6 @@
 port module GroupRecentActivity exposing (..)
 
-import Activity.ApiCalls exposing (getActivities, processApiError)
+import Activity.ApiCalls exposing (getActivities, processActivityApiError)
 import Activity.DataTypes exposing (Activity, ActivityMsg(..), BodyParameters, ContextPath(..), Search, string2Search)
 import Activity.HtmlParserAdapter exposing (toHtml, toString)
 import Browser
@@ -170,7 +170,7 @@ update msg model =
                             ( { model | activityTable = updatedTable }, Cmd.none )
 
                         Err err ->
-                            ( model, processApiError "Getting activities list" err errorNotification )
+                            ( model, processActivityApiError "Getting activities list" err errorNotification )
 
                 CopyToClipboard s ->
                     ( model, copy s )


### PR DESCRIPTION
https://issues.rudder.io/issues/29345

`Activity.ApiCalls.processApiError` was renamed to `Activity.ApiCalls.processActivityApiError` so we need to use `processActivityApiError`