### PR TITLE
Fixes #29398: Sanitize inventory signature path

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
@@ -62,28 +62,23 @@ object InventoryApi {
 
   val sigExtension = ".sign"
 
-  /*
-   * Compute the on-disk name to use for the uploaded signature file.
-   *
-   * SECURITY:`rawSigFileName` is the attacker-controlled multipart file name. We only ever work
-   * on its basename (`File(_).name`), so that a path such as `pwn/../../../etc/cron.d/pwn` can never
-   * escape the incoming inventory directory. For a legitimate upload (a bare file name, no directory)
-   * this is byte-identical to the previous behaviour.
-   *
-   * We keep the `.gz` compression marker and ensure a `.sign` extension when the uploaded signature
-   * does not already carry one.
-   */
-  def signatureFileName(rawSigFileName: String): String = {
-    val sigFilename = File(rawSigFileName).name
-    // remove gz extension for sig name comparison
-    val simpleOrig  =
-      if (sigFilename.endsWith(".gz")) sigFilename.substring(0, sigFilename.length - 3) else sigFilename
-    if (sigFilename.startsWith(simpleOrig)) { // assume extension is ok
-      sigFilename
+  def getInventoryAndSignatureFileName(rawInventoryFile: String, rawSigFile: String): (String, String) = {
+    val inventoryFile = File(rawInventoryFile)
+    val sigFile       = File(rawSigFile)
+
+    // remove gz extension for sig name comparison with inventory (optionally compressed) file
+    val simpleOrig = {
+      if (inventoryFile.name.endsWith(".gz")) inventoryFile.name.substring(0, inventoryFile.name.length - 3)
+      else inventoryFile.name
+    }
+
+    if (sigFile.name.startsWith(simpleOrig)) { // assume extension is ok
+      (inventoryFile.name, sigFile.name)
     } else {
       // we assume that anything that is not ending by .gz is a simple signature, whatever its extension
-      val ext = sigExtension + (if (sigFilename.endsWith(".gz")) ".gz" else "")
-      simpleOrig + ext
+      // and we derive signature name from inventory file name enterily
+      val ext = sigExtension + (if (sigFile.name.endsWith(".gz")) ".gz" else "")
+      (inventoryFile.name, simpleOrig + ext)
     }
   }
 }
@@ -146,15 +141,14 @@ class InventoryApi(
         // basename (see InventoryApi.signatureFileName / File(_).name) so that a crafted name like
         // `pwn/../../../etc/cron.d/pwn` cannot escape the incoming inventory directory, and we
         // additionally route both writes through FileUtils.sanitizePath as a defense-in-depth jail.
-        val originalFilename  = File(inventoryFile.fileName).name
-        val signatureFilename = InventoryApi.signatureFileName(signatureFile.fileName)
+        val (invName, sigName) = InventoryApi.getInventoryAndSignatureFileName(inventoryFile.fileName, signatureFile.fileName)
 
         for {
-          sigPath <- FileUtils.sanitizePath(incomingInventoryDir, signatureFilename)
-          invPath <- FileUtils.sanitizePath(incomingInventoryDir, originalFilename)
+          sigPath <- FileUtils.sanitizePath(incomingInventoryDir, sigName)
+          invPath <- FileUtils.sanitizePath(incomingInventoryDir, invName)
           _       <- writeFile(signatureFile, sigPath)
           _       <- writeFile(inventoryFile, invPath)
-        } yield s"Inventory '${originalFilename}' added to processing queue."
+        } yield s"Inventory '${invName}' added to processing queue."
       }
 
       val prog = (req.uploadedFiles.find(_.name == FILE), req.uploadedFiles.find(_.name == SIG)) match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
@@ -50,12 +50,43 @@ import com.normation.rudder.rest.RestUtils.effectiveResponse
 import com.normation.rudder.rest.RestUtils.toJsonError
 import com.normation.rudder.rest.RestUtils.toJsonResponse
 import com.normation.rudder.rest.implicits.*
+import com.normation.utils.FileUtils
 import net.liftweb.http.FileParamHolder
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import net.liftweb.json.JsonDSL.*
 import zio.*
 import zio.syntax.*
+
+object InventoryApi {
+
+  val sigExtension = ".sign"
+
+  /*
+   * Compute the on-disk name to use for the uploaded signature file.
+   *
+   * SECURITY:`rawSigFileName` is the attacker-controlled multipart file name. We only ever work
+   * on its basename (`File(_).name`), so that a path such as `pwn/../../../etc/cron.d/pwn` can never
+   * escape the incoming inventory directory. For a legitimate upload (a bare file name, no directory)
+   * this is byte-identical to the previous behaviour.
+   *
+   * We keep the `.gz` compression marker and ensure a `.sign` extension when the uploaded signature
+   * does not already carry one.
+   */
+  def signatureFileName(rawSigFileName: String): String = {
+    val sigFilename = File(rawSigFileName).name
+    // remove gz extension for sig name comparison
+    val simpleOrig  =
+      if (sigFilename.endsWith(".gz")) sigFilename.substring(0, sigFilename.length - 3) else sigFilename
+    if (sigFilename.startsWith(simpleOrig)) { // assume extension is ok
+      sigFilename
+    } else {
+      // we assume that anything that is not ending by .gz is a simple signature, whatever its extension
+      val ext = sigExtension + (if (sigFilename.endsWith(".gz")) ".gz" else "")
+      simpleOrig + ext
+    }
+  }
+}
 
 class InventoryApi(
     inventoryFileWatcher: InventoryFileWatcher,
@@ -100,9 +131,8 @@ class InventoryApi(
    */
   object UploadInventory extends LiftApiModule0 {
     val schema: API.UploadInventory.type = API.UploadInventory
-    val FILE         = "file"
-    val SIG          = "signature"
-    val sigExtension = ".sign"
+    val FILE = "file"
+    val SIG  = "signature"
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
       def writeFile(item: FileParamHolder, file: File) = {
@@ -112,30 +142,18 @@ class InventoryApi(
       }
       def parseInventory(pretty: Boolean, inventoryFile: FileParamHolder, signatureFile: FileParamHolder): IOResult[String] = {
         // here, we are at the end of our world. Evaluate ZIO and see what happen.
-        // do not take the whole path as it can lead to path traversal, just the filename
-        val originalFilename = File(inventoryFile.fileName).name
-        val sigFilename      = File(signatureFile.fileName).name
-
-        // for the signature, we want:
-        // - to assume the signature is for the given inventory, so make the name matches
-        // - still keep the extension so that we do what is needed for compressed file. No extension == assume non compressed
-        val signatureFilename = {
-          // remove gz extension for sig name comparison
-          val simpleOrig =
-            if (sigFilename.endsWith(".gz")) sigFilename.substring(0, sigFilename.size - 3) else sigFilename
-          if (signatureFile.fileName.startsWith(simpleOrig)) { // assume extension is ok
-            signatureFile.fileName
-          } else {
-            // we assume that anything that is not ending by .gz is a simple signature, whatever its extension
-            val ext = sigExtension + (if (signatureFile.fileName.endsWith(".gz")) ".gz" else "")
-
-            simpleOrig + ext
-          }
-        }
+        // SECURITY: the multipart file names are attacker-controlled. We only ever keep their
+        // basename (see InventoryApi.signatureFileName / File(_).name) so that a crafted name like
+        // `pwn/../../../etc/cron.d/pwn` cannot escape the incoming inventory directory, and we
+        // additionally route both writes through FileUtils.sanitizePath as a defense-in-depth jail.
+        val originalFilename  = File(inventoryFile.fileName).name
+        val signatureFilename = InventoryApi.signatureFileName(signatureFile.fileName)
 
         for {
-          _ <- writeFile(signatureFile, incomingInventoryDir / signatureFilename)
-          _ <- writeFile(inventoryFile, incomingInventoryDir / originalFilename)
+          sigPath <- FileUtils.sanitizePath(incomingInventoryDir, signatureFilename)
+          invPath <- FileUtils.sanitizePath(incomingInventoryDir, originalFilename)
+          _       <- writeFile(signatureFile, sigPath)
+          _       <- writeFile(inventoryFile, invPath)
         } yield s"Inventory '${originalFilename}' added to processing queue."
       }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/InventoryApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/InventoryApiTest.scala
@@ -1,0 +1,72 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest.lift
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+/*
+ * Check that path traversal are not possible in inventory API
+ */
+@RunWith(classOf[JUnitRunner])
+class InventoryApiTest extends Specification {
+
+  "InventoryApi.signatureFileName" should {
+
+    "reduce a path-traversal name to its basename" >> {
+      InventoryApi.signatureFileName("pwn/../../../../../../etc/cron.d/pwn") must beEqualTo("pwn")
+    }
+
+    "reduce an absolute path to its basename" >> {
+      InventoryApi.signatureFileName("/etc/cron.d/evil.sign") must beEqualTo("evil.sign")
+    }
+
+    "never return a name containing a path separator" >> {
+      InventoryApi.signatureFileName("a/b/c/node.ocs.gz.sign") must not(contain("/"))
+    }
+
+    "keep a plain signature name unchanged" >> {
+      InventoryApi.signatureFileName("node-uuid.ocs.sign") must beEqualTo("node-uuid.ocs.sign")
+    }
+
+    "keep the .gz compression marker" >> {
+      InventoryApi.signatureFileName("node-uuid.ocs.gz") must beEqualTo("node-uuid.ocs.gz")
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/InventoryApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/InventoryApiTest.scala
@@ -50,23 +50,25 @@ class InventoryApiTest extends Specification {
   "InventoryApi.signatureFileName" should {
 
     "reduce a path-traversal name to its basename" >> {
-      InventoryApi.signatureFileName("pwn/../../../../../../etc/cron.d/pwn") must beEqualTo("pwn")
+      InventoryApi.getInventoryAndSignatureFileName("inventory", "pwn/../../../../../../etc/cron.d/pwn") must beEqualTo(
+        ("inventory", "inventory.sign")
+      )
     }
 
     "reduce an absolute path to its basename" >> {
-      InventoryApi.signatureFileName("/etc/cron.d/evil.sign") must beEqualTo("evil.sign")
+      InventoryApi.getInventoryAndSignatureFileName("evil", "/etc/cron.d/evil.sign") must beEqualTo(("evil", "evil.sign"))
     }
 
     "never return a name containing a path separator" >> {
-      InventoryApi.signatureFileName("a/b/c/node.ocs.gz.sign") must not(contain("/"))
+      InventoryApi.getInventoryAndSignatureFileName("a/b/c/node.ocs.gz", "a/b/c/node.ocs.sign.gz") must beEqualTo(
+        ("node.ocs.gz", "node.ocs.sign.gz")
+      )
     }
 
     "keep a plain signature name unchanged" >> {
-      InventoryApi.signatureFileName("node-uuid.ocs.sign") must beEqualTo("node-uuid.ocs.sign")
-    }
-
-    "keep the .gz compression marker" >> {
-      InventoryApi.signatureFileName("node-uuid.ocs.gz") must beEqualTo("node-uuid.ocs.gz")
+      InventoryApi.getInventoryAndSignatureFileName("node-uuid.ocs.gz", "node-uuid.ocs.sign") must beEqualTo(
+        ("node-uuid.ocs.gz", "node-uuid.ocs.sign")
+      )
     }
   }
 }

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
@@ -65,19 +65,47 @@ object FileUtils {
 
   import FileError.*
 
+   /**
+   * Resolve symlinks on the deepest *existing* ancestor of `file` with `toRealPath`, then re-append
+   * (and lexically normalize) the still-non-existing trailing components.
+   *
+   * `toRealPath` only resolves paths that exist on disk. On a create/write path the target itself does
+   * not exist yet, so a naive `file.exists()`-guarded resolution leaves a symlinked *ancestor* (e.g.
+   * `<base>/link -> /etc`, then `<base>/link/newfile`) unresolved and the containment check becomes a
+   * purely lexical `startsWith` that a symlink defeats. Resolving the deepest existing ancestor closes
+   * that hole while still returning the real, symlink-free path for the containment test below.
+   */
+  private def resolveDeepestExisting(file: File): File = {
+    @tailrec
+    def rec(current: File, tail: List[String]): File = {
+      if (current.exists) {
+        // symlinks in the existing prefix are resolved by `toRealPath`; the non-existing tail is
+        // re-appended and `/` normalizes away any remaining `.`/`..` lexically.
+        File(tail.foldLeft(File(current.path.toRealPath()).path)((p, c) => p.resolve(c)).normalize())
+      } else {
+        current.parentOption match {
+          case Some(parent) => rec(parent, current.name :: tail)
+          case None         => File(tail.foldLeft(current.path)((p, c) => p.resolve(c)).normalize())
+        }
+      }
+    }
+    rec(file, Nil)
+  }
+
   /**
    * Check that `file` is contained into `baseFolder` after normalization. Return the normalized File.
    */
   def checkSanitizedIsIn(baseFolder: File, file: File): IOResult[File] = {
     // We also want to resolve symlinks before checking, let's resort to Java's `toRealPath`
     for {
-      baseExists  <- IOResult.attempt(baseFolder.exists())
-      realBasePath = if (baseExists) File(baseFolder.path.toRealPath()) else baseFolder
-      fileExists  <- IOResult.attempt(file.exists())
-      realFilePath = if (fileExists) File(file.path.toRealPath()) else file
+      baseExists   <- IOResult.attempt(baseFolder.exists())
+      realBasePath  = if (baseExists) File(baseFolder.path.toRealPath()) else baseFolder
+      // resolve symlinks even when the target does not exist yet, so a symlinked ancestor cannot
+      // escape the jail on the create/write path (see `resolveDeepestExisting`).
+      realFilePath <- IOResult.attempt(resolveDeepestExisting(file))
       // `false` means we allow access to the base directory itself
-      withinBase  <- IOResult.attempt(realBasePath.contains(realFilePath, strict = false))
-      _           <- ZIO.when(!withinBase)(OutsideBaseDir(file.nameOption, realFilePath).fail)
+      withinBase   <- IOResult.attempt(realBasePath.contains(realFilePath, strict = false))
+      _            <- ZIO.when(!withinBase)(OutsideBaseDir(file.nameOption, realFilePath).fail)
     } yield {
       realFilePath
     }

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
@@ -65,7 +65,7 @@ object FileUtils {
 
   import FileError.*
 
-   /**
+  /**
    * Resolve symlinks on the deepest *existing* ancestor of `file` with `toRealPath`, then re-append
    * (and lexically normalize) the still-non-existing trailing components.
    *

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/FileUtilsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/FileUtilsTest.scala
@@ -69,6 +69,11 @@ class FileUtilsTest extends Specification {
   val file3:   File = folder2 / "file3"
   file3.createFile()
 
+  // a symlinked *ancestor* pointing outside the jail, used to check the create/write path:
+  // the leaf itself does not exist yet, so containment must still be checked against the real target.
+  val linkToEtc: File = tmp / "linkToEtc"
+  linkToEtc.symbolicLinkTo(File("/etc"))
+
   "sanitize valid path" >> {
     val tail = "/file2"
     val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
@@ -109,6 +114,14 @@ class FileUtilsTest extends Specification {
     val tail = "/symlink1"
     val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     (res must beLeft(beAnInstanceOf[SecurityError])) and (res must beLeft(OutsideBaseDir(Some("symlink1"), root / "etc")))
+  }
+
+  "sanitize does not follow a symlinked ancestor on the create/write path" >> {
+    // the leaf `passwd_new` does not exist, but its ancestor `linkToEtc` escapes the jail
+    val tail = "/linkToEtc/passwd_new"
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
+    (res must beLeft(beAnInstanceOf[SecurityError])) and
+    (res must beLeft(OutsideBaseDir(Some("passwd_new"), root / "etc" / "passwd_new")))
   }
 
   "sanitize resolve jail dir and correctly check existing real path" >> {


### PR DESCRIPTION
https://issues.rudder.io/issues/29398

- resolve symlink on the deepest existing ancestor 
- extract the signature name part to make it testable
- sanitize both inventory and signature path