### PR TITLE
Fixes #28621: Search on processes don't work anymore

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -781,7 +781,7 @@ case class InstanceIdComparator(instanceId: InstanceId) extends NonLdapCriterion
  *
  * Used for "process" attribute
  */
-final case class JsonFixedKeyComparator(ldapAttr: String, jsonKey: String, quoteValue: Boolean) extends TStringComparator {
+final case class JsonFixedKeyComparator(ldapAttr: String, quoteValue: Boolean) extends TStringComparator {
   override val comparators = BaseComparators.comparators
 
   def format(attribute: String, value: String):              String                  = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -331,36 +331,36 @@ class NodeQueryCriteriaData(groupRepo: () => SubGroupComparatorRepository, insta
     ObjectCriterion(
       A_PROCESS,
       Chunk(
-        Criterion("pid", JsonFixedKeyComparator(A_PROCESS, "pid", quoteValue = false), UnsupportedByNodeMinimalApi),
+        Criterion("pid", JsonFixedKeyComparator(A_PROCESS, quoteValue = false), UnsupportedByNodeMinimalApi),
         Criterion(
-          "commandName",
-          JsonFixedKeyComparator(A_PROCESS, "commandName", quoteValue = true),
+          "name",
+          JsonFixedKeyComparator(A_PROCESS, quoteValue = true), // because of Process serialization
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "cpuUsage",
-          JsonFixedKeyComparator(A_PROCESS, "cpuUsage", quoteValue = false),
+          JsonFixedKeyComparator(A_PROCESS, quoteValue = false),
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "memory",
-          JsonFixedKeyComparator(A_PROCESS, "memory", quoteValue = false),
+          JsonFixedKeyComparator(A_PROCESS, quoteValue = false),
           UnsupportedByNodeMinimalApi
         ),
-        Criterion("tty", JsonFixedKeyComparator(A_PROCESS, "tty", quoteValue = true), UnsupportedByNodeMinimalApi),
+        Criterion("tty", JsonFixedKeyComparator(A_PROCESS, quoteValue = true), UnsupportedByNodeMinimalApi),
         Criterion(
           "virtualMemory",
-          JsonFixedKeyComparator(A_PROCESS, "virtualMemory", quoteValue = false),
+          JsonFixedKeyComparator(A_PROCESS, quoteValue = false),
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "started",
-          JsonFixedKeyComparator(A_PROCESS, "started", quoteValue = true),
+          JsonFixedKeyComparator(A_PROCESS, quoteValue = true),
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "user",
-          JsonFixedKeyComparator(A_PROCESS, "user", quoteValue = true),
+          JsonFixedKeyComparator(A_PROCESS, quoteValue = true),
           UnsupportedByNodeMinimalApi
         )
       )

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
@@ -311,10 +311,10 @@ ipHostNumber: 127.0.0.1
 environmentVariable: {"name":"SHELL","value":"/bin/sh"}
 customProperty:{"name":"datacenter", "value":"Paris"}
 customProperty:{"name":"from_inv", "value":{ "key1":"custom prop value", "key2":"some more json"}}
-process: {"pid":1,"commandName":"init [2]","cpuUsage":0.0,"memory":0.2000000
+process: {"pid":1,"name":"init [2]","cpuUsage":0.0,"memory":0.2000000
  0298023224,"started":"2015-01-21 17:24","tty":"?","user":"root","virtualMem
  ory":10648}
-process: {"pid":10,"commandName":"[kdevtmpfs]","cpuUsage":0.0,"memory":0.0,"
+process: {"pid":10,"name":"[kdevtmpfs]","cpuUsage":0.0,"memory":0.0,"
  started":"2015-01-21 17:24","tty":"?","user":"root","virtualMemory":0}
 
 # Example of a node

--- a/webapp/sources/rudder/rudder-core/src/test/resources/node-facts/4d3a43bc-8508-46a2-92d7-cfe7320309a5.json_
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/node-facts/4d3a43bc-8508-46a2-92d7-cfe7320309a5.json_
@@ -290,7 +290,7 @@
     "processes" : [
       {
         "pid" : 24832,
-        "commandName" : "(sd-pam)",
+        "name" : "(sd-pam)",
         "cpuUsage" : 0.0,
         "memory" : 1.0,
         "started" : "2022-09-07 15:30",
@@ -300,7 +300,7 @@
       },
       {
         "pid" : 24915,
-        "commandName" : "-bash",
+        "name" : "-bash",
         "cpuUsage" : 0.0,
         "memory" : 0.8,
         "started" : "2022-09-07 15:30",
@@ -310,7 +310,7 @@
       },
       {
         "pid" : 50026,
-        "commandName" : "/bin/sh /opt/rudder/bin/rudder-perl -I /opt/rudder/lib/perl5 /opt/rudder/bin/fusioninventory-agent --config=none --no-task=Deploy --local=/var/rudder/tmp/inventory/node1-4d3a43bc-8508-46a2-92d7-cfe7320309a5.ocs",
+        "name" : "/bin/sh /opt/rudder/bin/rudder-perl -I /opt/rudder/lib/perl5 /opt/rudder/bin/fusioninventory-agent --config=none --no-task=Deploy --local=/var/rudder/tmp/inventory/node1-4d3a43bc-8508-46a2-92d7-cfe7320309a5.ocs",
         "cpuUsage" : 0.0,
         "memory" : 0.2,
         "started" : "2022-09-07 19:56",
@@ -320,7 +320,7 @@
       },
       {
         "pid" : 50022,
-        "commandName" : "/bin/sh /opt/rudder/bin/run-inventory --local=/var/rudder/tmp/inventory/node1-4d3a43bc-8508-46a2-92d7-cfe7320309a5.ocs",
+        "name" : "/bin/sh /opt/rudder/bin/run-inventory --local=/var/rudder/tmp/inventory/node1-4d3a43bc-8508-46a2-92d7-cfe7320309a5.ocs",
         "cpuUsage" : 0.0,
         "memory" : 0.1,
         "started" : "2022-09-07 19:56",
@@ -330,7 +330,7 @@
       },
       {
         "pid" : 49923,
-        "commandName" : "/bin/sh /opt/rudder/share/commands/../lib/timestamp",
+        "name" : "/bin/sh /opt/rudder/share/commands/../lib/timestamp",
         "cpuUsage" : 0.0,
         "memory" : 0.2,
         "started" : "2022-09-07 19:56",
@@ -340,7 +340,7 @@
       },
       {
         "pid" : 49785,
-        "commandName" : "/bin/sh /opt/rudder/share/commands/agent-inventory",
+        "name" : "/bin/sh /opt/rudder/share/commands/agent-inventory",
         "cpuUsage" : 0.0,
         "memory" : 0.3,
         "started" : "2022-09-07 19:56",
@@ -350,7 +350,7 @@
       },
       {
         "pid" : 49925,
-        "commandName" : "/bin/sh /opt/rudder/share/commands/agent-run -N -D force_inventory -b doInventory",
+        "name" : "/bin/sh /opt/rudder/share/commands/agent-run -N -D force_inventory -b doInventory",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 19:56",
@@ -360,7 +360,7 @@
       },
       {
         "pid" : 49825,
-        "commandName" : "/bin/sh /opt/rudder/share/commands/agent-run -N -D force_inventory -b doInventory",
+        "name" : "/bin/sh /opt/rudder/share/commands/agent-run -N -D force_inventory -b doInventory",
         "cpuUsage" : 0.0,
         "memory" : 0.4,
         "started" : "2022-09-07 19:56",
@@ -370,7 +370,7 @@
       },
       {
         "pid" : 24830,
-        "commandName" : "/lib/systemd/systemd --user",
+        "name" : "/lib/systemd/systemd --user",
         "cpuUsage" : 0.0,
         "memory" : 1.5,
         "started" : "2022-09-07 15:30",
@@ -380,7 +380,7 @@
       },
       {
         "pid" : 339,
-        "commandName" : "/lib/systemd/systemd-journald",
+        "name" : "/lib/systemd/systemd-journald",
         "cpuUsage" : 0.0,
         "memory" : 1.9,
         "started" : "2022-09-07 11:43",
@@ -390,7 +390,7 @@
       },
       {
         "pid" : 683,
-        "commandName" : "/lib/systemd/systemd-logind",
+        "name" : "/lib/systemd/systemd-logind",
         "cpuUsage" : 0.0,
         "memory" : 1.0,
         "started" : "2022-09-07 11:43",
@@ -400,7 +400,7 @@
       },
       {
         "pid" : 1628,
-        "commandName" : "/lib/systemd/systemd-networkd",
+        "name" : "/lib/systemd/systemd-networkd",
         "cpuUsage" : 0.0,
         "memory" : 0.9,
         "started" : "2022-09-07 11:44",
@@ -410,7 +410,7 @@
       },
       {
         "pid" : 558,
-        "commandName" : "/lib/systemd/systemd-resolved",
+        "name" : "/lib/systemd/systemd-resolved",
         "cpuUsage" : 0.0,
         "memory" : 1.7,
         "started" : "2022-09-07 11:43",
@@ -420,7 +420,7 @@
       },
       {
         "pid" : 411,
-        "commandName" : "/lib/systemd/systemd-timesyncd",
+        "name" : "/lib/systemd/systemd-timesyncd",
         "cpuUsage" : 0.0,
         "memory" : 0.6,
         "started" : "2022-09-07 11:43",
@@ -430,7 +430,7 @@
       },
       {
         "pid" : 385,
-        "commandName" : "/lib/systemd/systemd-udevd",
+        "name" : "/lib/systemd/systemd-udevd",
         "cpuUsage" : 0.0,
         "memory" : 1.2,
         "started" : "2022-09-07 11:43",
@@ -440,7 +440,7 @@
       },
       {
         "pid" : 49921,
-        "commandName" : "/opt/rudder/bin/cf-agent -I -D info -Cnever -K -b doInventory -D force_inventory",
+        "name" : "/opt/rudder/bin/cf-agent -I -D info -Cnever -K -b doInventory -D force_inventory",
         "cpuUsage" : 55.0,
         "memory" : 5.6,
         "started" : "2022-09-07 19:56",
@@ -450,7 +450,7 @@
       },
       {
         "pid" : 4493,
-        "commandName" : "/opt/rudder/bin/cf-execd --no-fork",
+        "name" : "/opt/rudder/bin/cf-execd --no-fork",
         "cpuUsage" : 0.0,
         "memory" : 2.8,
         "started" : "2022-09-07 11:45",
@@ -460,7 +460,7 @@
       },
       {
         "pid" : 4495,
-        "commandName" : "/opt/rudder/bin/cf-serverd --graceful-detach=600 --no-fork --inform",
+        "name" : "/opt/rudder/bin/cf-serverd --graceful-detach=600 --no-fork --inform",
         "cpuUsage" : 0.0,
         "memory" : 2.6,
         "started" : "2022-09-07 11:45",
@@ -470,7 +470,7 @@
       },
       {
         "pid" : 746,
-        "commandName" : "/sbin/agetty -o -p -- \\u --keep-baud 115200,57600,38400,9600 ttyS0 vt220",
+        "name" : "/sbin/agetty -o -p -- \\u --keep-baud 115200,57600,38400,9600 ttyS0 vt220",
         "cpuUsage" : 0.0,
         "memory" : 0.1,
         "started" : "2022-09-07 11:43",
@@ -480,7 +480,7 @@
       },
       {
         "pid" : 757,
-        "commandName" : "/sbin/agetty -o -p -- \\u --noclear tty1 linux",
+        "name" : "/sbin/agetty -o -p -- \\u --noclear tty1 linux",
         "cpuUsage" : 0.0,
         "memory" : 0.1,
         "started" : "2022-09-07 11:43",
@@ -490,7 +490,7 @@
       },
       {
         "pid" : 1,
-        "commandName" : "/sbin/init",
+        "name" : "/sbin/init",
         "cpuUsage" : 0.0,
         "memory" : 2.2,
         "started" : "2022-09-07 11:43",
@@ -500,7 +500,7 @@
       },
       {
         "pid" : 381,
-        "commandName" : "/sbin/multipathd -d -s",
+        "name" : "/sbin/multipathd -d -s",
         "cpuUsage" : 0.0,
         "memory" : 5.6,
         "started" : "2022-09-07 11:43",
@@ -510,7 +510,7 @@
       },
       {
         "pid" : 674,
-        "commandName" : "/usr/bin/python3 /usr/bin/networkd-dispatcher --run-startup-triggers",
+        "name" : "/usr/bin/python3 /usr/bin/networkd-dispatcher --run-startup-triggers",
         "cpuUsage" : 0.0,
         "memory" : 2.3,
         "started" : "2022-09-07 11:43",
@@ -520,7 +520,7 @@
       },
       {
         "pid" : 773,
-        "commandName" : "/usr/bin/python3 /usr/share/unattended-upgrades/unattended-upgrade-shutdown --wait-for-signal",
+        "name" : "/usr/bin/python3 /usr/share/unattended-upgrades/unattended-upgrade-shutdown --wait-for-signal",
         "cpuUsage" : 0.0,
         "memory" : 2.6,
         "started" : "2022-09-07 11:43",
@@ -530,7 +530,7 @@
       },
       {
         "pid" : 681,
-        "commandName" : "/usr/lib/snapd/snapd",
+        "name" : "/usr/lib/snapd/snapd",
         "cpuUsage" : 0.0,
         "memory" : 5.6,
         "started" : "2022-09-07 11:43",
@@ -540,7 +540,7 @@
       },
       {
         "pid" : 2287,
-        "commandName" : "/usr/libexec/packagekitd",
+        "name" : "/usr/libexec/packagekitd",
         "cpuUsage" : 0.0,
         "memory" : 1.8,
         "started" : "2022-09-07 11:44",
@@ -550,7 +550,7 @@
       },
       {
         "pid" : 675,
-        "commandName" : "/usr/libexec/polkitd --no-debug",
+        "name" : "/usr/libexec/polkitd --no-debug",
         "cpuUsage" : 0.0,
         "memory" : 0.8,
         "started" : "2022-09-07 11:43",
@@ -560,7 +560,7 @@
       },
       {
         "pid" : 689,
-        "commandName" : "/usr/libexec/udisks2/udisksd",
+        "name" : "/usr/libexec/udisks2/udisksd",
         "cpuUsage" : 0.0,
         "memory" : 1.8,
         "started" : "2022-09-07 11:43",
@@ -570,7 +570,7 @@
       },
       {
         "pid" : 732,
-        "commandName" : "/usr/sbin/ModemManager",
+        "name" : "/usr/sbin/ModemManager",
         "cpuUsage" : 0.0,
         "memory" : 0.9,
         "started" : "2022-09-07 11:43",
@@ -580,7 +580,7 @@
       },
       {
         "pid" : 665,
-        "commandName" : "/usr/sbin/cron -f -P",
+        "name" : "/usr/sbin/cron -f -P",
         "cpuUsage" : 0.0,
         "memory" : 0.5,
         "started" : "2022-09-07 11:43",
@@ -590,7 +590,7 @@
       },
       {
         "pid" : 680,
-        "commandName" : "/usr/sbin/rsyslogd -n -iNONE",
+        "name" : "/usr/sbin/rsyslogd -n -iNONE",
         "cpuUsage" : 0.0,
         "memory" : 0.9,
         "started" : "2022-09-07 11:43",
@@ -600,7 +600,7 @@
       },
       {
         "pid" : 666,
-        "commandName" : "@dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only",
+        "name" : "@dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only",
         "cpuUsage" : 0.0,
         "memory" : 0.8,
         "started" : "2022-09-07 11:43",
@@ -610,7 +610,7 @@
       },
       {
         "pid" : 87,
-        "commandName" : "[acpi_thermal_pm]",
+        "name" : "[acpi_thermal_pm]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -620,7 +620,7 @@
       },
       {
         "pid" : 5965,
-        "commandName" : "[arc_evict]",
+        "name" : "[arc_evict]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -630,7 +630,7 @@
       },
       {
         "pid" : 5964,
-        "commandName" : "[arc_prune]",
+        "name" : "[arc_prune]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -640,7 +640,7 @@
       },
       {
         "pid" : 5966,
-        "commandName" : "[arc_reap]",
+        "name" : "[arc_reap]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -650,7 +650,7 @@
       },
       {
         "pid" : 75,
-        "commandName" : "[ata_sff]",
+        "name" : "[ata_sff]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -660,7 +660,7 @@
       },
       {
         "pid" : 73,
-        "commandName" : "[blkcg_punt_bio]",
+        "name" : "[blkcg_punt_bio]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -670,7 +670,7 @@
       },
       {
         "pid" : 115,
-        "commandName" : "[charger_manager]",
+        "name" : "[charger_manager]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -680,7 +680,7 @@
       },
       {
         "pid" : 17,
-        "commandName" : "[cpuhp/0]",
+        "name" : "[cpuhp/0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -690,7 +690,7 @@
       },
       {
         "pid" : 153,
-        "commandName" : "[cryptd]",
+        "name" : "[cryptd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -700,7 +700,7 @@
       },
       {
         "pid" : 5967,
-        "commandName" : "[dbu_evict]",
+        "name" : "[dbu_evict]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -710,7 +710,7 @@
       },
       {
         "pid" : 5968,
-        "commandName" : "[dbuf_evict]",
+        "name" : "[dbuf_evict]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -720,7 +720,7 @@
       },
       {
         "pid" : 78,
-        "commandName" : "[devfreq_wq]",
+        "name" : "[devfreq_wq]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -730,7 +730,7 @@
       },
       {
         "pid" : 5911,
-        "commandName" : "[dio/sda1]",
+        "name" : "[dio/sda1]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -740,7 +740,7 @@
       },
       {
         "pid" : 84,
-        "commandName" : "[ecryptfs-kthrea]",
+        "name" : "[ecryptfs-kthrea]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -750,7 +750,7 @@
       },
       {
         "pid" : 77,
-        "commandName" : "[edac-poller]",
+        "name" : "[edac-poller]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -760,7 +760,7 @@
       },
       {
         "pid" : 267,
-        "commandName" : "[ext4-rsv-conver]",
+        "name" : "[ext4-rsv-conver]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -770,7 +770,7 @@
       },
       {
         "pid" : 16,
-        "commandName" : "[idle_inject/0]",
+        "name" : "[idle_inject/0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -780,7 +780,7 @@
       },
       {
         "pid" : 19,
-        "commandName" : "[inet_frag_wq]",
+        "name" : "[inet_frag_wq]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -790,7 +790,7 @@
       },
       {
         "pid" : 362,
-        "commandName" : "[ipmi-msghandler]",
+        "name" : "[ipmi-msghandler]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -800,7 +800,7 @@
       },
       {
         "pid" : 96,
-        "commandName" : "[ipv6_addrconf]",
+        "name" : "[ipv6_addrconf]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -810,7 +810,7 @@
       },
       {
         "pid" : 266,
-        "commandName" : "[jbd2/sda1-8]",
+        "name" : "[jbd2/sda1-8]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -820,7 +820,7 @@
       },
       {
         "pid" : 372,
-        "commandName" : "[kaluad]",
+        "name" : "[kaluad]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -830,7 +830,7 @@
       },
       {
         "pid" : 20,
-        "commandName" : "[kauditd]",
+        "name" : "[kauditd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -840,7 +840,7 @@
       },
       {
         "pid" : 72,
-        "commandName" : "[kblockd]",
+        "name" : "[kblockd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -850,7 +850,7 @@
       },
       {
         "pid" : 24,
-        "commandName" : "[kcompactd0]",
+        "name" : "[kcompactd0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -860,7 +860,7 @@
       },
       {
         "pid" : 18,
-        "commandName" : "[kdevtmpfs]",
+        "name" : "[kdevtmpfs]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -870,7 +870,7 @@
       },
       {
         "pid" : 21,
-        "commandName" : "[khungtaskd]",
+        "name" : "[khungtaskd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -880,7 +880,7 @@
       },
       {
         "pid" : 71,
-        "commandName" : "[kintegrityd]",
+        "name" : "[kintegrityd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -890,7 +890,7 @@
       },
       {
         "pid" : 379,
-        "commandName" : "[kmpath_handlerd]",
+        "name" : "[kmpath_handlerd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -900,7 +900,7 @@
       },
       {
         "pid" : 374,
-        "commandName" : "[kmpath_rdacd]",
+        "name" : "[kmpath_rdacd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -910,7 +910,7 @@
       },
       {
         "pid" : 376,
-        "commandName" : "[kmpathd]",
+        "name" : "[kmpathd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -920,7 +920,7 @@
       },
       {
         "pid" : 25,
-        "commandName" : "[ksmd]",
+        "name" : "[ksmd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -930,7 +930,7 @@
       },
       {
         "pid" : 13,
-        "commandName" : "[ksoftirqd/0]",
+        "name" : "[ksoftirqd/0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -940,7 +940,7 @@
       },
       {
         "pid" : 106,
-        "commandName" : "[kstrp]",
+        "name" : "[kstrp]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -950,7 +950,7 @@
       },
       {
         "pid" : 83,
-        "commandName" : "[kswapd0]",
+        "name" : "[kswapd0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -960,7 +960,7 @@
       },
       {
         "pid" : 2,
-        "commandName" : "[kthreadd]",
+        "name" : "[kthreadd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -970,7 +970,7 @@
       },
       {
         "pid" : 86,
-        "commandName" : "[kthrotld]",
+        "name" : "[kthrotld]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -980,7 +980,7 @@
       },
       {
         "pid" : 32626,
-        "commandName" : "[kworker/0:0-cgroup_destroy]",
+        "name" : "[kworker/0:0-cgroup_destroy]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 16:50",
@@ -990,7 +990,7 @@
       },
       {
         "pid" : 7,
-        "commandName" : "[kworker/0:0H-events_highpri]",
+        "name" : "[kworker/0:0H-events_highpri]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1000,7 +1000,7 @@
       },
       {
         "pid" : 81,
-        "commandName" : "[kworker/0:1H-kblockd]",
+        "name" : "[kworker/0:1H-kblockd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1010,7 +1010,7 @@
       },
       {
         "pid" : 47519,
-        "commandName" : "[kworker/0:2-events]",
+        "name" : "[kworker/0:2-events]",
         "cpuUsage" : 0.1,
         "memory" : 0.0,
         "started" : "2022-09-07 19:34",
@@ -1020,7 +1020,7 @@
       },
       {
         "pid" : 47059,
-        "commandName" : "[kworker/u2:0-writeback]",
+        "name" : "[kworker/u2:0-writeback]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 19:32",
@@ -1030,7 +1030,7 @@
       },
       {
         "pid" : 48342,
-        "commandName" : "[kworker/u2:1-ext4-rsv-conversion]",
+        "name" : "[kworker/u2:1-ext4-rsv-conversion]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 19:40",
@@ -1040,7 +1040,7 @@
       },
       {
         "pid" : 48785,
-        "commandName" : "[kworker/u2:2-flush-8:0]",
+        "name" : "[kworker/u2:2-flush-8:0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 19:45",
@@ -1050,7 +1050,7 @@
       },
       {
         "pid" : 110,
-        "commandName" : "[kworker/u3:0]",
+        "name" : "[kworker/u3:0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1060,7 +1060,7 @@
       },
       {
         "pid" : 5970,
-        "commandName" : "[l2arc_feed]",
+        "name" : "[l2arc_feed]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1070,7 +1070,7 @@
       },
       {
         "pid" : 76,
-        "commandName" : "[md]",
+        "name" : "[md]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1080,7 +1080,7 @@
       },
       {
         "pid" : 15,
-        "commandName" : "[migration/0]",
+        "name" : "[migration/0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1090,7 +1090,7 @@
       },
       {
         "pid" : 95,
-        "commandName" : "[mld]",
+        "name" : "[mld]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1100,7 +1100,7 @@
       },
       {
         "pid" : 10,
-        "commandName" : "[mm_percpu_wq]",
+        "name" : "[mm_percpu_wq]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1110,7 +1110,7 @@
       },
       {
         "pid" : 162,
-        "commandName" : "[mpt/0]",
+        "name" : "[mpt/0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1120,7 +1120,7 @@
       },
       {
         "pid" : 161,
-        "commandName" : "[mpt_poll_0]",
+        "name" : "[mpt_poll_0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1130,7 +1130,7 @@
       },
       {
         "pid" : 5,
-        "commandName" : "[netns]",
+        "name" : "[netns]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1140,7 +1140,7 @@
       },
       {
         "pid" : 22,
-        "commandName" : "[oom_reaper]",
+        "name" : "[oom_reaper]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1150,7 +1150,7 @@
       },
       {
         "pid" : 222,
-        "commandName" : "[raid5wq]",
+        "name" : "[raid5wq]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1160,7 +1160,7 @@
       },
       {
         "pid" : 3,
-        "commandName" : "[rcu_gp]",
+        "name" : "[rcu_gp]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1170,7 +1170,7 @@
       },
       {
         "pid" : 4,
-        "commandName" : "[rcu_par_gp]",
+        "name" : "[rcu_par_gp]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1180,7 +1180,7 @@
       },
       {
         "pid" : 14,
-        "commandName" : "[rcu_sched]",
+        "name" : "[rcu_sched]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1190,7 +1190,7 @@
       },
       {
         "pid" : 11,
-        "commandName" : "[rcu_tasks_rude_]",
+        "name" : "[rcu_tasks_rude_]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1200,7 +1200,7 @@
       },
       {
         "pid" : 12,
-        "commandName" : "[rcu_tasks_trace]",
+        "name" : "[rcu_tasks_trace]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1210,7 +1210,7 @@
       },
       {
         "pid" : 89,
-        "commandName" : "[scsi_eh_0]",
+        "name" : "[scsi_eh_0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1220,7 +1220,7 @@
       },
       {
         "pid" : 91,
-        "commandName" : "[scsi_eh_1]",
+        "name" : "[scsi_eh_1]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1230,7 +1230,7 @@
       },
       {
         "pid" : 189,
-        "commandName" : "[scsi_eh_2]",
+        "name" : "[scsi_eh_2]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1240,7 +1240,7 @@
       },
       {
         "pid" : 90,
-        "commandName" : "[scsi_tmf_0]",
+        "name" : "[scsi_tmf_0]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1250,7 +1250,7 @@
       },
       {
         "pid" : 92,
-        "commandName" : "[scsi_tmf_1]",
+        "name" : "[scsi_tmf_1]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1260,7 +1260,7 @@
       },
       {
         "pid" : 190,
-        "commandName" : "[scsi_tmf_2]",
+        "name" : "[scsi_tmf_2]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1270,7 +1270,7 @@
       },
       {
         "pid" : 5960,
-        "commandName" : "[spl_delay_taskq]",
+        "name" : "[spl_delay_taskq]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1280,7 +1280,7 @@
       },
       {
         "pid" : 5961,
-        "commandName" : "[spl_dynamic_tas]",
+        "name" : "[spl_dynamic_tas]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1290,7 +1290,7 @@
       },
       {
         "pid" : 5962,
-        "commandName" : "[spl_kmem_cache]",
+        "name" : "[spl_kmem_cache]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1300,7 +1300,7 @@
       },
       {
         "pid" : 5959,
-        "commandName" : "[spl_system_task]",
+        "name" : "[spl_system_task]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1310,7 +1310,7 @@
       },
       {
         "pid" : 74,
-        "commandName" : "[tpm_dev_wq]",
+        "name" : "[tpm_dev_wq]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1320,7 +1320,7 @@
       },
       {
         "pid" : 94,
-        "commandName" : "[vfio-irqfd-clea]",
+        "name" : "[vfio-irqfd-clea]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1330,7 +1330,7 @@
       },
       {
         "pid" : 79,
-        "commandName" : "[watchdogd]",
+        "name" : "[watchdogd]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1340,7 +1340,7 @@
       },
       {
         "pid" : 23,
-        "commandName" : "[writeback]",
+        "name" : "[writeback]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1350,7 +1350,7 @@
       },
       {
         "pid" : 5969,
-        "commandName" : "[z_vdev_file]",
+        "name" : "[z_vdev_file]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1360,7 +1360,7 @@
       },
       {
         "pid" : 109,
-        "commandName" : "[zswap-shrink]",
+        "name" : "[zswap-shrink]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:43",
@@ -1370,7 +1370,7 @@
       },
       {
         "pid" : 5963,
-        "commandName" : "[zvol]",
+        "name" : "[zvol]",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1380,7 +1380,7 @@
       },
       {
         "pid" : 49926,
-        "commandName" : "awk -v info=0 -v full_strings=0 -v summary_only=0 -v quiet=0 -v multihost=0 -v green=\\033[1;32m -v darkgreen=\\033[0;32m -v red=\\033[1;31m -v yellow=\\033[1;33m -v magenta=\\033[1;35m -v normal=\\033[0;39m\\033[0;49m -v white=\\033[0;02m -v cyan=\\033[1;36m -v dblue=\\033[0;34m -v dgreen=\\033[0;32m -v timing=0 -v has_fflush=OK -v full_compliance=1 -v partial_run=1 -v error_fail=0 -v noncompliant_fail=0 -f /opt/rudder/share/commands/../lib/reports.awk",
+        "name" : "awk -v info=0 -v full_strings=0 -v summary_only=0 -v quiet=0 -v multihost=0 -v green=\\033[1;32m -v darkgreen=\\033[0;32m -v red=\\033[1;31m -v yellow=\\033[1;33m -v magenta=\\033[1;35m -v normal=\\033[0;39m\\033[0;49m -v white=\\033[0;02m -v cyan=\\033[1;36m -v dblue=\\033[0;34m -v dgreen=\\033[0;32m -v timing=0 -v has_fflush=OK -v full_compliance=1 -v partial_run=1 -v error_fail=0 -v noncompliant_fail=0 -f /opt/rudder/share/commands/../lib/reports.awk",
         "cpuUsage" : 0.0,
         "memory" : 0.8,
         "started" : "2022-09-07 19:56",
@@ -1390,7 +1390,7 @@
       },
       {
         "pid" : 24930,
-        "commandName" : "bash",
+        "name" : "bash",
         "cpuUsage" : 0.0,
         "memory" : 0.7,
         "started" : "2022-09-07 15:30",
@@ -1400,7 +1400,7 @@
       },
       {
         "pid" : 5927,
-        "commandName" : "bpfilter_umh",
+        "name" : "bpfilter_umh",
         "cpuUsage" : 0.0,
         "memory" : 0.1,
         "started" : "2022-09-07 11:45",
@@ -1410,7 +1410,7 @@
       },
       {
         "pid" : 49922,
-        "commandName" : "cat",
+        "name" : "cat",
         "cpuUsage" : 0.0,
         "memory" : 0.2,
         "started" : "2022-09-07 19:56",
@@ -1420,7 +1420,7 @@
       },
       {
         "pid" : 50027,
-        "commandName" : "fusioninventory-agent: running task Inventory",
+        "name" : "fusioninventory-agent: running task Inventory",
         "cpuUsage" : 47.0,
         "memory" : 10.1,
         "started" : "2022-09-07 19:56",
@@ -1430,7 +1430,7 @@
       },
       {
         "pid" : 5878,
-        "commandName" : "lxcfs /var/snap/lxd/common/var/lib/lxcfs -p /var/snap/lxd/common/lxcfs.pid",
+        "name" : "lxcfs /var/snap/lxd/common/var/lib/lxcfs -p /var/snap/lxd/common/lxcfs.pid",
         "cpuUsage" : 0.0,
         "memory" : 0.0,
         "started" : "2022-09-07 11:45",
@@ -1440,7 +1440,7 @@
       },
       {
         "pid" : 50040,
-        "commandName" : "ps -A -o user,pid,pcpu,pmem,vsz,tty,etime,command",
+        "name" : "ps -A -o user,pid,pcpu,pmem,vsz,tty,etime,command",
         "cpuUsage" : 0.0,
         "memory" : 0.3,
         "started" : "2022-09-07 19:56",
@@ -1450,7 +1450,7 @@
       },
       {
         "pid" : 797,
-        "commandName" : "sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups",
+        "name" : "sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups",
         "cpuUsage" : 0.0,
         "memory" : 1.1,
         "started" : "2022-09-07 11:43",
@@ -1460,7 +1460,7 @@
       },
       {
         "pid" : 24827,
-        "commandName" : "sshd: vagrant [priv]",
+        "name" : "sshd: vagrant [priv]",
         "cpuUsage" : 0.0,
         "memory" : 1.3,
         "started" : "2022-09-07 15:30",
@@ -1470,7 +1470,7 @@
       },
       {
         "pid" : 24914,
-        "commandName" : "sshd: vagrant@pts/0",
+        "name" : "sshd: vagrant@pts/0",
         "cpuUsage" : 0.0,
         "memory" : 1.3,
         "started" : "2022-09-07 15:30",
@@ -1480,7 +1480,7 @@
       },
       {
         "pid" : 24929,
-        "commandName" : "su",
+        "name" : "su",
         "cpuUsage" : 0.0,
         "memory" : 0.5,
         "started" : "2022-09-07 15:30",
@@ -1490,7 +1490,7 @@
       },
       {
         "pid" : 24928,
-        "commandName" : "sudo su",
+        "name" : "sudo su",
         "cpuUsage" : 0.0,
         "memory" : 0.1,
         "started" : "2022-09-07 15:30",
@@ -1500,7 +1500,7 @@
       },
       {
         "pid" : 24927,
-        "commandName" : "sudo su",
+        "name" : "sudo su",
         "cpuUsage" : 0.0,
         "memory" : 0.6,
         "started" : "2022-09-07 15:30",
@@ -1510,7 +1510,7 @@
       },
       {
         "pid" : 49924,
-        "commandName" : "tee /var/rudder/tmp/reports//2022-09-07T19:56:54+00:00@4d3a43bc-8508-46a2-92d7-cfe7320309a5.log",
+        "name" : "tee /var/rudder/tmp/reports//2022-09-07T19:56:54+00:00@4d3a43bc-8508-46a2-92d7-cfe7320309a5.log",
         "cpuUsage" : 0.0,
         "memory" : 0.2,
         "started" : "2022-09-07 19:56",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -1184,7 +1184,7 @@ class TestNodeFactQueryProcessor {
       "q2",
       parser("""
       {"select":"node","composition":"And","where":[
-        {"objectType":"process","attribute":"commandName","comparator":"regex","value":".*vtmp.*"}
+        {"objectType":"process","attribute":"name","comparator":"regex","value":".*vtmp.*"}
       ]}
       """).openOrThrowException("For tests"),
       s(1) :: Nil

--- a/webapp/sources/rudder/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
@@ -223,7 +223,8 @@ ldap.attr.vmMemory = Memory
 ldap.attr.virtualMachineUuid = UUID
 ldap.attr.subsystem = Subsystem
 ldap.attr.vmName = Name
-ldap.attr.commandName = Command name
+#only used in processes, we are lucky
+ldap.attr.name = Command name
 ldap.attr.memory = Memory usage
 ldap.attr.user = User
 ldap.attr.cpuUsage = CPU Usage


### PR DESCRIPTION
https://issues.rudder.io/issues/28621

So, we had exactly that occurence of: 
- a field whose nam is used in JSON LDAP search, 
- that changed in the serialization in https://github.com/Normation/rudder/pull/5656 

And we are lucky because there is no other `ldap.attr.name` :exploding_head: 

And the json field wasn't actually used anymore 