### PR TITLE
Fixes #29374: Rename fastparse class to actually fastparse

### DIFF
--- a/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FastparseTemplateParser.scala
+++ b/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FastparseTemplateParser.scala
@@ -107,7 +107,7 @@ object TemplateAst {
 
 final case class ParsedTemplate(parts: Seq[TemplateAst])
 
-object AmpersandTemplate {
+object FastparseTemplateParser {
   import TemplateAst.*
 
   def parse(content: String): PureResult[ParsedTemplate] = Parser.parse(content)

--- a/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/PolicyTemplateService.scala
+++ b/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/PolicyTemplateService.scala
@@ -50,7 +50,7 @@ import zio.syntax.*
  * The engine used to fill policy templates (".st" files) during policy generation:
  * - StringTemplate: the historical engine, based on the (mutable, synchronized)
  *   StringTemplate 3 library with the ampersand lexer;
- * - Fastparse: the new in-house engine (see AmpersandTemplate), an immutable AST
+ * - Fastparse: the new in-house engine (see FastparseTemplateParser), an immutable AST
  *   parsed with fastparse and rendered as a pure function.
  * Both accept the same template syntax; the choice is done once at service init
  * with the `rudder.policy.template.engine` property in rudder-web.properties.
@@ -144,7 +144,7 @@ class FastparsePolicyTemplateService extends PolicyTemplateService {
   override val engine: PolicyTemplateEngine = PolicyTemplateEngine.Fastparse
 
   override def parse(name: String, content: String): IOResult[PreparedTemplate] = {
-    AmpersandTemplate
+    FastparseTemplateParser
       .parse(content)
       .map(PreparedTemplate.FastparseTemplate.apply)
       .toIO
@@ -164,7 +164,7 @@ class FastparsePolicyTemplateService extends PolicyTemplateService {
       case PreparedTemplate.FastparseTemplate(ast) =>
         (for {
           t0     <- currentTimeNanos
-          result <- AmpersandTemplate.fill(ast, templateName, variables, replaceId).toIO
+          result <- FastparseTemplateParser.fill(ast, templateName, variables, replaceId).toIO
           t1     <- currentTimeNanos
           // rendering is one pure step: variable handling and stringification are not distinguishable
           _      <- timer.fill.update(_ + t1 - t0)

--- a/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/FastparseTemplateParserTest.scala
+++ b/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/FastparseTemplateParserTest.scala
@@ -45,11 +45,11 @@ import scala.collection.immutable.ArraySeq
 final case class TestParameter(parameterName: String, escapedValue: String)
 
 @RunWith(classOf[JUnitRunner])
-class AmpersandTemplateTest extends Specification {
+class FastparseTemplateParserTest extends Specification {
 
   private def fill(template: String, vars: (String, Any)*): String = {
-    AmpersandTemplate.parse(template) match {
-      case Right(parsed) => AmpersandTemplate.render(parsed.parts, vars.toMap)
+    FastparseTemplateParser.parse(template) match {
+      case Right(parsed) => FastparseTemplateParser.render(parsed.parts, vars.toMap)
       case Left(err)     => throw new RuntimeException(err.fullMsg)
     }
   }
@@ -166,22 +166,22 @@ class AmpersandTemplateTest extends Specification {
   }
 
   "STVariable fill" should {
-    val parsed = AmpersandTemplate.parse("&if(SYS)&sys=&SYS&&endif&-&V&").toOption.get
+    val parsed = FastparseTemplateParser.parse("&if(SYS)&sys=&SYS&&endif&-&V&").toOption.get
 
     "treat an empty may-be-empty system variable as absent" in {
       val vars = List(
         STVariable("SYS", mayBeEmpty = true, values = ArraySeq(""), isSystem = true),
         STVariable("V", mayBeEmpty = false, values = ArraySeq("v"), isSystem = false)
       )
-      AmpersandTemplate.fill(parsed, "test", vars, None) must beRight(("-v", "test"))
+      FastparseTemplateParser.fill(parsed, "test", vars, None) must beRight(("-v", "test"))
     }
     "error on a mandatory empty variable" in {
       val vars = List(STVariable("V", mayBeEmpty = false, values = ArraySeq.empty[Any], isSystem = false))
-      AmpersandTemplate.fill(parsed, "test", vars, None) must beLeft
+      FastparseTemplateParser.fill(parsed, "test", vars, None) must beLeft
     }
     "substitute the multi-policy tag in content and file name with replaceId" in {
-      val t = AmpersandTemplate.parse("id=&RudderUniqueID&").toOption.get
-      AmpersandTemplate.fill(t, "technique_RudderUniqueID.cf", Nil, Some(("RudderUniqueID", "d1"))) must
+      val t = FastparseTemplateParser.parse("id=&RudderUniqueID&").toOption.get
+      FastparseTemplateParser.fill(t, "technique_RudderUniqueID.cf", Nil, Some(("RudderUniqueID", "d1"))) must
       beRight(("id=d1", "technique_d1.cf"))
     }
   }

--- a/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/StringTemplateDifferentialTest.scala
+++ b/webapp/sources/rudder/rudder-templates/src/test/scala/com/normation/templates/StringTemplateDifferentialTest.scala
@@ -49,7 +49,7 @@ import org.specs2.runner.JUnitRunner
 import scala.jdk.CollectionConverters.*
 
 /**
- * Differential test between StringTemplate 3 and AmpersandTemplate: every .st
+ * Differential test between StringTemplate 3 and FastparseTemplateParser: every .st
  * file of the rudder-techniques repository is filled by both engines with the
  * same synthetic variable values (derived from the variables each template
  * references), in two passes (conditions all satisfied / all unsatisfied), and
@@ -157,7 +157,7 @@ class StringTemplateDifferentialTest extends Specification {
 
   def fillNew(content: String, values: Map[String, Any]): Either[String, String] = {
     val t0  = System.nanoTime()
-    val res = AmpersandTemplate.parse(content).map(p => AmpersandTemplate.render(p.parts, values))
+    val res = FastparseTemplateParser.parse(content).map(p => FastparseTemplateParser.render(p.parts, values))
     newNanos += System.nanoTime() - t0
     res.left.map(_.fullMsg)
   }
@@ -174,7 +174,7 @@ class StringTemplateDifferentialTest extends Specification {
   def check(root: Path, file: Path): List[String] = {
     val name    = root.relativize(file).toString
     val content = Files.readString(file, StandardCharsets.UTF_8)
-    AmpersandTemplate.parse(content) match {
+    FastparseTemplateParser.parse(content) match {
       case Left(err)     => List(s"$name: parse error: ${err.fullMsg}")
       case Right(parsed) =>
         val u = usageOf(parsed.parts)
@@ -193,7 +193,7 @@ class StringTemplateDifferentialTest extends Specification {
   }
 
   "all known .st templates" should {
-    "render identically (up to whitespace) with ST3 and AmpersandTemplate" in {
+    "render identically (up to whitespace) with ST3 and FastparseTemplateParser" in {
       val files    = templateRoots.map(r => (r, stFiles(r)))
       val failures = files.flatMap { case (root, fs) => fs.flatMap(check(root, _)) }
       println(
@@ -207,7 +207,7 @@ class StringTemplateDifferentialTest extends Specification {
     "print an indicative fill-time comparison on the biggest template" in {
       val file    = templateRoots.flatMap(stFiles).maxBy(Files.size)
       val content = Files.readString(file, StandardCharsets.UTF_8)
-      val values  = valuesFor(usageOf(AmpersandTemplate.parse(content).toOption.get.parts), condsSatisfied = true)
+      val values  = valuesFor(usageOf(FastparseTemplateParser.parse(content).toOption.get.parts), condsSatisfied = true)
       val n       = 1000
 
       def time(warmupAndRun: () => Unit): Long = {
@@ -230,8 +230,8 @@ class StringTemplateDifferentialTest extends Specification {
         t.toString: Unit
       }
 
-      val parsed  = AmpersandTemplate.parse(content).toOption.get
-      val newTime = time(() => AmpersandTemplate.render(parsed.parts, values): Unit)
+      val parsed  = FastparseTemplateParser.parse(content).toOption.get
+      val newTime = time(() => FastparseTemplateParser.render(parsed.parts, values): Unit)
 
       println(
         s"[bench] ${file.getFileName} (${Files.size(file)} bytes), $n fills: " +


### PR DESCRIPTION
https://issues.rudder.io/issues/29374

It is just a renaming