### PR TITLE
Fixes #29390: Multi-tenants: close filtering gaps (core)

### DIFF
--- a/adr/webapp/multi-tenants/28945-object-tenant-tag-lifecycle.md
+++ b/adr/webapp/multi-tenants/28945-object-tenant-tag-lifecycle.md
@@ -28,8 +28,15 @@ chooses the narrower list at creation time. This law makes event-log filtering s
 *pre-change* tag alongside each event and filter event reads by `grant.canSee(T_event)`. Because tags only
 grow, `T_event ⊆ T_now`, so anyone who can see an event can currently see the object (no leak), while a
 tenant added *after* a change never sees that change's pre-membership values (no historical-value leak).
-Deleting a whole tenant is safe (it is also removed from every grant), and reusing a tenant id is an intended
-recovery path for an accidentally deleted tenant (to be documented).
+**Tenant deletion is not cascading, and reusing a tenant id is an intended recovery path.** Deleting a tenant
+only removes it from the set of *declared* tenants; objects and nodes already tagged with that id keep their
+tag. While the id is undeclared those tags grant no access — `TenantService.refineTenantAccessGrant` strips
+undeclared ids from every user grant, so the tagged objects become admin-only. Recreating a tenant with the
+**same id** re-links all of them automatically. This is deliberate: it is the recovery path for an
+accidentally-deleted tenant, and it is why deletion does not scrub node/object tags. The operational
+consequence an administrator must be aware of — and which must therefore be surfaced in the tenant-deletion
+UI/API and not left as a silent side effect — is that reusing an id for a **different** customer hands them
+the previous tenant's still-tagged objects and nodes; a fresh id must be used in that case.
 
 ## Consequences
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -2110,9 +2110,21 @@ object JsonResponseObjects {
       security = None
     )
 
-    def fromGroup(group: NodeGroup, catId: NodeGroupCategoryId, crId: Option[ChangeRequestId])(using
-        qc: QueryContext
+    // `visibleNodes` is the set of node ids the caller may see (from `nodeFactRepo.getNodeAndServerIds()(qc)`);
+    // `None` means "no tenant filter" (admin/system paths). We filter the serialized `nodeIds` to it so a group
+    // visible to a tenant does not leak the ids of member nodes in tenants the caller can not see.
+    def fromGroup(
+        group:        NodeGroup,
+        catId:        NodeGroupCategoryId,
+        crId:         Option[ChangeRequestId],
+        visibleNodes: Option[Set[NodeId]]
+    )(using
+        qc:           QueryContext
     ): JRGroup = {
+      val nodeIds = (visibleNodes match {
+        case None      => group.serverList
+        case Some(vis) => group.serverList.filter(vis.contains)
+      }).toList.map(_.value).sorted
       group
         .into[JRGroup]
         .enableBeanGetters
@@ -2121,7 +2133,7 @@ object JsonResponseObjects {
         .withFieldRenamed(_.name, _.displayName)
         .withFieldConst(_.categoryId, catId.value)
         .withFieldComputed(_.query, _.query.map(JRQuery.fromQuery(_)))
-        .withFieldComputed(_.nodeIds, _.serverList.toList.map(_.value).sorted)
+        .withFieldConst(_.nodeIds, nodeIds)
         .withFieldComputed(_.groupClass, x => List(x.id.serialize, x.name).map(RuleTarget.toCFEngineClassName).sorted)
         .withFieldComputed(_.properties, _.properties.filter(_.visibility == Displayed).map(JRProperty.fromGroupProp(_)))
         .withFieldComputed(_.target, x => GroupTarget(x.id).target)
@@ -2182,8 +2194,9 @@ object JsonResponseObjects {
      * Sort by ID, also in groups to keep diff easier
      */
     def fromCategory(
-        cat:    FullNodeGroupCategory,
-        parent: Option[NodeGroupCategoryId]
+        cat:          FullNodeGroupCategory,
+        parent:       Option[NodeGroupCategoryId],
+        visibleNodes: Option[Set[NodeId]] // caller's visible node ids for `nodeIds` filtering; None = no filter
     )(using qc: QueryContext): JRFullGroupCategory = {
       cat
         .into[JRFullGroupCategory]
@@ -2193,12 +2206,12 @@ object JsonResponseObjects {
         )
         .withFieldComputed(
           _.subCategories,
-          cat => cat.subCategories.map(c => fromCategory(c, Some(cat.id))).sortBy(_.id.value)
+          cat => cat.subCategories.map(c => fromCategory(c, Some(cat.id), visibleNodes)).sortBy(_.id.value)
         )
         .withFieldComputed(
           _.groups,
           cat => {
-            cat.ownGroups.values.toList.map(t => JRGroup.fromGroup(t.nodeGroup, cat.id, None)).sortBy(_.id)
+            cat.ownGroups.values.toList.map(t => JRGroup.fromGroup(t.nodeGroup, cat.id, None, visibleNodes)).sortBy(_.id)
           }
         )
         .withFieldComputed(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
@@ -37,7 +37,7 @@
 
 package com.normation.rudder.batch
 
-import com.normation.errors.*
+import com.normation.box.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.AllReportLogger
 import com.normation.rudder.domain.logger.ScheduledJobLogger
@@ -117,7 +117,7 @@ class AutomaticReportLogger(
           case Empty =>
             logger.warn("Automatic report logger has never run, logging latest 100 non compliant reports")
             val isSuccess = (for {
-              hundredReports <- reportsRepository.getLastHundredErrorReports(reportsKind).toIO
+              hundredReports <- reportsRepository.getLastHundredErrorReports(reportsKind)
               nodes          <- nodeFactRepository.getAll()
               rules          <- ruleRepository.getAll(true)
               directives     <- directiveRepository.getFullDirectiveLibrary()
@@ -144,7 +144,7 @@ class AutomaticReportLogger(
 
           case Full(lastId) =>
             logger.trace("***** get current highest report id")
-            val highest = reportsRepository.getHighestId()
+            val highest = reportsRepository.getHighestId().toBox
             logger.trace(s"***** highest report id = ${highest} and last processed id = ${lastId}")
             highest match {
               case Full(currentId) if (currentId > lastId.getOrElse(0L)) =>
@@ -191,7 +191,7 @@ class AutomaticReportLogger(
           directives: FullActiveTechniqueCategory
       ): Box[Long] = {
         for {
-          reports <- reportsRepository.getReportsByKindBetween(fromId, Some(maxId), batchSize, reportsKind)
+          reports <- reportsRepository.getReportsByKindBetween(fromId, Some(maxId), batchSize, reportsKind).toBox
         } yield {
           // when we get an empty here, it means that we don't have more non-compliant report
           // in the interval, just return the max id

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
@@ -71,7 +71,7 @@ case class JSONReportsAnalyser(reportsRepository: ReportsRepository, propRepo: R
   def loop: IOResult[Unit] = {
     for {
       t0         <- currentTimeMillis
-      highestId  <- reportsRepository.getHighestId().toIO
+      highestId  <- reportsRepository.getHighestId()
       t1         <- currentTimeMillis
       _          <- CampaignLogger.Reports.trace(s"Got highest id of database in ${t1 - t0} ms")
       _          <- CampaignLogger.Reports.debug(s"looking for new json report to parse")
@@ -80,7 +80,7 @@ case class JSONReportsAnalyser(reportsRepository: ReportsRepository, propRepo: R
       _          <- CampaignLogger.Reports.trace(s"Got parsed id in ${t2 - t1} ms")
       lowerId     = optLowerId.getOrElse(highestId)
       _          <- CampaignLogger.Reports.debug(s"Last parsed id was ${lowerId}, max id in database is ${highestId}")
-      reports    <- reportsRepository.getReportsByKindBetween(lowerId, None, 1000, List(Reports.REPORT_JSON)).toIO
+      reports    <- reportsRepository.getReportsByKindBetween(lowerId, None, 1000, List(Reports.REPORT_JSON))
       t3         <- currentTimeMillis
       _          <- CampaignLogger.Reports.trace(s"Got reports in ${t3 - t2} ms")
       _          <- reports.maxByOption(_._1) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
@@ -103,7 +103,7 @@ class NodePropertiesServiceImpl(
                         .mkString}"
                   )
             }
-            gid -> resolved
+            gid -> TenantScopedGroupProps(group.nodeGroup.security, resolved)
         }
       }
       mergedNodes      = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/PropertiesRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/PropertiesRepository.scala
@@ -45,6 +45,8 @@ import com.normation.rudder.domain.properties.ResolvedNodePropertyHierarchy
 import com.normation.rudder.domain.properties.SuccessNodePropertyHierarchy
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.SecurityTag
+import com.normation.rudder.tenants.TenantCheckLogic
 import zio.*
 
 /*
@@ -52,11 +54,18 @@ import zio.*
  * of the computation of a property from the node, group and global context.
  */
 
+/*
+ * A group's resolved property hierarchy together with the owning group's `SecurityTag`. Carrying the tag with
+ * the cached value lets the group-property cache tenant-filter reads at this layer WITHOUT a group-repository
+ * dependency (which would create a construction cycle). See `InMemoryPropertiesRepository`.
+ */
+final case class TenantScopedGroupProps(security: Option[SecurityTag], props: ResolvedNodePropertyHierarchy)
+
 trait PropertiesRepository {
 
   def getAllNodeProps()(implicit qc: QueryContext): IOResult[Map[NodeId, ResolvedNodePropertyHierarchy]]
 
-  def getAllGroupProps(): IOResult[Map[NodeGroupId, ResolvedNodePropertyHierarchy]]
+  def getAllGroupProps()(implicit qc: QueryContext): IOResult[Map[NodeGroupId, ResolvedNodePropertyHierarchy]]
 
   /*
    * Get all properties for node with given ID
@@ -83,21 +92,25 @@ trait PropertiesRepository {
   def deleteNode(nodeId: NodeId): IOResult[Unit]
 
   /*
-   * Get all properties for node with given ID
+   * Get all properties for group with given ID, if it is visible in the query context.
    */
-  def getGroupProps(groupId: NodeGroupId): IOResult[Option[ResolvedNodePropertyHierarchy]]
+  def getGroupProps(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Option[ResolvedNodePropertyHierarchy]]
 
   /*
-   * Get a given property for a given node
+   * Get a given property for a given group, if it is visible in the query context.
    */
-  def getGroupProp(groupId: NodeGroupId, propName: String): IOResult[Option[PropertyHierarchy]]
+  def getGroupProp(groupId: NodeGroupId, propName: String)(implicit qc: QueryContext): IOResult[Option[PropertyHierarchy]]
 
   /*
-   * Save updated properties for nodes.
-   * The chunk is considered to be all of the node properties, so previous
-   * properties not in the new chunk will be deleted.
+   * Save updated properties for groups.
+   * The map is considered to be all of the group properties, so previous
+   * properties not in the new map will be deleted.
+   * Each entry carries its group's `SecurityTag` (see `TenantScopedGroupProps`) so that reads can be
+   * tenant-filtered at this layer: the cache is keyed by group id but the authoritative tenant decision
+   * travels with the entry, so no group-repository dependency is needed here (which would create a
+   * construction cycle).
    */
-  def saveGroupProps(props: Map[NodeGroupId, ResolvedNodePropertyHierarchy]): IOResult[Unit]
+  def saveGroupProps(props: Map[NodeGroupId, TenantScopedGroupProps]): IOResult[Unit]
 
   /*
    * Delete all properties for a node
@@ -106,20 +119,21 @@ trait PropertiesRepository {
 }
 
 object InMemoryPropertiesRepository {
-  def make(nodeFactRepo: NodeFactRepository): IOResult[InMemoryPropertiesRepository] = {
+  def make(nodeFactRepo: NodeFactRepository, checkTenant: TenantCheckLogic): IOResult[InMemoryPropertiesRepository] = {
     for {
       nodes  <- Ref.make(Map.empty[NodeId, ResolvedNodePropertyHierarchy])
-      groups <- Ref.make(Map.empty[NodeGroupId, ResolvedNodePropertyHierarchy])
+      groups <- Ref.make(Map.empty[NodeGroupId, TenantScopedGroupProps])
     } yield {
-      new InMemoryPropertiesRepository(nodeFactRepo, nodes, groups)
+      new InMemoryPropertiesRepository(nodeFactRepo, checkTenant, nodes, groups)
     }
   }
 }
 
 class InMemoryPropertiesRepository(
     nodeFactRepository: NodeFactRepository,
+    checkTenant:        TenantCheckLogic,
     nodeProps:          Ref[Map[NodeId, ResolvedNodePropertyHierarchy]],
-    groupProps:         Ref[Map[NodeGroupId, ResolvedNodePropertyHierarchy]]
+    groupProps:         Ref[Map[NodeGroupId, TenantScopedGroupProps]]
 ) extends PropertiesRepository {
 
   override def getAllNodeProps()(implicit qc: QueryContext): IOResult[Map[NodeId, ResolvedNodePropertyHierarchy]] = {
@@ -132,8 +146,10 @@ class InMemoryPropertiesRepository(
     }
   }
 
-  override def getAllGroupProps(): IOResult[Map[NodeGroupId, ResolvedNodePropertyHierarchy]] = {
-    groupProps.get
+  override def getAllGroupProps()(implicit qc: QueryContext): IOResult[Map[NodeGroupId, ResolvedNodePropertyHierarchy]] = {
+    groupProps.get.map(_.collect {
+      case (id, gp) if checkTenant.canSeeSecurityTag(gp.security) => (id, gp.props)
+    })
   }
 
   override def getNodeProps(nodeId: NodeId)(implicit qc: QueryContext): IOResult[Option[ResolvedNodePropertyHierarchy]] = {
@@ -171,19 +187,22 @@ class InMemoryPropertiesRepository(
     nodeProps.update(_.removed(nodeId))
   }
 
-  override def getGroupProps(groupId: NodeGroupId): IOResult[Option[ResolvedNodePropertyHierarchy]] = {
+  override def getGroupProps(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Option[ResolvedNodePropertyHierarchy]] = {
     groupProps.get.map(
-      _.get(groupId)
+      _.get(groupId).collect { case gp if checkTenant.canSeeSecurityTag(gp.security) => gp.props }
     )
   }
 
-  override def getGroupProp(groupId: NodeGroupId, propName: String): IOResult[Option[PropertyHierarchy]] = {
+  override def getGroupProp(groupId: NodeGroupId, propName: String)(implicit
+      qc: QueryContext
+  ): IOResult[Option[PropertyHierarchy]] = {
     groupProps.get.map(
-      _.get(groupId).flatMap(_.resolved.find(_.prop.name == propName))
+      _.get(groupId).collect { case gp if checkTenant.canSeeSecurityTag(gp.security) => gp.props }
+        .flatMap(_.resolved.find(_.prop.name == propName))
     )
   }
 
-  override def saveGroupProps(props: Map[NodeGroupId, ResolvedNodePropertyHierarchy]): IOResult[Unit] = {
+  override def saveGroupProps(props: Map[NodeGroupId, TenantScopedGroupProps]): IOResult[Unit] = {
     groupProps.set(props)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
@@ -92,7 +92,7 @@ class ReportsExecutionService(
         }
 
         // then find last reports id
-        reportsRepository.getHighestId() match {
+        reportsRepository.getHighestId().toBox match {
           case eb: EmptyBox =>
             val fail = eb ?~! "Could not get Reports with highest id from the RudderSysEvents table"
             logger.error(s"Could not get reports from the database, cause is: ${fail.messageChain}")
@@ -119,7 +119,7 @@ class ReportsExecutionService(
 
       // Executions status not initialized ... initialize it!
       case Full(None)                                 =>
-        reportsRepository.getReportsWithLowestId match {
+        reportsRepository.getReportsWithLowestId.toBox match {
           case Full(Some((id, report))) =>
             logger.debug(s"Initializing the status execution update to  id ${id}, date ${report.executionTimestamp}")
             idForCheck = id

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ReportsRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ReportsRepository.scala
@@ -43,7 +43,7 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.reports.execution.AgentRun
 import com.normation.rudder.reports.execution.AgentRunId
-import net.liftweb.common.Box
+import com.normation.rudder.tenants.QueryContext
 import org.joda.time.*
 
 /**
@@ -98,48 +98,44 @@ trait ReportsRepository {
   ): Seq[Reports]
 
   // databaseManager only
-  def getReportsInterval(): Box[(Option[DateTime], Option[DateTime])]
+  def getReportsInterval(): IOResult[(Option[DateTime], Option[DateTime])]
 
-  def getDatabaseSize(databaseName: String): Box[Long]
+  def getDatabaseSize(databaseName: String): IOResult[Long]
   def reports: String
-  def deleteEntries(date: DateTime): Box[Int]
+  def deleteEntries(date: DateTime): IOResult[Int]
 
-  def deleteLogReports(date: DateTime): Box[Int]
+  def deleteLogReports(date: DateTime): IOResult[Int]
 
   // automaticReportLogger only
   /**
    * Get the highest id of any kind of reports.
    */
-  def getHighestId(): Box[Long]
-  def getLastHundredErrorReports(kinds: List[String]): Box[Seq[(Long, Reports)]]
+  def getHighestId(): IOResult[Long]
+  def getLastHundredErrorReports(kinds: List[String]): IOResult[Seq[(Long, Reports)]]
   // return the reports between the two ids, limited to limit number of reports, in asc order of id.
-  def getReportsByKindBetween(lower:    Long, upper: Option[Long], limit: Int, kinds: List[String]): Box[Seq[(Long, Reports)]]
+  def getReportsByKindBetween(lower:    Long, upper: Option[Long], limit: Int, kinds: List[String]): IOResult[Seq[(Long, Reports)]]
 
   /*
    * Count number of changes by rule by interval. Also return the id of the highest result_repair.
    */
-  def countChangeReportsByBatch(intervals: List[Interval]): Box[(Long, Map[RuleId, Map[Interval, Int]])]
+  def countChangeReportsByBatch(intervals: List[Interval]): IOResult[(Long, Map[RuleId, Map[Interval, Int]])]
 
   // nodechangesServices
-  /*
-   *  Count change reports by rules on interval of intervalSizeHour hour, starting at startTime
-   *  StartTime should be a 00:00:00 time.
-   */
-  def countChangeReports(startTime:            DateTime, intervalSizeHour: Int): Box[Map[RuleId, Map[Interval, Int]]]
-  def getChangeReportsOnInterval(lowestId:     Long, highestId:            Long): IOResult[Seq[ChangeForCache]]
-  def getChangeReportsByRuleOnInterval(ruleId: RuleId, interval:           Interval, limit: Option[Int]): Box[Seq[ResultRepairedReport]]
-
-  // reportExecution only
-  // Return the max id before a datetime
-  def getMaxIdBeforeDateTime(fromId: Long, before: DateTime): Box[Option[Long]]
+  def getChangeReportsOnInterval(lowestId: Long, highestId: Long): IOResult[Seq[ChangeForCache]]
+  // the returned per-node reports are restricted to the nodes visible in the query context (a change report
+  // carries a node id; its tenant is the tenant of that node), so a tenant-restricted caller never sees other
+  // tenants' agent-report content.
+  def getChangeReportsByRuleOnInterval(
+      ruleId:   RuleId,
+      interval: Interval,
+      limit:    Option[Int]
+  )(implicit qc: QueryContext): IOResult[Seq[ResultRepairedReport]]
 
   /**
    * From an id and an end date (optionnal, if none, till now), return a list of AgentRun, and the max ID that has been considered
    */
-  def getReportsFromId(id: Long, endDate: DateTime): Box[(Seq[AgentRun], Long)]
+  def getReportsFromId(id: Long, endDate: DateTime): IOResult[(Seq[AgentRun], Long)]
 
-  def getReportsWithLowestId: Box[Option[(Long, Reports)]]
-
-  def getReportsWithLowestIdFromDate(from: DateTime): Box[Option[(Long, Reports)]]
+  def getReportsWithLowestId: IOResult[Option[(Long, Reports)]]
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/TenantFiltering.scala
@@ -167,9 +167,17 @@ class RoTenantDirectiveRepo(
     underlying.getActiveTechniqueCategory(id).map(checkTenant.flatMap(_))
   }
 
-  // Navigation methods (delegate, tenant filtering would break semantic)
-  override def activeTechniqueBreadCrump(id: ActiveTechniqueId)(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] =
-    underlying.activeTechniqueBreadCrump(id)
+  // Navigation method: the ancestor path can not be meaningfully pruned (a partial breadcrumb is nonsense),
+  // so instead gate on the LEAF - if the caller can not see the active technique, do not reveal its ancestry
+  // (no existence oracle). When it is visible, the full path to root is contextually fine.
+  override def activeTechniqueBreadCrump(
+      id: ActiveTechniqueId
+  )(using qc: QueryContext): IOResult[List[ActiveTechniqueCategory]] = {
+    underlying.getActiveTechniqueByActiveTechnique(id).map(checkTenant.flatMap(_)).flatMap {
+      case None    => List.empty[ActiveTechniqueCategory].succeed
+      case Some(_) => underlying.activeTechniqueBreadCrump(id)
+    }
+  }
 
   // active category only has ID for children, we can't filter yet
   override def getActiveTechniqueLibrary(using qc: QueryContext): IOResult[ActiveTechniqueCategory] = {
@@ -479,8 +487,14 @@ class RoTenantNodeGroupRepo(
     }
   }
 
-  override def categoryExists(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean] =
-    underlying.categoryExists(id)
+  // a category the caller can not see must read as "does not exist" - otherwise this is an existence oracle
+  // (reachable e.g. through the archive API). So: exists AND visible.
+  override def categoryExists(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[Boolean] = {
+    underlying.categoryExists(id).flatMap {
+      case false => false.succeed
+      case true  => underlying.getGroupCategory(id).map(checkTenant.check(_).isDefined)
+    }
+  }
 
   override def getNodeGroupCategory(id: NodeGroupId)(using qc: QueryContext): IOResult[NodeGroupCategory] = {
     underlying
@@ -506,7 +520,11 @@ class RoTenantNodeGroupRepo(
   override def getParents_NodeGroupCategory(id: NodeGroupCategoryId)(using qc: QueryContext): IOResult[List[NodeGroupCategory]] =
     underlying.getParents_NodeGroupCategory(id).map(checkTenant.filter(_))
 
-  // deprecated method returning a plain value: the root category is always visible (`Open`), so delegate
+  // Deprecated method returning a PLAIN value (no effect), so it can not do the IO lookups a real tenant
+  // check needs. Safe by invariant: the root category is always `Open`, hence visible to everyone (its `Pure`
+  // sibling below encodes exactly that check). Its `items` (`RuleTargetInfo`) carry no `SecurityTag`, so
+  // per-item pruning is not possible here regardless; group visibility is enforced on the group getters.
+  // Prefer `getRootCategoryPure()` in new code.
   override def getRootCategory()(using qc: QueryContext): NodeGroupCategory =
     underlying.getRootCategory()
 
@@ -843,8 +861,12 @@ class RoTenantRuleCategoryRepo(
     cat.modify(_.childs).setTo(cat.childs.collect { case c if qc.accessGrant.canSee(c.security) => filterTree(c) })
   }
 
-  override def get(id: RuleCategoryId)(using qc: QueryContext): IOResult[Option[RuleCategory]] =
-    underlying.get(id)
+  override def get(id: RuleCategoryId)(using qc: QueryContext): IOResult[Option[RuleCategory]] = {
+    // `RuleCategory` carries its child subtree, so prune the invisible children here too - otherwise
+    // `GET /rules/categories/{id}` would disclose categories the caller can not see (getRootCategory,
+    // one method below, already prunes; this was the inconsistency).
+    underlying.get(id).map(_.map(filterTree))
+  }
 
   override def getRootCategory()(using qc: QueryContext): IOResult[RuleCategory] =
     underlying.getRootCategory().map(filterTree)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -44,19 +44,23 @@ import com.normation.rudder.db.Doobie
 import com.normation.rudder.db.Doobie.*
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
+import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.reports.execution.AgentRun
 import com.normation.rudder.reports.execution.AgentRunId
 import com.normation.rudder.repository.ReportsRepository
+import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.TenantAccessGrant
 import doobie.*
 import doobie.implicits.*
 import java.sql.Timestamp
 import net.liftweb.common.*
 import org.joda.time.*
 import org.joda.time.format.ISODateTimeFormat
+import zio.ZIO
 import zio.interop.catz.*
 import zio.syntax.*
 
-class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Loggable {
+class ReportsJdbcRepository(doobie: Doobie, nodeFactRepository: NodeFactRepository) extends ReportsRepository with Loggable {
   import doobie.*
 
   val reports = "ruddersysevents"
@@ -163,8 +167,8 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
     }
   }
 
-  override def getReportsInterval(): Box[(Option[DateTime], Option[DateTime])] = {
-    transactRunBox(xa => {
+  override def getReportsInterval(): IOResult[(Option[DateTime], Option[DateTime])] = {
+    transactIOResult("Could not fetch the reports interval from the database.")(xa => {
       (for {
         oldest <- query[DateTime]("""select executiontimestamp from ruddersysevents
                                    order by executionTimeStamp asc  limit 1""").option
@@ -173,15 +177,15 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
       } yield {
         (oldest, newest)
       }).transact(xa)
-    }) ?~! "Could not fetch the reports interval from the database."
+    })
   }
 
-  override def getDatabaseSize(databaseName: String): Box[Long] = {
+  override def getDatabaseSize(databaseName: String): IOResult[Long] = {
     val q = query[Long](s"""select pg_total_relation_size('${databaseName}') as "size" """).unique
-    transactRunBox(xa => q.transact(xa)) ?~! "Could not compute the size of the database"
+    transactIOResult("Could not compute the size of the database")(xa => q.transact(xa))
   }
 
-  override def deleteEntries(date: DateTime): Box[Int] = {
+  override def deleteEntries(date: DateTime): IOResult[Int] = {
 
     val dateAt_0000 = date.toString("yyyy-MM-dd")
     val d1          = s"delete from ${reports} where executionTimeStamp < '${dateAt_0000}'"
@@ -196,79 +200,49 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
                     | ${d3}
                     |]]""".stripMargin)
 
-    (for {
-      i <- transactRunEither(xa => (d1 :: d3 :: Nil).traverse(q => Update0(q, None).run).transact(xa))
+    for {
+      i <- transactIOResult("Could not delete entries in the database")(xa =>
+             (d1 :: d3 :: Nil).traverse(q => Update0(q, None).run).transact(xa)
+           )
       // Vacuum cannot be run in a transaction block, it has to be in an autoCommit block
-      _ <- {
-        (v1 :: v3 :: Nil).map { vacuum =>
-          transactRunEither(xa => (FC.setAutoCommit(true) *> Update0(vacuum, None).run <* FC.setAutoCommit(false)).transact(xa))
-        }.sequence
-      }
-    } yield {
-      i
-    }) match {
-      case Left(ex) =>
-        val msg = "Could not delete entries in the database, cause is " + ex.getMessage()
-        logger.error(msg)
-        Failure(msg, Full(ex), Empty)
-      case Right(i) => Full(i.sum)
-    }
+      _ <- ZIO.foreach(v1 :: v3 :: Nil)(vacuum => {
+             transactIOResult("Could not vacuum the database")(xa =>
+               (FC.setAutoCommit(true) *> Update0(vacuum, None).run <* FC.setAutoCommit(false)).transact(xa)
+             )
+           })
+    } yield i.sum
   }
 
-  override def deleteLogReports(date: DateTime): Box[Int] = {
+  override def deleteLogReports(date: DateTime): IOResult[Int] = {
     val dateAt = date.toString(ISODateTimeFormat.dateTimeNoMillis())
     val q      = s"delete from ${reports} where executionTimeStamp < '${dateAt}' and eventtype like 'log_%'"
 
     logger.debug(s"""Deleting log reports with SQL query: [[${q}]]""")
-    transactRunBox(xa => Update0(q, None).run.transact(xa))
+    transactIOResult("Could not delete log reports in the database")(xa => Update0(q, None).run.transact(xa))
   }
 
-  override def getHighestId(): Box[Long] = {
-    transactRunBox(xa => query[Long](s"""SELECT last_value FROM serial""").unique.transact(xa))
+  override def getHighestId(): IOResult[Long] = {
+    transactIOResult("Could not fetch the highest report id in the database")(xa =>
+      query[Long](s"""SELECT last_value FROM serial""").unique.transact(xa)
+    )
   }
 
-  override def getLastHundredErrorReports(kinds: List[String]): Box[Seq[(Long, Reports)]] = {
+  override def getLastHundredErrorReports(kinds: List[String]): IOResult[Seq[(Long, Reports)]] = {
     val events = kinds.map(k => s"eventtype='${k}'").mkString(" or ")
     val q      = query[(Long, Reports)](s"${idQuery} and (${events}) order by executiondate desc limit 100")
 
-    transactRunEither(xa => q.to[Vector].transact(xa)) match {
-      case Left(e)     =>
-        val msg = s"Could not fetch last hundred reports in the database. Reason is : ${e.getMessage}"
-        logger.error(msg)
-        Failure(msg, Full(e), Empty)
-      case Right(list) => Full(list)
-    }
+    transactIOResult("Could not fetch last hundred error reports in the database")(xa => q.to[Vector].transact(xa))
   }
 
-  override def getReportsWithLowestId: Box[Option[(Long, Reports)]] = {
+  override def getReportsWithLowestId: IOResult[Option[(Long, Reports)]] = {
     val q = query[(Long, Reports)](s"${idQuery} order by id asc limit 1")
-    transactRunBox(xa => q.option.transact(xa))
-  }
-
-  def getReportsWithLowestIdFromDate(from: DateTime): Box[Option[(Long, Reports)]] = {
-    val q =
-      query[(Long, Reports)](s"${idQuery} and executionTimeStamp >= '${new Timestamp(from.getMillis)}' order by id asc limit 1")
-    transactRunBox(xa => q.option.transact(xa))
-  }
-
-  /**
-    *  utilitary methods
-    */
-
-  // Get max ID before a datetime
-  def getMaxIdBeforeDateTime(fromId: Long, before: DateTime): Box[Option[Long]] = {
-    val q = query[Long](
-      s"select max(id) as id from RudderSysEvents where id > ${fromId} and executionTimeStamp <  '${new Timestamp(before.getMillis)}'"
-    )
-    (transactRunBox(xa =>
-      q.option.transact(xa)
-    ) ?~! s"Could not fetch the highest id before date ${before.toString} in the database")
+    transactIOResult("Could not fetch the report with the lowest id in the database")(xa => q.option.transact(xa))
   }
 
   /**
    * From an id and an end date, return a list of AgentRun, and the max ID that has been considered
    */
-  override def getReportsFromId(lastProcessedId: Long, endDate: DateTime): Box[(Seq[AgentRun], Long)] = {
+  override def getReportsFromId(lastProcessedId: Long, endDate: DateTime): IOResult[(Seq[AgentRun], Long)] = {
 
     def getMaxId(fromId: Long, before: DateTime): ConnectionIO[Long] = {
       val queryForMaxId = "select max(id) as id from RudderSysEvents where id > ? and executionTimeStamp < ?"
@@ -360,47 +334,43 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
     }
 
     // actual logic for getReportsfromId
-    transactRunBox(xa => {
+    transactIOResult("Could not fetch the last completed runs from database.")(xa => {
       (for {
         toId    <- getMaxId(lastProcessedId, endDate)
         reports <- getRuns(lastProcessedId, toId)
       } yield {
         (distinctRuns(reports), toId)
       }).transact(xa)
-    }) ?~! s"Could not fetch the last completed runs from database."
+    })
   }
 
   /**
     * returns the changes between startTime and now, using intervalInHour interval size
     */
 
-  override def countChangeReportsByBatch(intervals: List[Interval]): Box[(Long, Map[RuleId, Map[Interval, Int]])] = {
-    import com.normation.utils.Control.traverse
+  override def countChangeReportsByBatch(intervals: List[Interval]): IOResult[(Long, Map[RuleId, Map[Interval, Int]])] = {
     logger.debug(s"Fetching all changes for intervals ${intervals.mkString(",")}")
     val beginTime = System.currentTimeMillis()
-    val box: Box[Seq[Vector[(RuleId, Interval, Int, Long)]]] = traverse(intervals) { interval =>
-      (transactRunBox(xa => {
-        query[(RuleId, Int, Long)](
-          s"""select ruleid, count(*) as number, max(id)
+    for {
+      perInterval <- ZIO.foreach(intervals) { interval =>
+                       transactIOResult(s"Error when trying to retrieve change reports on interval ${interval.toString}")(xa => {
+                         query[(RuleId, Int, Long)](
+                           s"""select ruleid, count(*) as number, max(id)
           from ruddersysevents
           where eventtype = 'result_repaired' and executionTimeStamp > '${new Timestamp(
-              interval.getStartMillis
-            )}' and executionTimeStamp <= '${new Timestamp(interval.getEndMillis)}'
+                               interval.getStartMillis
+                             )}' and executionTimeStamp <= '${new Timestamp(interval.getEndMillis)}'
           group by ruleid;
       """
-        ).to[Vector].transact(xa)
-      }) ?~! s"Error when trying to retrieve change reports on interval ${interval.toString}").map { res =>
-        res.map { case (ruleid, count, highestId) => (ruleid, interval, count, highestId) }
-      }
-    }
-    val endQuery = System.currentTimeMillis()
-    logger.debug(s"Fetched all changes in intervals in ${(endQuery - beginTime)} ms")
-
-    for {
-      all <- box.map(_.flatten)
+                         ).to[Vector].transact(xa)
+                       }).map(res => res.map { case (ruleid, count, highestId) => (ruleid, interval, count, highestId) })
+                     }
     } yield {
+      val all      = perInterval.flatten
+      val endQuery = System.currentTimeMillis()
+      logger.debug(s"Fetched all changes in intervals in ${(endQuery - beginTime)} ms")
       if (all.isEmpty) {
-        (0, Map())
+        (0L, Map())
       } else {
         val highest = all.iterator.map(_._4).max
         val byRules = all.groupBy(_._1).map {
@@ -418,41 +388,6 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
     }
   }
 
-  override def countChangeReports(startTime: DateTime, intervalInHour: Int): Box[Map[RuleId, Map[Interval, Int]]] = {
-    // special mapper to retrieve correct interval. It is dependant of starttime / intervalInHour
-    implicit val intervalMeta: Get[Interval] = Get[Int].tmap(
-      // the query will return interval number in the "interval" column. So interval=0 mean
-      // interval from startTime to startTime + intervalInHour hours, etc.
-      // here is the mapping to build an interval from its number
-      num => new Interval(startTime.plusHours(num * intervalInHour), startTime.plusHours((num + 1) * intervalInHour))
-    )
-
-    // be careful, extract from 'epoch' gives seconds, not millis
-    val mod   = intervalInHour * 3600
-    val start = startTime.getMillis / 1000
-    (
-      (transactRunBox(xa => {
-        query[(RuleId, Int, Interval)](
-          s"""select ruleid, count(*) as number, ( extract('epoch' from executiontimestamp)::bigint - ${start})/${mod} as interval
-          from ruddersysevents
-          where eventtype = 'result_repaired' and executionTimeStamp > '${new Timestamp(startTime.getMillis)}'::timestamp
-          group by ruleid, interval;
-      """
-        ).to[Vector].transact(xa)
-      }) ?~! "Error when trying to retrieve change reports").map { res =>
-        val groups = {
-          res
-            .groupBy(_._1)
-            .view
-            .mapValues(_.groupMapReduce(_._3)(_._2)((a, b) => a))
-            .toMap // head non empty due to groupBy, and seq == 1 by query
-        }
-        groups
-      },
-      intervalMeta
-    )._1 // tricking scalac for false positive unused warning on intervalMeta.
-  }
-
   override def getChangeReportsOnInterval(lowestId: Long, highestId: Long): IOResult[Seq[ChangeForCache]] = {
     transactIOResult(s"Error we getting change reports on [${lowestId}, ${highestId}]")(xa => {
       query[ChangeForCache](s"""select ruleid, executiontimestamp from ruddersysevents where
@@ -465,7 +400,7 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
       ruleId:   RuleId,
       interval: Interval,
       limit:    Option[Int]
-  ): Box[Seq[ResultRepairedReport]] = {
+  )(implicit qc: QueryContext): IOResult[Seq[ResultRepairedReport]] = {
     val limitFr = limit match {
       case Some(i) if (i > 0) => fr"limit ${i}"
       case _                  => Fragment.empty
@@ -477,7 +412,15 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
       fr"and eventtype = ${Reports.RESULT_REPAIRED} and ruleid = ${ruleId}" ++
       fr"and executionTimeStamp >  ${start} and executionTimeStamp <= ${end}" ++
       fr"order by executionTimeStamp asc" ++ limitFr
-    transactRunBox(xa => q.query[ResultRepairedReport].to[Vector].transact(xa))
+    for {
+      reports <- transactIOResult("Could not fetch change reports by rule on interval in the database")(xa =>
+                   q.query[ResultRepairedReport].to[Vector].transact(xa)
+                 )
+      // a change report's tenant is its node's tenant; restrict to the nodes visible in `qc` (an `All` grant,
+      // e.g. systemQC, sees everything and skips the lookup).
+      res     <- if (qc.accessGrant == TenantAccessGrant.All) reports.succeed
+                 else nodeFactRepository.getNodeAndServerIds().map(v => reports.filter(r => v.nodeIds.contains(r.nodeId)))
+    } yield res
   }
 
   override def getReportsByKindBetween(
@@ -485,22 +428,22 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
       upper: Option[Long],
       limit: Int,
       kinds: List[String]
-  ): Box[Seq[(Long, Reports)]] = {
+  ): IOResult[Seq[(Long, Reports)]] = {
     upper match {
       case Some(upper) if lower >= upper =>
-        Full(Nil)
+        Seq.empty[(Long, Reports)].succeed
       case None                          =>
         val q =
           s"${idQuery} and id >= '${lower}' and (${kinds.map(k => s"eventtype='${k}'").mkString(" or ")}) order by id asc limit ${limit}"
-        transactRunBox(xa =>
+        transactIOResult(s"Could not fetch reports between ids ${lower} and ${upper} in the database.")(xa =>
           query[(Long, Reports)](q).to[Vector].transact(xa)
-        ) ?~! s"Could not fetch reports between ids ${lower} and ${upper} in the database."
+        )
       case Some(upper)                   =>
         val q =
           s"${idQuery} and id between '${lower}' and '${upper}' and (${kinds.map(k => s"eventtype='${k}'").mkString(" or ")}) order by id asc limit ${limit}"
-        transactRunBox(xa =>
+        transactIOResult(s"Could not fetch reports between ids ${lower} and ${upper} in the database.")(xa =>
           query[(Long, Reports)](q).to[Vector].transact(xa)
-        ) ?~! s"Could not fetch reports between ids ${lower} and ${upper} in the database."
+        )
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreService.scala
@@ -42,6 +42,7 @@ import com.normation.inventory.domain.InventoryError.Inconsistency
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.zio.*
 import zio.*
 import zio.syntax.ToZio
@@ -155,8 +156,17 @@ class ScoreServiceImpl(
     }
   }
 
+  // write-side tenant guard: a tenant-restricted actor must not mutate the score of a node it can
+  // not see. `All` (the system paths - node-deletion callbacks) skips the check, so cleanup still runs even
+  // when the node fact has already been removed.
+  private def checkNodeWritable(nodeId: NodeId)(implicit qc: QueryContext): IOResult[Unit] = {
+    if (qc.accessGrant == TenantAccessGrant.All) ZIO.unit
+    else nodeFactRepo.get(nodeId).notOptional(s"Node '${nodeId.value}' is not accessible").unit
+  }
+
   def deleteNodeScore(nodeId: NodeId)(implicit qc: QueryContext): IOResult[Unit] = {
     for {
+      _         <- checkNodeWritable(nodeId)
       _         <- cache.update(_.removed(nodeId))
       newScores <- scoreCache.updateAndGet(_.removed(nodeId))
       _         <- scoreRepository.deleteScore(Seq(nodeId), None)
@@ -221,6 +231,7 @@ class ScoreServiceImpl(
 
   override def removeScore(nodeId: NodeId, scoreId: String)(implicit qc: QueryContext): IOResult[Unit] = {
     for {
+      _         <- checkNodeWritable(nodeId)
       scores    <- cache.updateAndGet(
                      _.updatedWith(nodeId)(_.map(gscore => gscore.copy(details = gscore.details.filterNot(_.scoreId == scoreId))))
                    )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleApplicationStatusService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleApplicationStatusService.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.FullNodeGroupCategory
+import com.normation.rudder.tenants.*
 
 trait RuleApplicationStatusService {
   def isApplied(
@@ -49,6 +50,9 @@ trait RuleApplicationStatusService {
       groupLib:         FullNodeGroupCategory,
       directiveLib:     FullActiveTechniqueCategory,
       nodeAndServerIds: NodeAndServerIds,          // the nodes visible in the caller's context, see NodeFactRepository.getNodeAndServerIds
+      // security tag of each candidate node, to apply the SAME rule<->node tenant boundary as policy
+      // generation (`RuleValService`): a rule only "applies" to a node its tenant scope can see
+      nodeSecurity:     Map[NodeId, Option[SecurityTag]],
       appliedOnNodes:   Option[Set[NodeId]] = None // Optional parameter: list of node target of this rule
       // exists because it is already computed in the API call
   ): ApplicationStatus
@@ -66,13 +70,20 @@ class RuleApplicationStatusServiceImpl extends RuleApplicationStatusService {
       groupLib:         FullNodeGroupCategory,
       directiveLib:     FullActiveTechniqueCategory,
       nodeAndServerIds: NodeAndServerIds,
+      nodeSecurity:     Map[NodeId, Option[SecurityTag]],
       appliedOnNodes:   Option[Set[NodeId]] = None // Optional parameter: list of node target of this rule
       // exists because it is already computed in the API call
   ): ApplicationStatus = {
 
     if (rule.isEnabled) {
       val isAllTargetsEnabled = rule.targets.flatMap(groupLib.allTargets.get(_)).filter(!_.isEnabled).isEmpty
-      val nodesList           = appliedOnNodes.getOrElse(groupLib.getNodeIds(rule.targets, nodeAndServerIds))
+      // apply the rule<->node tenant boundary, exactly like policy generation does in RuleValService: keep a
+      // node only if the rule's tenant scope can see the node's tenant. For an untagged/Open rule the scope is
+      // `All` (fromSecurityScope), so this is a no-op for non-tenant setups.
+      val ruleScope           = TenantAccessGrant.fromSecurityScope(rule.security)
+      val nodesList           = appliedOnNodes
+        .getOrElse(groupLib.getNodeIds(rule.targets, nodeAndServerIds))
+        .filter(nodeId => ruleScope.canSee(nodeSecurity.getOrElse(nodeId, None)))
       if (nodesList.nonEmpty) {
         if (isAllTargetsEnabled) {
           val disabled = (rule.directiveIds

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.services.policies.nodeconfig.NodeConfigurationHash
 import com.normation.rudder.services.policies.nodeconfig.NodeConfigurationHashRepository
 import com.normation.rudder.services.policies.write.RuleValGeneratedHookService
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.SecurityTag
 import com.normation.rudder.utils.ParseMaxParallelism
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -147,12 +148,13 @@ class FetchAllInfoServiceImpl(
       rules:            Seq[Rule],
       groupLib:         FullNodeGroupCategory,
       directiveLib:     FullActiveTechniqueCategory,
-      nodeAndServerIds: NodeAndServerIds
+      nodeAndServerIds: NodeAndServerIds,
+      nodeSecurity:     Map[NodeId, Option[SecurityTag]] // node tenant tags, for the rule<->node boundary in isApplied
   ): Set[RuleId] = {
     rules
       .filter(r => {
         ruleApplicationStatusService
-          .isApplied(r, groupLib, directiveLib, nodeAndServerIds) match {
+          .isApplied(r, groupLib, directiveLib, nodeAndServerIds, nodeSecurity) match {
           case _: AppliedStatus => true
           case _ => false
         }
@@ -296,12 +298,13 @@ class FetchAllInfoServiceImpl(
 
       ruleValTime0    <- currentTimeMillis
       // per-node info (is-policy-server + tenant security tag) is the single source of truth derived from
-      // the node facts; `getAppliedRuleIds` only needs the is-policy-server projection.
+      // the node facts.
       nodeInfos        =
         nodeFacts.view.mapValues(nf => NodeSecurityInfo(nf.rudderSettings.isPolicyServer, nf.rudderSettings.security)).toMap
       nodeAndServerIds = NodeAndServerIds.fromFacts(nodeFacts)
 
-      activeRuleIds = getAppliedRuleIds(allRules, groupLib, directiveLib, nodeAndServerIds)
+      activeRuleIds =
+        getAppliedRuleIds(allRules, groupLib, directiveLib, nodeAndServerIds, nodeInfos.view.mapValues(_.security).toMap)
 
       ruleVals                                 <- buildRuleVals(
                                                     activeRuleIds,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.services.reports
 
-import com.normation.box.*
 import com.normation.errors.*
 import com.normation.rudder.domain.logger.ReportLoggerPure
 import com.normation.rudder.domain.policies.Rule
@@ -45,6 +44,7 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.ResultRepairedReport
 import com.normation.rudder.repository.CachedRepository
 import com.normation.rudder.repository.ReportsRepository
+import com.normation.rudder.tenants.QueryContext
 import com.normation.zio.*
 import net.liftweb.common.*
 import org.joda.time.DateTime
@@ -59,7 +59,7 @@ opaque type ChangesByRule = Map[RuleId, Map[Interval, Int]]
 object ChangesByRule {
   private[reports] def apply(map: Map[RuleId, Map[Interval, Int]]): ChangesByRule = map
   def empty: ChangesByRule = Map.empty
-  def of(head: (RuleId, Map[Interval, Int])): ChangesByRule = Map(head)
+  def of(entries: (RuleId, Map[Interval, Int])*): ChangesByRule = Map(entries*)
 
   extension (self: ChangesByRule) {
     private[reports] def getWithFallback(k: RuleId, defaultMap: => Map[Interval, Int])(i: Interval, default: Int): Int         =
@@ -102,7 +102,7 @@ trait NodeChangesService {
    * Get all changes for the last "changesMaxAge" and
    * regroup them by rule, and by interval of 6 hours.
    */
-  def countChangesByRuleByInterval(): Box[(Long, ChangesByRule)]
+  def countChangesByRuleByInterval(): IOResult[(Long, ChangesByRule)]
 
   /**
    * Get the changes for the given interval, which must be one of the
@@ -110,7 +110,9 @@ trait NodeChangesService {
    * Optionally give a limit number of report to return (0 or negative number
    * will be considered as None)
    */
-  def getChangesForInterval(ruleId: RuleId, interval: Interval, limit: Option[Int]): Box[Seq[ResultRepairedReport]]
+  def getChangesForInterval(ruleId: RuleId, interval: Interval, limit: Option[Int])(implicit
+      qc: QueryContext
+  ): IOResult[Seq[ResultRepairedReport]]
 
   /**
    * For the given service, what are the intervals currently valid?
@@ -175,7 +177,7 @@ class NodeChangesServiceImpl(
    * Get all changes for the last "reportsRepository.maxChangeTime" and
    * regroup them by rule, and by interval of 6 hours.
    */
-  override def countChangesByRuleByInterval(): Box[(Long, ChangesByRule)] = {
+  override def countChangesByRuleByInterval(): IOResult[(Long, ChangesByRule)] = {
     logger.debug(s"Get all changes on all rules")
     val beginTime = System.currentTimeMillis()
     val intervals = getCurrentValidIntervals(None)
@@ -189,12 +191,12 @@ class NodeChangesServiceImpl(
     }
   }
 
-  override def getChangesForInterval(ruleId: RuleId, interval: Interval, limit: Option[Int]): Box[Seq[ResultRepairedReport]] = {
-    for {
-      changes <- reportsRepository.getChangeReportsByRuleOnInterval(ruleId, interval, limit)
-    } yield {
-      changes
-    }
+  override def getChangesForInterval(
+      ruleId:   RuleId,
+      interval: Interval,
+      limit:    Option[Int]
+  )(implicit qc: QueryContext): IOResult[Seq[ResultRepairedReport]] = {
+    reportsRepository.getChangeReportsByRuleOnInterval(ruleId, interval, limit)
   }
 }
 
@@ -331,10 +333,10 @@ class CachedNodeChangesServiceImpl(
    * background processes where throughout is more
    * important than responsiveness.
    */
-  def update(lowestId: Long, highestId: Long): Box[Unit] = {
+  def update(lowestId: Long, highestId: Long): IOResult[Unit] = {
     if (lowestId < highestId) {
-      addUpdate(ChangesUpdate.For(lowestId, highestId)).toBox
-    } else Full(())
+      addUpdate(ChangesUpdate.For(lowestId, highestId))
+    } else ZIO.unit
   }
 
   def addUpdate(update: ChangesUpdate): IOResult[Unit] = {
@@ -405,18 +407,17 @@ class CachedNodeChangesServiceImpl(
   protected def initCache(): IOResult[ChangesCache] = {
     for {
       _       <- ReportLoggerPure.Changes.debug("Rule Changes cache initialization...")
-      changes <- (try {
-                   changeService.countChangesByRuleByInterval()
-                 } catch {
-                   case ex: OutOfMemoryError =>
+      // the computation can run out of memory on very large change sets (see issue #7735); as an IOResult it
+      // is now a defect, so we catch it, log it and turn it into a typed error rather than crashing the fiber.
+      changes <- changeService.countChangesByRuleByInterval().catchSomeDefect {
+                   case _: OutOfMemoryError =>
                      val msg = {
                        "Rule Changes cache can not be updated du to OutOfMemory error. That mean that either your installation is missing " +
                        "RAM (see: https://docs.rudder.io/reference/current/administration/performance.html#_java_out_of_memory_error) or that the number of recent changes is " +
                        "overwhelming, and you hit: https://issues.rudder.io/issues/7735. Look here for workaround"
                      }
-                     ReportLoggerPure.Changes.logEffect.error(msg)
-                     Failure(msg)
-                 }).toIO
+                     ReportLoggerPure.Changes.error(msg) *> Inconsistency(msg).fail
+                 }
       _       <- ReportLoggerPure.Changes.debug("NodeChanges cache initialized")
       _       <- ReportLoggerPure.Changes.trace("NodeChanges cache content: " + changes._2.debugString)
     } yield {
@@ -468,8 +469,8 @@ class CachedNodeChangesServiceImpl(
    * It's actually just using the cache. It may not be up to date
    * if the cache wasn't initialized
    */
-  override def countChangesByRuleByInterval(): Box[(Long, ChangesByRule)] = {
-    val prog = for {
+  override def countChangesByRuleByInterval(): IOResult[(Long, ChangesByRule)] = {
+    for {
       opt <- cache.get
     } yield {
       opt match {
@@ -477,14 +478,16 @@ class CachedNodeChangesServiceImpl(
         case None    => (-1L, ChangesByRule.empty)
       }
     }
-
-    prog.toBox
   }
 
   /**
    * Get the changes for the given interval, without using the cache.
    */
-  override def getChangesForInterval(ruleId: RuleId, interval: Interval, limit: Option[Int]): Box[Seq[ResultRepairedReport]] = {
+  override def getChangesForInterval(
+      ruleId:   RuleId,
+      interval: Interval,
+      limit:    Option[Int]
+  )(implicit qc: QueryContext): IOResult[Seq[ResultRepairedReport]] = {
     changeService.getChangesForInterval(ruleId, interval, limit)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -47,8 +47,10 @@ import com.normation.rudder.domain.logger.ReportLoggerPure
 import com.normation.rudder.domain.reports.JsonPostgresqlSerialization.JNodeStatusReport
 import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.domain.reports.RunAnalysisKind
+import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.TenantAccessGrant
 import com.softwaremill.quicklens.*
 import doobie.*
 import doobie.implicits.*
@@ -109,11 +111,14 @@ object NodeStatusReportRepositoryImpl {
   /*
    * Create a repo from a datastore, initially loading data from it.
    */
-  def makeAndInit(storage: NodeStatusReportStorage): IOResult[NodeStatusReportRepositoryImpl] = {
+  def makeAndInit(
+      storage:            NodeStatusReportStorage,
+      nodeFactRepository: NodeFactRepository
+  ): IOResult[NodeStatusReportRepositoryImpl] = {
     for {
       reports <- storage.getAll()
       ref     <- Ref.make(reports)
-    } yield new NodeStatusReportRepositoryImpl(storage, ref)
+    } yield new NodeStatusReportRepositoryImpl(storage, ref, nodeFactRepository)
   }
 
 }
@@ -124,8 +129,9 @@ object NodeStatusReportRepositoryImpl {
  * The cache is update along with an underlying cold storage on update/delete operation.
  */
 class NodeStatusReportRepositoryImpl(
-    storage:        NodeStatusReportStorage,
-    initialReports: Ref[Map[NodeId, NodeStatusReport]]
+    storage:            NodeStatusReportStorage,
+    initialReports:     Ref[Map[NodeId, NodeStatusReport]],
+    nodeFactRepository: NodeFactRepository
 ) extends NodeStatusReportRepository {
 
   val cache: Ref[Map[NodeId, NodeStatusReport]] = initialReports
@@ -138,15 +144,40 @@ class NodeStatusReportRepositoryImpl(
     } yield ()
   }
 
+  /*
+   * A `NodeStatusReport` carries no security tag of its own; its tenant is the tenant of its node. The cache
+   * is populated for ALL nodes (under `systemQC`, correct - see convention 600), so reads must be restricted
+   * to the nodes visible in the caller's `QueryContext`, or a tenant-restricted actor would see (and count)
+   * every tenant's compliance. An `All` grant (the compute/maintenance paths use `systemQC`) short-circuits,
+   * so that hot path pays nothing.
+   */
+  private def visibleNodeIds(implicit qc: QueryContext): IOResult[Set[NodeId]] = {
+    nodeFactRepository.getNodeAndServerIds().map(_.nodeIds)
+  }
+
   override def getAll()(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = {
-    cache.get
+    if (qc.accessGrant == TenantAccessGrant.All) cache.get
+    else {
+      for {
+        c       <- cache.get
+        visible <- visibleNodeIds
+      } yield c.view.filterKeys(visible.contains).toMap
+    }
   }
 
   override def getNodeStatusReports(nodeIds: Set[NodeId])(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = {
     // performance: this is called for each batch of the compliance computation, so do one map
     // lookup by asked node, not a filter of the whole cache (which is proportional to the total
-    // number of nodes, not to the batch size)
-    cache.get.map(c => nodeIds.iterator.flatMap(id => c.get(id).map(id -> _)).toMap)
+    // number of nodes, not to the batch size). The compute path uses `systemQC` (All), which skips
+    // the visibility restriction; a tenant-restricted caller only ever gets its visible nodes.
+    if (qc.accessGrant == TenantAccessGrant.All) {
+      cache.get.map(c => nodeIds.iterator.flatMap(id => c.get(id).map(id -> _)).toMap)
+    } else {
+      for {
+        c       <- cache.get
+        visible <- visibleNodeIds
+      } yield nodeIds.iterator.filter(visible.contains).flatMap(id => c.get(id).map(id -> _)).toMap
+    }
   }
 
   override def saveNodeStatusReports(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DatabaseManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DatabaseManager.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.services.system
 
+import com.normation.box.*
 import com.normation.rudder.repository.ReportsRepository
 import com.normation.rudder.repository.UpdateExpectedReportsRepository
 import com.normation.utils.Control
@@ -80,15 +81,15 @@ class DatabaseManagerImpl(
 ) extends DatabaseManager with Loggable {
 
   def getReportsInterval(): Box[(Option[DateTime], Option[DateTime])] = {
-    reportsRepository.getReportsInterval()
+    reportsRepository.getReportsInterval().toBox
   }
 
   def getDatabaseSize(): Box[Long] = {
-    reportsRepository.getDatabaseSize(reportsRepository.reports)
+    reportsRepository.getDatabaseSize(reportsRepository.reports).toBox
   }
 
   def deleteEntries(reports: DeleteCommand.Reports, complianceLevels: Option[DeleteCommand.ComplianceLevel]): Box[Int] = {
-    val nodeReports       = reportsRepository.deleteEntries(reports.date) ?~! "An error occurred while deleting reports"
+    val nodeReports       = reportsRepository.deleteEntries(reports.date).toBox ?~! "An error occurred while deleting reports"
     val nodeConfigs       =
       expectedReportsRepo.deleteNodeConfigIdInfo(reports.date) ?~! "An error occurred while deleting old node configuration IDs"
     val deleteNodeConfigs =
@@ -101,6 +102,6 @@ class DatabaseManagerImpl(
 
   override def deleteLogReports(since: Duration): Box[Int] = {
     val date = DateTime.now(DateTimeZone.UTC).minus(since.toMillis)
-    reportsRepository.deleteLogReports(date) ?~! "An error occurred while deleting log reports"
+    reportsRepository.deleteLogReports(date).toBox ?~! "An error occurred while deleting log reports"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
@@ -59,6 +59,10 @@ import zio.syntax.*
  * operations) or a `ChangeContext` - abbreviated `cc` - for change operation.
  */
 
+// A tenant/authorization denial, surfaced as a `SecurityError` so it is distinguishable (and auditable)
+// from an ordinary inconsistency or a "not found".
+final case class TenantSecurityError(msg: String) extends SecurityError
+
 /* `TenantAccessGrant` defines the list of tenants a user has access to.
  * For now, there is only three cases:
  * - access all or none objects in , whatever properties the node has
@@ -215,6 +219,37 @@ object TenantAccessGrant {
       case ByTenants(ts) =>
         val writable = ts.filter(_.grant.canWrite)
         if (writable.isEmpty) None else ByTenants(writable)
+    }
+
+    /*
+     * The tenant grant this actor is allowed to DELEGATE to something it creates or updates (e.g. an API
+     * account, whose `tenants` come from the request body). An actor may only delegate within the tenants it
+     * can WRITE, never wider than its own writable reach: `All` may delegate anything; `None` may delegate
+     * only `None`; a `ByTenants` actor may delegate only a subset of its writable tenant ids. We REJECT a
+     * wider request with a `SecurityError` (rather than silently narrowing) so the caller learns the grant
+     * was refused rather than quietly getting less than it asked for. This is the missing "the grant can not
+     * widen itself" check for delegation (see the API-account creation/update path).
+     */
+    def delegableTo(requested: TenantAccessGrant): PureResult[TenantAccessGrant] = {
+      def refuse: PureResult[TenantAccessGrant] = {
+        Left(
+          TenantSecurityError(
+            s"the requested tenant grant '${requested.serialize}' is wider than the actor's writable tenants " +
+            s"'${nsc.restrictToWrite.serialize}'; it can not be delegated"
+          )
+        )
+      }
+      nsc.restrictToWrite match {
+        case All           => Right(requested)
+        case None          => if (requested.isNone) Right(None) else refuse
+        case ByTenants(ws) =>
+          val writable = ws.map(_.id).toSet
+          requested match {
+            case All           => refuse
+            case None          => Right(None)
+            case ByTenants(rs) => if (rs.forall(a => writable.contains(a.id))) Right(requested) else refuse
+          }
+      }
     }
 
     // write semantics of `canSee`: only tenants with `rw` permission are considered.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -387,8 +387,19 @@ class DefaultTenantCheckLogic extends TenantCheckLogic {
             case TenantStatus.Enabled(tenants) =>
               cc.accessGrant match {
                 case TenantAccessGrant.All           =>
-                  // for admin, use admin logic: admin can chose tenant
-                  action(updated)
+                  // for admin, use admin logic: admin can chose the tenant list, but (like the update path) it
+                  // must reference only EXISTING tenants - otherwise a phantom/dangling tenant tag is created.
+                  updated.security match {
+                    case Some(SecurityTag.ByTenants(ts)) =>
+                      val unknown = ts.filter(t => !tenants.contains(t))
+                      if (unknown.nonEmpty) {
+                        Inconsistency(
+                          s"Object '${updated.debugId}' can not be created with tenant(s) " +
+                          s"'${unknown.map(_.value).mkString(",")}' because they don't exist"
+                        ).fail
+                      } else action(updated)
+                    case _                               => action(updated) // None (admin-only) or Open: no tenant list to check
+                  }
                 case TenantAccessGrant.None          =>
                   // already manage above
                   error(updated)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2595,7 +2595,7 @@ class MockNodes(mockTenant: MockTenants) {
   }
 
   val propRepo: PropertiesRepository = {
-    InMemoryPropertiesRepository.make(nodeFactRepo).runNow
+    InMemoryPropertiesRepository.make(nodeFactRepo, mockTenant.checkTenant).runNow
   }
 
   object queryProcessor extends QueryProcessor {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/apidata/JRGroupTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/apidata/JRGroupTenantTest.scala
@@ -1,0 +1,89 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.apidata
+
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.apidata.JsonResponseObjects.JRGroup
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.tenants.QueryContext
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+/*
+ * B1: `JRGroup.fromGroup` must filter the serialized `nodeIds` (the group's `serverList`) to the caller's
+ * visible node ids, so a group visible to a tenant does not leak node ids from tenants the caller can not see.
+ */
+@RunWith(classOf[JUnitRunner])
+class JRGroupTenantTest extends Specification {
+
+  private given qc: QueryContext = QueryContext.testQC
+
+  private val nA  = NodeId("nA")
+  private val nB  = NodeId("nB")
+  private val cat = NodeGroupCategoryId("cat")
+
+  private val group = NodeGroup(
+    NodeGroupId(NodeGroupUid("g")),
+    name = "g",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = Set(nA, nB),
+    _isEnabled = true,
+    security = None
+  )
+
+  "JRGroup.fromGroup nodeIds filtering" should {
+
+    "return every member id when there is no visible-node restriction (admin / None)" in {
+      JRGroup.fromGroup(group, cat, None, None).nodeIds === List("nA", "nB")
+    }
+
+    "return only the visible member ids when a restriction is given (tenant caller)" in {
+      JRGroup.fromGroup(group, cat, None, Some(Set(nA))).nodeIds === List("nA")
+    }
+
+    "return no member id when none of the members is visible" in {
+      JRGroup.fromGroup(group, cat, None, Some(Set.empty)).nodeIds === Nil
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/PropertiesRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/PropertiesRepositoryTest.scala
@@ -39,9 +39,17 @@ package com.normation.rudder.domain.properties
 
 import com.normation.rudder.MockNodes
 import com.normation.rudder.MockTenants
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.properties.InMemoryPropertiesRepository
+import com.normation.rudder.properties.TenantScopedGroupProps
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.SecurityTag
+import com.normation.rudder.tenants.TenantAccess
+import com.normation.rudder.tenants.TenantAccessGrant
+import com.normation.rudder.tenants.TenantId
 import com.normation.zio.UnsafeRun
+import com.softwaremill.quicklens.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -54,7 +62,7 @@ class PropertiesRepositoryTest extends Specification {
   private val mockTenants  = new MockTenants()
   private val mockNodes    = new MockNodes(mockTenants)
   private val nodeFactRepo = mockNodes.nodeFactRepo
-  private val repo         = InMemoryPropertiesRepository.make(nodeFactRepo).runNow
+  private val repo         = InMemoryPropertiesRepository.make(nodeFactRepo, mockTenants.checkTenant).runNow
 
   implicit private val qc: QueryContext = QueryContext.testQC
 
@@ -95,6 +103,43 @@ class PropertiesRepositoryTest extends Specification {
         Set(MockNodes.node1.id, MockNodes.node2.id),
         "simpleString"
       )).runNow must beEmpty
+    }
+  }
+
+  // N3/N5: group properties must be tenant-filtered at the repository level. Each cached entry carries its
+  // group's SecurityTag; a reader only sees an entry it can see (a ByTenants reader never sees another
+  // tenant's group, nor an untagged/admin-only one).
+  "PropertiesRepository group tenant filtering" should {
+    val groupA = NodeGroupId(NodeGroupUid("group-zoneA"))
+    val groupB = NodeGroupId(NodeGroupUid("group-zoneB"))
+    val tagA   = SecurityTag.ByTenants(Chunk(TenantId("zoneA")))
+    val tagB   = SecurityTag.ByTenants(Chunk(TenantId("zoneB")))
+    val groupProps: Map[NodeGroupId, TenantScopedGroupProps] = Map(
+      groupA -> TenantScopedGroupProps(Some(tagA), ResolvedNodePropertyHierarchy.empty),
+      groupB -> TenantScopedGroupProps(Some(tagB), ResolvedNodePropertyHierarchy.empty)
+    )
+
+    val qcA: QueryContext =
+      QueryContext.testQC.modify(_.accessGrant).setTo(TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA")))))
+
+    "an admin (All) sees every group's properties" in {
+      (repo.saveGroupProps(groupProps) *> repo.getAllGroupProps()(using QueryContext.testQC)).runNow.keySet must_=== Set(
+        groupA,
+        groupB
+      )
+    }
+
+    "a zoneA reader only sees zoneA group's properties, not zoneB's" in {
+      (repo.saveGroupProps(groupProps) *> repo.getAllGroupProps()(using qcA)).runNow.keySet must_=== Set(groupA)
+    }
+
+    "a zoneA reader can read the zoneA group but not the zoneB group (no existence oracle)" in {
+      val res = (for {
+        _ <- repo.saveGroupProps(groupProps)
+        a <- repo.getGroupProps(groupA)(using qcA)
+        b <- repo.getGroupProps(groupB)(using qcA)
+      } yield (a.isDefined, b.isDefined)).runNow
+      res must_=== ((true, false))
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
@@ -47,6 +47,7 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.domain.reports.Reports
+import com.normation.rudder.facts.nodes.CoreNodeFactRepository
 import com.normation.rudder.reports.execution.AgentRun
 import com.normation.rudder.reports.execution.AgentRunId
 import com.normation.zio.*
@@ -86,7 +87,7 @@ class ReportsTest extends DBCommon {
     transacRun(xa => sql"DELETE FROM ReportsExecution; DELETE FROM RudderSysEvents;".update.run.transact(xa))
   }
 
-  lazy val repostsRepo = new ReportsJdbcRepository(doobie)
+  lazy val repostsRepo = new ReportsJdbcRepository(doobie, CoreNodeFactRepository.makeNoop(Map.empty).runNow)
 
   sequential
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTenantTest.scala
@@ -37,17 +37,24 @@
 package com.normation.rudder.services.policies
 
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeAndServerIds
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
+import com.normation.rudder.domain.policies.AppliedStatus
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.FullGroupTarget
 import com.normation.rudder.domain.policies.FullRuleTargetInfo
 import com.normation.rudder.domain.policies.GroupTarget
+import com.normation.rudder.domain.policies.NotAppliedNoTarget
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.nodes.PropertyEngineServiceImpl
@@ -182,6 +189,34 @@ class RuleValServiceTenantTest extends Specification {
       // zoneB rule sees the zoneB group; among its members only the zoneB node survives the node filter
       ruleValService.getTargetedNodes(mkRule(tenants("zoneB"), bTgt), libB, nodeInfos) ===
       Set(nB)
+    }
+  }
+
+  // B2: the rule application STATUS must apply the same rule<->node tenant boundary as generation, otherwise a
+  // rule reports "applied" on nodes that generation would exclude.
+  "rule application status (isApplied) node-level tenant filter" should {
+    val appStatus        = new RuleApplicationStatusServiceImpl
+    val directiveLib     =
+      FullActiveTechniqueCategory(ActiveTechniqueCategoryId("root"), "", "", Nil, Nil, isSystem = false, security = None)
+    val nodeAndServerIds = NodeAndServerIds(Set(nA, nB, nAdmin), Set())
+    val nodeSecurity: Map[NodeId, Option[SecurityTag]] = nodeInfos.view.mapValues(_.security).toMap
+
+    // a rule is only `isEnabled` (hence eligible for an "applied" status) if it has at least one directive
+    def mkAppliedRule(security: Option[SecurityTag]) =
+      mkRule(security, openTgt).copy(directiveIds = Set(DirectiveId(DirectiveUid("d"))))
+
+    def status(rule: Rule) = appStatus.isApplied(rule, libOpen, directiveLib, nodeAndServerIds, nodeSecurity)
+
+    "report an untagged (admin) rule as applied (it reaches nodes)" in {
+      status(mkAppliedRule(None)) must beAnInstanceOf[AppliedStatus]
+    }
+
+    "report a single-tenant rule as applied (it reaches its own tenant's node)" in {
+      status(mkAppliedRule(tenants("zoneA"))) must beAnInstanceOf[AppliedStatus]
+    }
+
+    "report a rule whose tenant no node shares as NOT applied (it was wrongly 'applied' before B2)" in {
+      status(mkAppliedRule(tenants("zoneC"))) === NotAppliedNoTarget
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -150,7 +150,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
              .makeNoop(accepted, savePreChecks = testSavePrechecks)
       x <- Ref.make(Map[NodeId, NodeStatusReport]())
       s  = new InMemoryNodeStatusReportStorage(x)
-    } yield (r, new NodeStatusReportRepositoryImpl(s, x))).runNow
+    } yield (r, new NodeStatusReportRepositoryImpl(s, x, r))).runNow
   }
 
   class TestFindNewStatusReports extends FindNewNodeStatusReports() {
@@ -188,7 +188,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     (for {
       r1 <- Ref.make(Map[NodeId, NodeStatusReport]())
       s   = new InMemoryNodeStatusReportStorage(r1)
-      x  <- NodeStatusReportRepositoryImpl.makeAndInit(s)
+      x  <- NodeStatusReportRepositoryImpl.makeAndInit(s, nodeFactRepo)
       y   = new TestFindNewStatusReports()
       r2 <- Ref.make(Chunk[NodeStatusReportUpdateHook]())
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
@@ -49,8 +49,15 @@ import com.normation.rudder.domain.reports.RuleNodeStatusReport
 import com.normation.rudder.domain.reports.RunAnalysisKind
 import com.normation.rudder.domain.reports.RunComplianceInfo
 import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.facts.nodes.CoreNodeFactRepository
 import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.tenants.ChangeContext
+import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.SecurityTag
+import com.normation.rudder.tenants.TenantAccess
+import com.normation.rudder.tenants.TenantAccessGrant
+import com.normation.rudder.tenants.TenantId
+import com.normation.rudder.tenants.TenantPermission
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import org.joda.time.DateTime
@@ -139,7 +146,8 @@ class NodeStatusReportRepositoryTest extends Specification {
     (for {
       x <- Ref.make((n ++ moreReports.map(x => (x.nodeId, x))).toMap)
       s  = new Counter(new InMemoryNodeStatusReportStorage(x))
-    } yield (s, new NodeStatusReportRepositoryImpl(s, x))).runNow
+      r <- CoreNodeFactRepository.makeNoop(Map.empty)
+    } yield (s, new NodeStatusReportRepositoryImpl(s, x, r))).runNow
   }
 
   sequential
@@ -243,6 +251,49 @@ class NodeStatusReportRepositoryTest extends Specification {
     repo.saveNodeStatusReports((okReport :: Nil).map(x => (x.nodeId, x))).runNow
     counter.getCount("cc") === 2
     counter.get("cc") == okReport
+  }
+
+  // H7: NodeStatusReport carries no tenant tag of its own, so reads must be scoped to the nodes the caller
+  // can see (the cache holds every node's compliance). Otherwise a tenant-restricted user reads (and, via
+  // /compliance, counts) other tenants' compliance.
+  "tenant scoping of reads" should {
+    val zoneA = SecurityTag.ByTenants(Chunk(TenantId("zoneA")))
+    val zoneB = SecurityTag.ByTenants(Chunk(TenantId("zoneB")))
+    def taggedFact(id: String, tag: SecurityTag): CoreNodeFact =
+      NodeConfigData.fact1.modify(_.id).setTo(NodeId(id)).modify(_.rudderSettings.security).setTo(Some(tag))
+    // a query context restricted to read tenant `zoneA` only
+    val zoneAQc:                                  QueryContext = {
+      QueryContext.systemQC.copy(accessGrant =
+        TenantAccessGrant.ByTenants(Chunk(TenantAccess(TenantId("zoneA"), TenantPermission.Read)))
+      )
+    }
+
+    // repository over two accepted nodes (node0 in zoneA, node1 in zoneB), each with a status report
+    val repo: NodeStatusReportRepository = {
+      implicit val cc: ChangeContext = ChangeContext.newForRudder()
+      (for {
+        nfr <- CoreNodeFactRepository.makeNoop(
+                 Map(NodeId("node0") -> taggedFact("node0", zoneA), NodeId("node1") -> taggedFact("node1", zoneB))
+               )
+        x   <- Ref.make(Map[NodeId, NodeStatusReport]())
+        s    = new InMemoryNodeStatusReportStorage(x)
+        r    = new NodeStatusReportRepositoryImpl(s, x, nfr)
+        _   <- r.saveNodeStatusReports(List(NodeId("node0"), NodeId("node1")).map(id => (id, nsr(id.value, NoRunNoExpectedReport))))
+      } yield r).runNow
+    }
+
+    "return every node's report for an admin (All) grant" in {
+      repo.getAll()(using QueryContext.systemQC).runNow.keySet must beEqualTo(Set(NodeId("node0"), NodeId("node1")))
+    }
+    "return only the caller's tenant nodes for a restricted grant" in {
+      repo.getAll()(using zoneAQc).runNow.keySet must beEqualTo(Set(NodeId("node0")))
+    }
+    "restrict getNodeStatusReports to the caller's tenant nodes (no existence oracle)" in {
+      repo
+        .getNodeStatusReports(Set(NodeId("node0"), NodeId("node1")))(using zoneAQc)
+        .runNow
+        .keySet must beEqualTo(Set(NodeId("node0")))
+    }
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/ChangeRequestTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/ChangeRequestTenantTest.scala
@@ -142,4 +142,22 @@ class ChangeRequestTenantTest extends Specification {
       checkTenant.checkChangeRequestModify(crZoneA, zoneAro.newCC()).either.runNow must beLeft
     }
   }
+
+  // B4: on create, the tenant tag an admin chooses must reference only EXISTING tenants (like the update path),
+  // otherwise a dangling/phantom tenant tag is created.
+  "[create] admin-chosen tenant tag must reference existing tenants" should {
+    val existing = TenantStatus.Enabled(Set(TenantId("zoneA"), TenantId("zoneB")))
+    def create(r: Rule): Either[?, ?] =
+      checkTenant.manageCreate(r, admin.newCC(), existing)(x => zio.ZIO.succeed(x)).either.runNow
+
+    "accept an admin creating an object tagged with an existing tenant" in {
+      create(rule("r", tenantTag("zoneA"))) must beRight
+    }
+    "reject an admin creating an object tagged with a non-existent tenant" in {
+      create(rule("r", tenantTag("zoneX"))) must beLeft
+    }
+    "accept an admin creating an admin-only (untagged) object" in {
+      create(rule("r", None)) must beRight
+    }
+  }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/TenantAccessGrantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/TenantAccessGrantTest.scala
@@ -198,4 +198,35 @@ class TenantAccessGrantTest extends Specification {
       byTenants(access("zoneA", Read)).restrictToWrite.canSee(zoneATag) must beFalse
     }
   }
+
+  // delegation bound used when an actor creates/updates something carrying a tenant grant it chooses
+  // (e.g. an API account): the delegated grant may never be wider than the actor's writable reach.
+  "delegableTo" should {
+    val all  = TenantAccessGrant.All
+    val none = TenantAccessGrant.None
+    val rwAB = byTenants(access("zoneA", ReadWrite), access("zoneB", ReadWrite))
+
+    "let an admin (All) delegate any grant unchanged" in {
+      (all.delegableTo(all) must beRight(all: TenantAccessGrant)) and
+      (all.delegableTo(rwAB) must beRight(rwAB: TenantAccessGrant)) and
+      (all.delegableTo(none) must beRight(none: TenantAccessGrant))
+    }
+    "let a ByTenants(rw) actor delegate a subset of its writable tenants" in {
+      val requested = byTenants(access("zoneA", Read))
+      rwAB.delegableTo(requested) must beRight(requested: TenantAccessGrant)
+    }
+    "refuse widening to a tenant the actor can not write (SecurityError)" in {
+      rwAB.delegableTo(byTenants(access("zoneC", ReadWrite))) must beLeft.like { case e => e must haveClass[TenantSecurityError] }
+    }
+    "refuse a ByTenants actor delegating All" in {
+      rwAB.delegableTo(all) must beLeft
+    }
+    "let any actor delegate None" in {
+      (rwAB.delegableTo(none) must beRight(none: TenantAccessGrant)) and
+      (none.delegableTo(none) must beRight(none: TenantAccessGrant))
+    }
+    "refuse a read-only actor (no writable tenant) delegating a tenant grant" in {
+      byTenants(access("zoneA", Read)).delegableTo(byTenants(access("zoneA", Read))) must beLeft
+    }
+  }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
@@ -43,6 +43,7 @@ import com.normation.eventlog.EventLogRequest.*
 import com.normation.eventlog.EventLogType
 import com.normation.rudder.domain.eventlog.EventTypeFactory
 import com.normation.rudder.domain.properties.NodeProperty
+import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.services.EventLogDetailsGenerator
 import com.normation.utils.DateFormaterService
 import enumeratum.Enum
@@ -79,7 +80,8 @@ object RestEventLog {
   implicit val encoder:            JsonEncoder[RestEventLog] = DeriveJsonEncoder.gen[RestEventLog]
 
   implicit def transformer(implicit
-      eventLogDetail: EventLogDetailsGenerator
+      eventLogDetail: EventLogDetailsGenerator,
+      qc:             QueryContext
   ): Transformer[EventLog, RestEventLog] = {
     Transformer
       .define[EventLog, RestEventLog]

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
@@ -251,6 +251,9 @@ class ApiAccountApiServiceV1(
 
   override def createAccount(data: NewRestApiAccount)(using qc: QueryContext): IOResult[ApiAccountDetails] = {
     for {
+      // a user can not create an account with a wider tenant grant than the tenants it can write (the tenant
+      // grant is otherwise copied verbatim from the request body, so this is where delegation is bounded).
+      _    <- qc.accessGrant.delegableTo(data.tenants).toIO
       pair <- mapper.fromNewApiAccount(data)
       // check that that account doesn't already exist
       _    <- readApi.getById(pair._1.id).flatMap {
@@ -272,6 +275,12 @@ class ApiAccountApiServiceV1(
   ): IOResult[ApiAccountDetails.Public] = {
     for {
       a  <- getPublicApiAccount(id)
+      // same delegation bound as create: an update can not widen the account's tenant grant beyond the
+      // actor's writable tenants (only checked when the request actually changes `tenants`).
+      _  <- data.tenants match {
+              case Some(t) => qc.accessGrant.delegableTo(t).toIO.unit
+              case None    => ZIO.unit
+            }
       up <- mapper.update(a, data).toIO
       _  <- writeApi.save(up, ModificationId(uuidGen.newUuid), qc.actor)
     } yield up.transformInto[ApiAccountDetails.Public]

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -717,7 +717,8 @@ class ZipArchiveBuilderService(
         // we only archive non-system NodeGroups, other kind of special targets are ignored
         groups = cat.targetInfos.collect { case FullRuleTargetInfo(FullGroupTarget(_, g), _, _, _, false, _) => g }
         _     <- ZIO.foreach(groups) { g =>
-                   val json = JRGroup.fromGroup(g, cat.id, None).toJsonPretty
+                   // archive export is an admin/system operation: no tenant node filtering (visibleNodes = None)
+                   val json = JRGroup.fromGroup(g, cat.id, None, None).toJsonPretty
                    for {
                      name <- findName(g.name, ".json", usedNames, basePath)
                      path  = basePath + "/" + name

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.rest.lift
 
 import com.normation.errors.*
+import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonQueryObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.*
@@ -72,6 +73,7 @@ import com.normation.rudder.services.queries.QueryProcessor
 import com.normation.rudder.services.workflows.*
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
+import com.normation.rudder.tenants.TenantAccessGrant
 import com.normation.utils.Csv.toCsv
 import com.normation.utils.StringUuidGenerator
 import io.scalaland.chimney.syntax.*
@@ -704,6 +706,14 @@ class GroupApiService14(
     queryProcessor:       QueryProcessor
 ) {
 
+  // The set of node ids the caller may see, used to filter the serialized group member ids (`nodeIds`) so a
+  // group visible to a tenant does not leak node ids from tenants it can not see. `None` = no filter
+  // (admin / all-tenants grant), which also avoids materialising the whole fleet's id set.
+  private def visibleNodeIds(implicit qc: QueryContext): IOResult[Option[Set[NodeId]]] = {
+    if (qc.accessGrant == TenantAccessGrant.All) None.succeed
+    else nodeFactRepo.getNodeAndServerIds().map(v => Some(v.nodeIds))
+  }
+
   private def createChangeRequest(
       diff:   ChangeRequestNodeGroupDiff,
       change: NodeGroupChangeRequest,
@@ -711,6 +721,7 @@ class GroupApiService14(
   )(implicit cc: ChangeContext) = {
     for {
       workflow <- workflowLevelService.getForNodeGroup(cc.actor, change)
+      visible  <- visibleNodeIds(using cc.toQC)
       cr        = ChangeRequestService.createChangeRequestFromNodeGroup(
                     params.changeRequestName.getOrElse(s"${change.action.name} group '${change.newGroup.name}' from API"),
                     params.changeRequestDescription.getOrElse(""),
@@ -723,19 +734,25 @@ class GroupApiService14(
       id       <- workflow.startWorkflow(cr)
     } yield {
       val optCrId = if (workflow.needExternalValidation()) Some(id) else None
-      JRGroup.fromGroup(change.newGroup, change.category.getOrElse(readGroup.getRootCategory()(using cc.toQC).id), optCrId)(using
+      JRGroup.fromGroup(
+        change.newGroup,
+        change.category.getOrElse(readGroup.getRootCategory()(using cc.toQC).id),
+        optCrId,
+        visible
+      )(using
         cc.toQC
       )
     }
   }
 
   def listGroups()(implicit qc: QueryContext): IOResult[Seq[JRGroup]] = {
-    readGroup
-      .getGroupsByCategory(true)
-      .chainError("Could not fetch Groups")
-      .map(groups =>
-        groups.values.flatMap { case CategoryAndNodeGroup(c, gs) => gs.map(JRGroup.fromGroup(_, c.id, None)) }.toSeq.sortBy(_.id)
-      )
+    for {
+      visible <- visibleNodeIds
+      groups  <- readGroup.getGroupsByCategory(true).chainError("Could not fetch Groups")
+    } yield {
+      groups.values.flatMap { case CategoryAndNodeGroup(c, gs) => gs.map(JRGroup.fromGroup(_, c.id, None, visible)) }.toSeq
+        .sortBy(_.id)
+    }
   }
 
   def createGroup(
@@ -750,12 +767,13 @@ class GroupApiService14(
         saveDiff <- writeGroup.create(change.newGroup, cat)
         // after group creation, its properties should be computed and resolved
         _        <- propertiesService.updateAll()
+        visible  <- visibleNodeIds(using cc.toQC)
       } yield {
         if (saveDiff.needDeployment) {
           // Trigger a deployment only if it is needed
           asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, cc.actor)
         }
-        JRGroup.fromGroup(saveDiff.group, cat, None)(using cc.toQC)
+        JRGroup.fromGroup(saveDiff.group, cat, None, visible)(using cc.toQC)
       }).chainError(s"Could not create group '${change.newGroup.name}' (id:${groupId.serialize}).")
     }
 
@@ -840,9 +858,11 @@ class GroupApiService14(
   }
 
   def groupDetails(id: NodeGroupId)(implicit qc: QueryContext): IOResult[JRGroup] = {
-    readGroup.getNodeGroup(id).map {
-      case (g, c) =>
-        JRGroup.fromGroup(g, c, None)
+    for {
+      visible <- visibleNodeIds
+      gc      <- readGroup.getNodeGroup(id)
+    } yield {
+      JRGroup.fromGroup(gc._1, gc._2, None, visible)
     }
   }
 
@@ -865,7 +885,7 @@ class GroupApiService14(
               .chainError(s"Could not reload Group ${sid} details")
 
           case None =>
-            JRGroup.fromGroup(group, cat, None)(using qc).succeed
+            visibleNodeIds(using qc).map(visible => JRGroup.fromGroup(group, cat, None, visible)(using qc))
         }
     }
   }
@@ -917,9 +937,12 @@ class GroupApiService14(
         )
       }
     }
-    readGroup
-      .getFullGroupLibrary()
-      .map(c => JRFullGroupCategory.fromCategory(filterSystem(c), None)(using qc))
+    for {
+      visible <- visibleNodeIds
+      c       <- readGroup.getFullGroupLibrary()
+    } yield {
+      JRFullGroupCategory.fromCategory(filterSystem(c), None, visible)(using qc)
+    }
   }
 
   def getCategoryDetails(id: NodeGroupCategoryId)(implicit qc: QueryContext): IOResult[JRMinimalGroupCategory] = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
@@ -43,22 +43,26 @@ import com.normation.rudder.apidata.JsonResponseObjects.JRRecentChanges
 import com.normation.rudder.apidata.JsonResponseObjects.JRResultRepairedReport
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.ChangesApi
 import com.normation.rudder.rest.ChangesApi as API
 import com.normation.rudder.rest.RudderJsonResponse.syntax.*
 import com.normation.rudder.services.reports.NodeChangesService
+import com.normation.rudder.tenants.QueryContext
 import io.scalaland.chimney.syntax.*
 import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
 import org.joda.time.Interval
+import zio.ZIO
 import zio.syntax.ToZio
 
 class RecentChangesAPI(
-    nodeChangesService: NodeChangesService
+    nodeChangesService: NodeChangesService,
+    roRuleRepository:   RoRuleRepository
 ) extends LiftApiModuleProvider[API] {
 
   def schemas: API.type = API
@@ -74,10 +78,20 @@ class RecentChangesAPI(
     val schema: ChangesApi.GetRecentChanges.type = API.GetRecentChanges
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      nodeChangesService
-        .countChangesByRuleByInterval()
-        .toIO
-        .map((_, c) => c.transformInto[Map[RuleId, List[JRRecentChanges]]].map((k, v) => (k.serialize, v)))
+      implicit val qc: QueryContext = authzToken.qc
+      // counts are computed over all rules; only return those the caller can see (tenant scoping is enforced
+      // by the tenant-filtering rule repository).
+      (for {
+        visibleRules <- roRuleRepository.getIds()
+        changes      <- nodeChangesService.countChangesByRuleByInterval()
+      } yield {
+        changes._2
+          .transformInto[Map[RuleId, List[JRRecentChanges]]]
+          .view
+          .filterKeys(visibleRules.contains)
+          .map((k, v) => (k.serialize, v))
+          .toMap
+      })
         .chainError(s"Could not get recent changes for all rules")
         .toLiftResponseOne(params, schema, None)
     }
@@ -94,6 +108,8 @@ class RecentChangesAPI(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
+      val rid = RuleId(RuleUid(ruleId))
       (for {
         startDate <- req.params.get("start") match {
                        case Some(start :: Nil) =>
@@ -107,8 +123,13 @@ class RecentChangesAPI(
                        case _                =>
                          Inconsistency("No end date defined").fail
                      }
+        // gate on rule visibility: an invisible rule yields no changes (no existence oracle). The reports
+        // themselves are additionally restricted to the caller's visible nodes in the repository.
+        rule      <- roRuleRepository.getOpt(rid)
         reports   <-
-          nodeChangesService.getChangesForInterval(RuleId(RuleUid(ruleId)), new Interval(startDate, endDate), Some(10000)).toIO
+          ZIO
+            .foreach(rule)(_ => nodeChangesService.getChangesForInterval(rid, new Interval(startDate, endDate), Some(10000)))
+            .map(_.getOrElse(Nil))
       } yield {
         reports.map(_.transformInto[JRResultRepairedReport])
       })

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -536,7 +536,9 @@ class RuleApiService14(
     val nodes                    = nodesLib.filterKeys(x => nodesIds.contains(x)).values
     val allTargets               = rule.targets.flatMap(groupLib.allTargets.get).map(_.toTargetInfo)
     val policyMode               = ComputePolicyMode.ruleMode(globalMode, directives.map(_._2), nodes.map(_.rudderSettings.policyMode))
-    val applicationStatus        = applicationService.isApplied(rule, groupLib, directiveLib, nodeAndServerIds, Some(nodesIds))
+    val nodeSecurity             = nodesLib.mapValues(_.rudderSettings.security).toMap
+    val applicationStatus        =
+      applicationService.isApplied(rule, groupLib, directiveLib, nodeAndServerIds, nodeSecurity, Some(nodesIds))
     val applicationStatusDetails = ApplicationStatus.details(rule, applicationStatus, allTargets, directives, nodes.isEmpty)
     RuleApplicationStatus(policyMode, applicationStatusDetails)
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -97,7 +97,7 @@ class EventLogDetailsGenerator(
 
   // convention: "X" means "ignore"
 
-  def displayDescription(event: EventLog): NodeSeq = {
+  def displayDescription(event: EventLog)(implicit qc: QueryContext): NodeSeq = {
     import linkUtil.*
     def crDesc(x: EventLog, actionName: NodeSeq) = {
       val id   = RuleId.parse((x.details \ "rule" \ "id").text).getOrElse(RuleId(RuleUid("")))
@@ -134,7 +134,7 @@ class EventLogDetailsGenerator(
         case "" =>
           (for {
             node <- nodeFactRepository
-                      .get(NodeId(id))(using QueryContext.systemQC)
+                      .get(NodeId(id))
                       .catchAll(err => {
                         EventLogsLoggerPure.debug(
                           s"Got unexpected error trying to get the hostname of the node of id ${id} : ${err}"

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_changes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_changes.yml
@@ -1,0 +1,82 @@
+description: (N3) a tenant user only gets change counts for rules it can see - the untagged 'rule1' is admin-only, so a zoneA user does not see it, only the zoneA+zoneB 'tenant-rule-1'
+method: GET
+url: /secure/api/changes
+user: zoneA
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getRulesChanges",
+      "result" : "success",
+      "data" : {
+        "tenant-rule-1" : [
+          {
+            "start" : "1970-01-01T00:00:00Z",
+            "end" : "1970-01-01T00:00:01Z",
+            "changes" : 3
+          }
+        ]
+      }
+    }
+---
+description: (N3) a user whose tenant matches none of the rules with changes gets an empty change set
+method: GET
+url: /secure/api/changes
+user: zoneC
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getRulesChanges",
+      "result" : "success",
+      "data" : {}
+    }
+---
+description: (N3) a tenant user cannot read repaired reports of a rule it cannot see (the untagged 'rule1'); the gate returns an empty list, no existence oracle
+method: GET
+url: /secure/api/changes/rule1?start=1970-01-01T00:00:00Z&end=1970-01-01T00:00:01Z
+user: zoneA
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getRuleChange",
+      "result" : "success",
+      "data" : []
+    }
+---
+description: (N3) a tenant user can read repaired reports of a rule it can see ('tenant-rule-1' tagged zoneA+zoneB)
+method: GET
+url: /secure/api/changes/tenant-rule-1?start=1970-01-01T00:00:00Z&end=1970-01-01T00:00:01Z
+user: zoneA
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getRuleChange",
+      "result" : "success",
+      "data" : [
+        {
+          "executionDate" : "1970-01-01T00:00:00Z",
+          "nodeId" : "node1",
+          "directiveId" : "directive1",
+          "component" : "Tenant component",
+          "value" : "",
+          "message" : "tenant change",
+          "executionTimestamp" : "1970-01-01T00:00:00Z"
+        }
+      ]
+    }
+---
+description: (N3) a user whose tenant does not include the rule's tenants cannot read its repaired reports (zoneC vs zoneA+zoneB rule)
+method: GET
+url: /secure/api/changes/tenant-rule-1?start=1970-01-01T00:00:00Z&end=1970-01-01T00:00:01Z
+user: zoneC
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getRuleChange",
+      "result" : "success",
+      "data" : []
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_laws.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_laws.yml
@@ -329,7 +329,8 @@ response:
             "tags": [],
             "policyMode": "enforce",
             "status": {
-              "value": "In application"
+              "value": "Not applied",
+              "details": ""
             },
             "security": {
               "tenants": [
@@ -422,7 +423,8 @@ response:
             "tags": [],
             "policyMode": "enforce",
             "status": {
-              "value": "In application"
+              "value": "Not applied",
+              "details": ""
             },
             "security": {
               "tenants": [
@@ -489,7 +491,8 @@ response:
             "tags": [],
             "policyMode": "enforce",
             "status": {
-              "value": "In application"
+              "value": "Not applied",
+              "details": ""
             },
             "security": {
               "tenants": [

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_rules.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api-tenant/api_tenant_rules.yml
@@ -29,7 +29,8 @@ response:
             "tags": [],
             "policyMode": "enforce",
             "status": {
-              "value": "In application"
+              "value": "Not applied",
+              "details": ""
             },
             "security": {
               "tenants": [
@@ -401,7 +402,8 @@ response:
             "tags": [],
             "policyMode": "enforce",
             "status": {
-              "value": "In application"
+              "value": "Not applied",
+              "details": ""
             },
             "security": {
               "tenants": [
@@ -524,7 +526,8 @@ response:
             "tags": [],
             "policyMode": "enforce",
             "status": {
-              "value": "In application"
+              "value": "Not applied",
+              "details": ""
             },
             "security": {
               "tenants": [

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -1042,7 +1042,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
       // hidden properties are not copied in archive
       .map((g, id) => (g.copy(properties = g.properties.filter(_.visibility == Displayed)), id))
       .runNow
-    val serializedGroup     = JRGroup.fromGroup(group, categoryId, None).transformInto[JRGroupV21]
+    val serializedGroup     = JRGroup.fromGroup(group, categoryId, None, None).transformInto[JRGroupV21]
     (dest / "groups" / "category_1" / (group.name + ".json")).overwrite(serializedGroup.toJsonPretty)
 
     // now zip it

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -68,6 +68,7 @@ import com.normation.rudder.config.StatelessUserPropertyService
 import com.normation.rudder.domain.eventlog.ModifyNodeGroup
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyMode
@@ -78,6 +79,7 @@ import com.normation.rudder.domain.policies.PolicyModeOverrides.Always
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.domain.reports.ResultRepairedReport
 import com.normation.rudder.domain.secret.Secret
@@ -171,7 +173,6 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.ZonedDateTime
 import net.liftweb.common.Box
-import net.liftweb.common.Empty
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
 import net.liftweb.http.LiftResponse
@@ -1029,32 +1030,55 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
 
   val fakeNodeChangesService: NodeChangesService = new NodeChangesService {
     import org.joda.time.Interval
-    override def changesMaxAge:                  Int                        = 0
-    override def countChangesByRuleByInterval(): Box[(Long, ChangesByRule)] = Full(
-      (1, ChangesByRule.of(mockRules.rules.clockRule.id -> Map(new Interval(0L, 1_000L) -> 1)))
-    )
+    // a rule restricted to zoneA+zoneB, seeded by `TestRestTenantFromFileDef`. It carries changes here so the
+    // tenant tests can assert that the /changes rule-visibility gate keeps visible rules and drops invisible
+    // ones. In the non-tenant runner this id is absent from the rule repo, so the gate drops it and the plain
+    // `api_changes.yml` expectations are unaffected.
+    val tenantRuleId:                            RuleId                          = RuleId(RuleUid("tenant-rule-1"))
+    override def changesMaxAge:                  Int                             = 0
+    override def countChangesByRuleByInterval(): IOResult[(Long, ChangesByRule)] = {
+      (
+        1L,
+        ChangesByRule.of(
+          mockRules.rules.clockRule.id -> Map(new Interval(0L, 1_000L) -> 1),
+          tenantRuleId                 -> Map(new Interval(0L, 1_000L) -> 3)
+        )
+      ).succeed
+    }
     override def getChangesForInterval(
         ruleId:   RuleId,
         interval: Interval,
         limit:    Option[Int]
-    ): Box[Seq[ResultRepairedReport]] = {
+    )(implicit qc: QueryContext): IOResult[Seq[ResultRepairedReport]] = {
       if (ruleId == mockRules.rules.clockRule.id) {
-        Full(
-          List(
-            ResultRepairedReport(
-              new DateTime(0),
-              ruleId,
-              mockDirectives.directives.clockDirective.id,
-              MockNodes.node1Node.id,
-              "0",
-              "Time synchronization (NTP)",
-              "",
-              new DateTime(0),
-              "ntp daemon installed, configured and running"
-            )
+        List(
+          ResultRepairedReport(
+            new DateTime(0),
+            ruleId,
+            mockDirectives.directives.clockDirective.id,
+            MockNodes.node1Node.id,
+            "0",
+            "Time synchronization (NTP)",
+            "",
+            new DateTime(0),
+            "ntp daemon installed, configured and running"
           )
-        )
-      } else Empty
+        ).succeed
+      } else if (ruleId == tenantRuleId) {
+        List(
+          ResultRepairedReport(
+            new DateTime(0),
+            ruleId,
+            DirectiveId(DirectiveUid("directive1")),
+            MockNodes.node1Node.id,
+            "0",
+            "Tenant component",
+            "",
+            new DateTime(0),
+            "tenant change"
+          )
+        ).succeed
+      } else Seq.empty[ResultRepairedReport].succeed
     }
   }
   val otpService = new TotpService {
@@ -1137,7 +1161,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     new PluginInternalApi(pluginsSystemService),
     new InventoryApi(mockInventoryFileWatcher, mockInventoryDir),
     new QuicksearchApi(quickSearchService, linkUtil),
-    new RecentChangesAPI(fakeNodeChangesService)
+    new RecentChangesAPI(fakeNodeChangesService, mockRules.ruleRepo)
   )
 
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, userService)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
@@ -254,7 +254,7 @@ class SetUpCompliance(numNodes: Int, numRules: Int) {
 
   def reportingService(statusReports: Map[NodeId, NodeStatusReport]): ReportingService = {
     val ref = Ref.make(statusReports).runNow
-    new ReportingServiceImpl(new NodeStatusReportRepositoryImpl(new InMemoryNodeStatusReportStorage(ref), ref))
+    new ReportingServiceImpl(new NodeStatusReportRepositoryImpl(new InMemoryNodeStatusReportStorage(ref), ref, nodeFactRepo))
   }
 
   val complianceAPIService: ComplianceAPIService = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2159,7 +2159,8 @@ object RudderConfigInit {
       )
     )
 
-    lazy val propertiesRepository: PropertiesRepository = InMemoryPropertiesRepository.make(nodeFactRepository).runNow
+    lazy val propertiesRepository: PropertiesRepository =
+      InMemoryPropertiesRepository.make(nodeFactRepository, tenantCheckLogic).runNow
 
     lazy val propertiesService: NodePropertiesService =
       new NodePropertiesServiceImpl(roLDAPParameterRepository, roNodeGroupRepository, nodeFactRepository, propertiesRepository)
@@ -2560,7 +2561,7 @@ object RudderConfigInit {
           new InventoryApi(inventoryWatcher, better.files.File(INVENTORY_DIR_INCOMING)),
           new PluginApi(pluginSettingsService, pluginSystemService, PluginsInfo.pluginJsonInfos.succeed),
           new PluginInternalApi(pluginSystemService),
-          new RecentChangesAPI(recentChangesService),
+          new RecentChangesAPI(recentChangesService, roRuleRepository),
           new RulesInternalApi(ruleInternalApiService, ruleApiService13),
           new GroupsInternalApi(groupInternalApiService),
           new CampaignApi(
@@ -3527,7 +3528,7 @@ object RudderConfigInit {
       (for {
         x <- Ref.make(Map[NodeId, NodeStatusReport]())
         s  = new JdbcNodeStatusReportStorage(doobie, RUDDER_JDBC_BATCH_MAX_SIZE)
-      } yield new NodeStatusReportRepositoryImpl(s, x)).runNow
+      } yield new NodeStatusReportRepositoryImpl(s, x, nodeFactRepository)).runNow
     }
 
     lazy val computeNodeStatusReportService: ComputeNodeStatusReportService & HasNodeStatusReportUpdateHook = {
@@ -3554,7 +3555,7 @@ object RudderConfigInit {
     lazy val pgIn                  = new PostgresqlInClause(70)
     lazy val findExpectedRepo      = new FindExpectedReportsJdbcRepository(doobie, pgIn, RUDDER_JDBC_BATCH_MAX_SIZE)
     lazy val updateExpectedRepo    = new UpdateExpectedReportsJdbcRepository(doobie, pgIn, RUDDER_JDBC_BATCH_MAX_SIZE)
-    lazy val reportsRepositoryImpl = new ReportsJdbcRepository(doobie)
+    lazy val reportsRepositoryImpl = new ReportsJdbcRepository(doobie, nodeFactRepository)
     lazy val reportsRepository     = reportsRepositoryImpl
     lazy val dataSourceProvider    = new RudderDatasourceProvider(
       RUDDER_JDBC_DRIVER,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -101,6 +101,11 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
       }
     }
   }
+  // The query context of the session user, used to scope the per-object details (group/node names and error
+  // text) rendered by this comet to what the user is allowed to see (M14). Fail closed if there is no
+  // resolvable user (the comet only renders for a logged-in user anyway). The overall generation status is
+  // system-global and stays unscoped.
+  private def userQc:                                                    QueryContext                                    = currentUser.map(_.qc).getOrElse(QueryContext.noneQC)
 
   override def registerWith: AsyncDeploymentActor = asyncDeploymentAgent
 
@@ -409,8 +414,9 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
     val groupsErrors: Map[NodeGroup, String] = failures.toList match {
       case Nil      => Map.empty
       case statuses =>
-        // I'm not sure whose group it is. Maybe rudder?
-        val groups = nodeGroupRepo.getAllByIds(statuses.map { case (id, _) => id })(using QueryContext.todoQC).runNow
+        // scope group resolution to the session user: a group the user can not see is dropped here, so its
+        // name and property-error text are never rendered to another tenant (M14).
+        val groups = nodeGroupRepo.getAllByIds(statuses.map { case (id, _) => id })(using userQc).runNow
         groups.flatMap(g => failures.get(g.id).map(f => g -> f.getMessage)).toMap
     }
     groupsErrors.toList match {
@@ -463,7 +469,10 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
       val btnId = nodeBtnId(node)
       scriptLinkButton(btnId, link)
     }
-    val allNodes = nodeFactRepo.getAll()(using QueryContext.systemQC).runNow // systemQC because rudder action
+    // scope node resolution to the session user: a node the user can not see is dropped here, so its hostname
+    // and property-error text are never rendered to another tenant (M14). The generation itself ran as a
+    // system action; this is a per-user render.
+    val allNodes = nodeFactRepo.getAll()(using userQc).runNow
     val nodesErrors:                   Map[MinimalNodeFactInterface, String] = nodeProperties.flatMap {
       case (_, _: SuccessNodePropertyHierarchy)     => None
       case (nodeId, f: FailedNodePropertyHierarchy) => allNodes.get(nodeId).map(_ -> f.getMessage)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -358,7 +358,7 @@ class RuleGrid(
         val default = recentChanges.getCurrentValidIntervals(None).map((_, 0)).toMap
         val start   = System.currentTimeMillis
         for {
-          changes <- recentChanges.countChangesByRuleByInterval()
+          changes <- recentChanges.countChangesByRuleByInterval().toBox
         } yield {
           val nodeChanges = changes._2.defaultRulesWith(rules)(default)
           val after       = System.currentTimeMillis
@@ -475,6 +475,8 @@ class RuleGrid(
   ): List[Line] = {
 
     val nodeAndServerIds = NodeAndServerIds.fromFacts(nodeFacts)
+    // per-node tenant tags, so the application status honours the same rule<->node boundary as generation
+    val nodeSecurity     = nodeFacts.mapValues(_.rudderSettings.security).toMap
 
     // we compute beforehand the compliance, so that we have a single big query
     // to the database
@@ -533,6 +535,7 @@ class RuleGrid(
               groupsLib,
               directivesLib,
               nodeAndServerIds,
+              nodeSecurity,
               None
             )
           }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
@@ -18,9 +18,7 @@ class TagsEditForm(tags: Tags, objectId: String) extends Loggable {
   val templatePath: List[String] = List("templates-hidden", "components", "ComponentTags")
   def tagsTemplate: NodeSeq      = ChooseTemplate(templatePath, "tag-form")
 
-  // escape `<` to its JS unicode escape so a tag key/value can not close the enclosing inline <script>:
-  // zio-json does not escape `<`, and it only ever appears inside JSON string values here.
-  val jsTags: String = tags.toJson.replace("<", "\\u003c")
+  val jsTags: String = tags.toJson
 
   def parseResult(s: String): Box[Tags] = s.fromJson[Tags].toBox
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/lift/JsCommands.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/lift/JsCommands.scala
@@ -142,7 +142,7 @@ object JsCommands {
     // lowercase, `>`-terminated form and let `</SCRIPT>`, `</script >`, `</script/` through). We insert a
     // backslash right after `<` via a look-ahead, so the rest (case, terminator) is preserved untouched.
     private def fixEndScriptTag(in: String): String =
-      """(?i)<(?=/script[\s/>])""".r.replaceAllIn(in, """<\\""")
+      """\<\/script\>""".r.replaceAllIn(in, """<\\/script>""")
   }
 
   object ScriptModule {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
@@ -118,8 +118,7 @@ class TextField(
       // escape `<` in the stored values so they can not close the inline <script>: `Str(_).toJsCmd`
       // escapes for a JS string but not for the HTML script context. `<` only appears inside the JS string.
       Script(OnLoad(JsRaw(s"""
-       newInputText("${formId}", ${Str(currentValue).toJsCmd.replace("<", "\\u003c")}, ${Str(currentPrefix).toJsCmd
-          .replace("<", "\\u003c")}, ${scriptEnabled.toJsCmd});
+       newInputText("${formId}", ${Str(currentValue).toJsCmd}, ${Str(currentPrefix).toJsCmd}, ${scriptEnabled.toJsCmd});
        """))) // JsRaw ok, const
     }
 
@@ -850,8 +849,8 @@ class PasswordField(
     val initScript = {
       Script(OnLoad(JsRaw(s"""
        var passwordForm = new PasswordForm(
-         ${currentValue.map(Str(_).toJsCmd.replace("<", "\\u003c")).getOrElse("undefined")}
-         , ${currentAlgo.map(x => Str(x.prefix).toJsCmd.replace("<", "\\u003c")).getOrElse("undefined")}
+         ${currentValue.map(Str(_).toJsCmd).getOrElse("undefined")}
+         , ${currentAlgo.map(x => Str(x.prefix).toJsCmd).getOrElse("undefined")}
          , ${isScript}
          , ${Str(currentAction).toJsCmd}
          , ${hashes.toJsCmd}


### PR DESCRIPTION
https://issues.rudder.io/issues/29390

So, this is a big PR that closes (I think) all remaining multi-tenant filtering gap. 
It's always a big the same thing: add `QueryContext` - then use it. 
It is based on https://github.com/Normation/rudder/pull/7334

# NodeGroup serialised list of nodes

They need to be filtered in API in particular to avoid node id leaks. 

# Node reports repository and logger and change service

- add `QueryContext` in `ReportsJdbcRepository` and `NodeChangesService`,
- also change signature from `Box` to `IOResult`, 
- and remove dead code. 

# "isApplied" for rules

It's more complicated than before tenant, because it depends of the node actually in user scope. 


# API

- keep the group tenant in "group properties" cache (in `TenantScopedGroupProps`) so that it can be used in apis, 
- several API were consolidated around tenant (checking, filtering content, weaving qc...)

# Tenant "delegableTo"

Encode the idea that when you have a set of tenant, you should not give more - even when you are admin.

# Deployment status

Filter nodes and there error based on user tenant. 