### PR TITLE
Fixes #27111: Link to search in agent version donut are not correct

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
@@ -161,7 +161,7 @@ const onClickDoughnuts = (e, active, currentChart, id, data) => {
           { objectType: "node"
           , attribute : "agentVersion"
           , comparator: "regex"
-          , value     : "(\\d+:)?" + data.replace(/\./g, "(\.|~)") + ".*"
+          , value     : "(\\d+:)?" + data.replace(/\./g, "(\\.|~)") + ".*"
           }
         ];
         break;


### PR DESCRIPTION
https://issues.rudder.io/issues/27111

The added `\` put one backslash in the resulting query, and so we are at least not telling "anything or..."
<img width="795" height="105" alt="image" src="https://github.com/user-attachments/assets/434b3d55-1f56-49a4-ad77-4958fdf14bb8" />
