### PR TITLE
Fixes #29409: Allow to isolate global properties on a target (a set of nodes)

### DIFF
--- a/adr/webapp/29409-scoped-global-parameters.md
+++ b/adr/webapp/29409-scoped-global-parameters.md
@@ -1,0 +1,135 @@
+# Scoped global parameters: a property level between global and group
+
+* Status: accepted
+* Deciders: FAR
+* Date: 2026-07-28
+
+## Context
+
+Rudder resolves a node's properties over three levels: global parameters, group properties, node
+properties. Only the two lower levels can be restricted to a subset of the fleet; a global parameter
+is, by construction, distributed to **every** node - it is merged into every node's properties
+(`NodeContextBuilder`, "now we set defaults global parameters to all nodes"), written into every
+node's `properties.json`, and written again into every node's `rudder-parameters.json`.
+
+That is a problem for any producer of configuration that concerns only part of the fleet. The
+security-benchmarks plugin is the case that forced the issue: a benchmark stores its per-item
+enable/audit/enforce modes and its parameters as a global parameter named after the benchmark, then
+relies on group and node properties for per-group / per-node overrides. The benchmark applies to a
+`RuleTarget`, but its configuration lands on every node of the installation.
+
+Three distinct consequences:
+
+* **Tenant leak.** ADR
+  [`28945-tenant-enforcement-at-policy-generation`](multi-tenants/28945-tenant-enforcement-at-policy-generation.md)
+  clamps a *rule* to the nodes its `SecurityTag` can see. There is no equivalent clamp for
+  parameters, so a tenant-tagged global parameter is written verbatim into the policies of every
+  node of every tenant.
+* **Scale.** A CIS benchmark model has ~400 items; the derived default value is tens of KB of JSON,
+  replicated to every node, twice on disk, and held per node in the in-memory property-hierarchy
+  cache. It also makes *any* global parameter change regenerate *all* nodes
+  (`NodeConfigurationCacheRepository`, `parameterHash`).
+* **Model.** A plugin's internal storage occupies the user-facing "global parameter" namespace.
+
+Two options were rejected before this one:
+
+* **Reuse `Visibility.Hidden` to mean "not distributed".** `Visibility` is today a pure API/UI
+  filter, and in production only the benchmark plugin sets `Hidden`, so its semantics were ours to
+  change. But the benchmark's mode keys are consumed **at agent runtime**: `common/1.0/properties.cf`
+  reads `node.properties[<benchmarkId>]` and defines a class `<benchmarkId>_<itemId>_<mode>` per
+  item (the `rudder_auto_conditions` mechanism), and the generated `technique.cf` guards every
+  control on that class. Not distributing the property would silently define no class, run no
+  control, and raise no error. More fundamentally, `Visibility` is a *unary* predicate on the
+  property while the requirement is *relational* - "this value belongs to these nodes" - so no
+  re-reading of a boolean can express it.
+* **Give targets a stable identity (a first-class `Target` entity) and hang properties off it.**
+  Attractive for other reasons (targets in rules, compliance per target), but not needed here: the
+  stable identity is already the **property name**. Group and node overrides key off the name and
+  survive any change of target, so only the *distribution scope* has to move.
+
+## Decision
+
+**Add an optional `scope` to a global parameter.** A parameter with a scope is distributed only to
+the nodes matched by that scope; a parameter without one keeps today's behaviour.
+
+* The scope is a field on `GlobalParameter`, not a new entity: same shape and storage pattern as
+  `security` and `visibility` (a key in the property's HOCON config plus an optional LDAP
+  attribute), one repository, one API, one event log.
+* The scope is typed **`RuleTarget`** and persisted with the existing `RuleTarget` string form. This
+  is deliberate: if named targets ever become entities, `NamedTarget(id)` is just another
+  `RuleTarget` value and the field needs no migration.
+* The accessor is a total `Option[RuleTarget]`, because the target is **parsed where the parameter
+  crosses a boundary** - `LDAPEntityMapper.entry2Parameter` and the git-archive unserialisation both
+  reject an unparsable target and fail the read. Reading a broken scope as "no scope" would mean
+  "distribute everywhere", exactly the leak this ADR removes, so it must not be a case the domain
+  has to handle: it is rejected before a `GlobalParameter` exists. Every other builder takes an
+  already-typed `RuleTarget`.
+* The accessor lives on `GlobalParameter` only. A `NodeProperty.scope` would be meaningless, and a
+  signature must not lie.
+
+**Resolution order becomes global < scoped < group < node**, materialized by a new
+`ParentProperty.Target` case in the hierarchy ADT (kind `target`). A scoped parameter overrides the
+unscoped parameter of the same name and is in turn overridden by group and node properties, exactly
+like any other level.
+
+**Scope resolution happens once per property, not once per node.** Targets are resolved through
+`RoNodeGroupRepository`/`FullNodeGroupCategory.getNodeIds` with a `NodeAndServerIds` obtained from
+`NodeFactRepository.getNodeAndServerIds()` - never by hand.
+
+**A scope belongs to a property *name*, not merely to a value, and it defines that name's domain of
+definition.** On a node outside the scope, the name does not exist at all: not as an inherited
+default, and not through a group or node override of the same name either. This is the load-bearing
+part of the decision. Restricting only the parameter's own value would leave the leak wide open -
+a node excluded from a benchmark target but member of a group that overrides the benchmark's
+property would still receive that configuration, which is exactly what the scope is for.
+
+This is unambiguous because **a global parameter's name is unique in storage** (its LDAP RDN *is*
+`parameterName`), so a name carries at most one parameter and therefore at most one scope. There is
+no "which scope wins" question, and no need for a combining or conflict rule between scopes.
+
+Concretely, resolution is unchanged - the group DAG, the override order, everything - and the scope
+is applied as a filter on names once the merge is done. Errors about an out-of-scope name are
+dropped too: a node must not fail its property resolution, and therefore its policy generation,
+because of a property it does not have.
+
+**`rudder_auto_conditions` therefore stays a single unscoped parameter.** Beyond the storage
+constraint, what it discloses is cheap: benchmark ids are random UUIDs unless a caller supplies its
+own, so a node learns how many benchmarks exist and their opaque ids - not their names, and not
+their configuration. It is also functionally safe: on a node outside a benchmark target the id is
+listed but `node.properties[<benchmarkId>]` is absent, which yields no class and no error.
+
+**Scoped parameters are shown at group level like unscoped ones**, so that a group overriding one
+displays what it overrides. This view is *indicative*: a group is not necessarily a subset of the
+scope, so the displayed parent is what a member node inside the scope inherits, not a promise about
+every member. That matches the existing meaning of the group property view, which is already a
+potential hierarchy rather than a per-node truth (group membership is dynamic). The authoritative
+resolution is the per-node one, where the domain-of-definition rule above applies.
+
+**Referencing a scoped parameter from a node outside its scope is a generation error.** The property
+is genuinely absent for that node, and `${rudder.parameters[X]}` fails as it does for any unknown
+parameter. Failing closed here is preferable to silently substituting the unscoped value.
+
+## Consequences
+
+* The tenant leak and the fleet-wide bloat are fixed for any producer of partial configuration, not
+  only for security benchmarks.
+* Combined with the removal of the parameter distribution channel (`rudder-parameters.json` and the
+  `rudder_parameters` bundle, planned for the next major), the `parameterHash` term of the
+  node-configuration hash disappears and a scoped-parameter change only regenerates the nodes in its
+  scope. Scoping alone does not achieve that: the two changes are worth sequencing together.
+* The property JSON contract gains a `target` kind in the inheritance hierarchy. This is additive,
+  but the Elm decoder rejects unknown kinds, so the UI must be updated in the same change.
+* Migrating an existing producer to a scope removes the property from out-of-scope nodes, which
+  stops whatever it was driving there. That is the intent, but it is a visible behaviour change and
+  must be release-noted, not shipped silently.
+* Because the scope governs the whole name, a group or node override of a scoped name silently does
+  not apply outside the scope. That would be surprising for a user-authored parameter - but `scope`
+  is deliberately not settable through the API, so every scoped name is owned by the plugin that
+  created it, and overriding it outside its scope has no meaning.
+* Should a "several producers feed one shared name" use case ever appear, it needs both a composite
+  `(name, scope)` identity in the parameter repository and a combination rule in the merge engine.
+  Neither is built here, on purpose: nothing can produce that state today.
+* `Visibility` keeps its current meaning - API/UI listings and archives - and stays useful next to
+  `scope`: a benchmark's blob should be scoped *and* hidden. The one distribution rule attached to
+  it is that a hidden parameter is not published in the agent's parameter namespace, since "hidden"
+  means "not a user-facing parameter".

--- a/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
@@ -406,6 +406,13 @@ attributetype ( RudderAttributes:309
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
+attributetype ( RudderAttributes:310
+  NAME 'parameterScope'
+  DESC 'Serialized rule target restricting the nodes a parameter is distributed to'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
 #### Nodes
 
 attributetype ( RudderAttributes:351
@@ -592,7 +599,8 @@ objectclass ( RudderObjectClasses:120
   STRUCTURAL
   MUST ( parameterName )
   MAY ( parameterValue $ description $ propertyProvider $
-        overridable $ inheritMode $ revision $ visibility $ securityTag) )
+        overridable $ inheritMode $ revision $ visibility $ securityTag $
+        parameterScope ) )
 
 #
 # Application properties

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -328,6 +328,10 @@ object JsonQueryObjects {
   ) {
     def updateParameter(parameter: GlobalParameter): GlobalParameter = {
       // provider from API is force set to default.
+      // `scope` is deliberately not settable from the API yet (ADR 29409): it is written by the
+      // producer of the parameter, and letting a user choose a target here would need its own
+      // authorization rule (which targets may a tenant scope a parameter to?). Leaving it out of
+      // the patch means an update of a scoped parameter keeps its scope, like hidden properties.
       val patched =
         parameter.patch(PatchProperty(id, value, Some(PropertyProvider.defaultPropertyProvider), description, inheritMode))
       security match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -1334,12 +1334,15 @@ object JsonResponseObjects {
       description:     String,
       inheritMode:     Option[InheritMode],
       provider:        Option[PropertyProvider],
-      security:        Option[SecurityTag]
+      security:        Option[SecurityTag],
+      // serialized RuleTarget the parameter is restricted to, absent when it applies to all
+      // nodes (ADR 29409)
+      scope:           Option[String]
   )
 
   object JRGlobalParameter {
     import GenericProperty.*
-    def empty(name: String): JRGlobalParameter = JRGlobalParameter(None, name, "".toConfigValue, "", None, None, None)
+    def empty(name: String): JRGlobalParameter = JRGlobalParameter(None, name, "".toConfigValue, "", None, None, None, None)
     def fromGlobalParameter(p: GlobalParameter, crId: Option[ChangeRequestId])(using qc: QueryContext): JRGlobalParameter = {
       JRGlobalParameter(
         crId.map(_.value.toString),
@@ -1348,7 +1351,8 @@ object JsonResponseObjects {
         p.description,
         p.inheritMode,
         p.provider,
-        qc.accessGrant.visibleSecurityTag(p.security)
+        qc.accessGrant.visibleSecurityTag(p.security),
+        p.scope.map(_.target)
       )
     }
 
@@ -1432,14 +1436,24 @@ object JsonResponseObjects {
         valueType: String,
         parent:    Option[JRParentPropertyDetails]
     ) extends JRParentPropertyDetails
+    // a global parameter restricted to a target (ADR 29409): `id` is the serialized target
+    @jsonHint("target")
+    final case class JRParentTargetDetails(
+        name:      String,
+        id:        String,
+        valueType: String,
+        parent:    Option[JRParentPropertyDetails]
+    ) extends JRParentPropertyDetails
 
     def fromParentProperty(p: ParentProperty[?]): JRParentPropertyDetails = {
       def serializeValueType(v: ConfigValue): String = v.valueType.name().toLowerCase().capitalize
       p match {
-        case g: ParentProperty.Group =>
+        case g: ParentProperty.Group  =>
           JRParentGroupDetails(g.name, g.id, serializeValueType(g.value.value), g.parentProperty.map(fromParentProperty))
-        case n: ParentProperty.Node  =>
+        case n: ParentProperty.Node   =>
           JRParentNodeDetails(n.name, n.id, serializeValueType(n.value.value), n.parentProperty.map(fromParentProperty))
+        case t: ParentProperty.Target =>
+          JRParentTargetDetails(t.name, t.id, serializeValueType(t.value.value), t.parentProperty.map(fromParentProperty))
         case ParentProperty.Global(value) =>
           JRParentGlobalDetails(serializeValueType(value.value))
       }
@@ -1573,20 +1587,28 @@ object JsonResponseObjects {
     ): Option[JRPropertyHierarchy] = {
       def renderHtml(nodeParentProperty: ParentProperty[?]): List[String] = {
         nodeParentProperty match {
-          case n: ParentProperty.Node  =>
+          case n: ParentProperty.Node   =>
             n.parentProperty
               .map(renderHtml)
               .getOrElse(Nil) :::
             (s"<p>from <b>node '${n.name}' (${n.id})</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
                                                                  else identity[String])
                 .apply(n.value.value.render(ConfigRenderOptions.defaults().setOriginComments(false)))}</pre></p>" :: Nil)
-          case g: ParentProperty.Group =>
+          case g: ParentProperty.Group  =>
             g.parentProperty
               .map(renderHtml)
               .getOrElse(Nil) :::
             (s"<p>from <b>group '${g.name}' (${g.id})</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
                                                                   else identity[String])
                 .apply(g.value.value.render(ConfigRenderOptions.defaults().setOriginComments(false)))}</pre></p>" :: Nil)
+          case t: ParentProperty.Target =>
+            t.parentProperty
+              .map(renderHtml)
+              .getOrElse(Nil) :::
+            (s"<p>from <b>global property '${t.name}' scoped to '${t.id}'</b>:<pre>${(if (escapeHtml)
+                                                                                        xml.Utility.escape(_: String)
+                                                                                      else identity[String])
+                .apply(t.value.value.render(ConfigRenderOptions.defaults().setOriginComments(false)))}</pre></p>" :: Nil)
           case ParentProperty.Global(v) =>
             s"<p>from <b>global property '${v.name}'</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
                                                                  else identity[String])
@@ -1637,12 +1659,25 @@ object JsonResponseObjects {
         resolvedValue: ConfigValue,
         parent:        Option[JRParentProperty]
     ) extends JRParentProperty
+
+    // a global parameter restricted to a target (ADR 29409): `id` is the serialized target
+    @jsonHint("target")
+    final case class JRParentTarget(
+        name:          String,
+        id:            String,
+        value:         ConfigValue,
+        resolvedValue: ConfigValue,
+        parent:        Option[JRParentProperty]
+    ) extends JRParentProperty
+
     def fromParentProperty(p: ParentProperty[?]): JRParentProperty = {
       p match {
-        case n: ParentProperty.Node  =>
+        case n: ParentProperty.Node   =>
           JRParentNode(n.name, n.id, n.value.value, n.resolvedValue.value, n.parentProperty.map(fromParentProperty))
-        case g: ParentProperty.Group =>
+        case g: ParentProperty.Group  =>
           JRParentGroup(g.name, g.id, g.value.value, g.resolvedValue.value, g.parentProperty.map(fromParentProperty))
+        case t: ParentProperty.Target =>
+          JRParentTarget(t.name, t.id, t.value.value, t.resolvedValue.value, t.parentProperty.map(fromParentProperty))
         case _ =>
           JRParentGlobal(p.value.value)
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
@@ -122,6 +122,8 @@ object RudderLDAPConstants extends Loggable {
   // Parameters
   val A_PARAMETER_NAME  = "parameterName"
   val A_PARAMETER_VALUE = "parameterValue"
+  // serialized RuleTarget restricting the nodes the parameter is distributed to (ADR 29409)
+  val A_PARAMETER_SCOPE = "parameterScope"
 
   // Web properties
   val A_PROPERTY_NAME  = "propertyName"
@@ -238,7 +240,7 @@ object RudderLDAPConstants extends Loggable {
   OC.createObjectClass(
     OC_PARAMETER,
     must = Set(A_PARAMETER_NAME),
-    may = Set(A_PARAMETER_VALUE, A_DESCRIPTION, A_PROPERTY_PROVIDER)
+    may = Set(A_PARAMETER_VALUE, A_DESCRIPTION, A_PROPERTY_PROVIDER, A_PARAMETER_SCOPE)
   )
 
   OC.createObjectClass(OC_PROPERTY, must = Set(A_PROPERTY_NAME), may = Set(A_PROPERTY_VALUE, A_DESCRIPTION))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/ParameterDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/ParameterDiff.scala
@@ -65,10 +65,13 @@ final case class ModifyGlobalParameterDiff(
     modProvider:    Option[SimpleDiff[Option[PropertyProvider]]] = None,
     modInheritMode: Option[SimpleDiff[Option[InheritMode]]] = None,
     modVisibility:  Option[SimpleDiff[Option[Visibility]]] = None,
-    modSecurityTag: Option[SimpleDiff[Option[SecurityTag]]] = None
+    modSecurityTag: Option[SimpleDiff[Option[SecurityTag]]] = None,
+    // serialized rule target, see ADR 29409
+    modScope:       Option[SimpleDiff[Option[String]]] = None
 ) extends ParameterDiff {
   def needDeployment: Boolean = {
-    modValue.isDefined || modInheritMode.isDefined || modSecurityTag.isDefined
+    // a scope change moves the parameter between nodes, so policies must be rewritten
+    modValue.isDefined || modInheritMode.isDefined || modSecurityTag.isDefined || modScope.isDefined
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -43,6 +43,7 @@ import com.normation.GitVersion.Revision
 import com.normation.errors.*
 import com.normation.inventory.domain.CustomProperty
 import com.normation.rudder.domain.logger.ApplicationLogger
+import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.services.policies.ParameterEntry
 import com.normation.rudder.tenants.HasSecurityTag
 import com.normation.rudder.tenants.SecurityTag
@@ -185,7 +186,8 @@ final case class PatchProperty(
     description: Option[String] = None,
     inheritMode: Option[InheritMode] = None,
     visibility:  Option[Visibility] = None,
-    security:    Option[Option[SecurityTag]] = None
+    security:    Option[Option[SecurityTag]] = None,
+    scope:       Option[Option[RuleTarget]] = None
 )
 
 /*
@@ -280,7 +282,8 @@ sealed trait GenericProperty[P <: GenericProperty[?]] {
         patchOne[String](GenericProperty.DESCRIPTION, p.description, _.toConfigValue)(_),
         patchOne[InheritMode](GenericProperty.INHERIT_MODE, p.inheritMode, _.value.toConfigValue)(_),
         (c: Config) => patchVisibility(c, p.visibility),
-        (c: Config) => patchSecurity(c, p.security)
+        (c: Config) => patchSecurity(c, p.security),
+        (c: Config) => patchScope(c, p.scope)
       ).foldLeft(config) { case (c, patchStep) => patchStep(c) }
     )
   }
@@ -299,6 +302,7 @@ object GenericProperty {
   val INHERIT_MODE = "inheritMode" // options: inheritance mode
   val VISIBILITY   = "visibility"  // optional, if missing Visibility.default
   val SECURITY     = "security"    // optional, if missing None
+  val SCOPE        = "scope"       // optional, if missing the property applies to all nodes
 
   def getMode(config: Config):                            Option[InheritMode] = {
     if (config.hasPath(INHERIT_MODE)) {
@@ -432,6 +436,19 @@ object GenericProperty {
     case None                               => c
     case Some(v) if v == Visibility.default => c.withoutPath(GenericProperty.VISIBILITY)
     case Some(v)                            => c.withValue(GenericProperty.VISIBILITY, v.entryName.toConfigValue)
+  }
+
+  /*
+   * Patch the scope, with the semantic that Some(None) remove it.
+   * The target is stored with its usual string form, so that a future kind of target
+   * (a named one, for example) needs no change here nor any data migration.
+   */
+  final private[properties] def patchScope(c: Config, s: Option[Option[RuleTarget]]): Config = {
+    s match {
+      case None          => c
+      case Some(None)    => c.withoutPath(GenericProperty.SCOPE)
+      case Some(Some(t)) => c.withValue(GenericProperty.SCOPE, ConfigValueFactory.fromAnyRef(t.target))
+    }
   }
 
   /*
@@ -633,9 +650,10 @@ object GenericProperty {
       description: Option[String],
       visibility:  Option[Visibility],
       security:    Option[SecurityTag],
+      scope:       Option[RuleTarget] = None,
       options:     ConfigParseOptions = ConfigParseOptions.defaults()
   ): PureResult[Config] = {
-    parseValue(value).map(v => toConfig(name, rev, v, mode, provider, description, visibility, security, options))
+    parseValue(value).map(v => toConfig(name, rev, v, mode, provider, description, visibility, security, scope, options))
   }
 
   /**
@@ -651,6 +669,8 @@ object GenericProperty {
       visibility:  Option[Visibility],
       // security so that in json is becomes: { "security": { "tenants": [...] }, ...}
       security:    Option[SecurityTag], // optional for backward compat. None means "no tenant"
+      // None means "no scope", ie the property is distributed to all nodes
+      scope:       Option[RuleTarget] = None,
       options:     ConfigParseOptions = ConfigParseOptions.defaults()
   ): Config = {
     val m              = new java.util.HashMap[String, ConfigValue]()
@@ -665,7 +685,8 @@ object GenericProperty {
     mode.foreach(x => m.put(INHERIT_MODE, ConfigValueFactory.fromAnyRef(x.value)))
     val withVisibility = GenericProperty.patchVisibility(ConfigFactory.parseMap(m, options.getOriginDescription), visibility)
     // `security.map(Some(_))`: None means "no tenant" (leave the path absent), Some(tag) sets it
-    GenericProperty.patchSecurity(withVisibility, security.map(Some(_)))
+    val withSecurity   = GenericProperty.patchSecurity(withVisibility, security.map(Some(_)))
+    GenericProperty.patchScope(withSecurity, scope.map(Some(_)))
   }
 
   def valueToConfig(value: ConfigValue): Config = {
@@ -924,6 +945,24 @@ object JsonPropertySerialisation {
  */
 final case class GlobalParameter(config: Config) extends GenericProperty[GlobalParameter] {
   override def fromConfig(c: Config): GlobalParameter = GlobalParameter(c)
+
+  /*
+   * The set of nodes this parameter is distributed to, or None for all of them.
+   * Only a global parameter can carry a scope: it is the root of the inheritance
+   * hierarchy, and lower levels are already restricted by construction.
+   *
+   * Total by construction: the scope is parsed where a `GlobalParameter` is built from an
+   * external representation - LDAP (`LDAPEntityMapper.entry2Parameter`) and the git archive
+   * (`XmlUnserialisationImpl`) both reject an unparsable target rather than reading it as
+   * "no scope", which would distribute the value to the whole fleet (ADR 29409). Every other
+   * builder takes an already-typed `RuleTarget`.
+   */
+  def scope: Option[RuleTarget] = {
+    if (config.hasPath(GenericProperty.SCOPE)) RuleTarget.unser(config.getString(GenericProperty.SCOPE)).toOption
+    else None
+  }
+
+  def withScope(t: Option[RuleTarget]): GlobalParameter = fromConfig(GenericProperty.patchScope(config, Some(t)))
 }
 
 object GlobalParameter {
@@ -954,10 +993,11 @@ object GlobalParameter {
       description: String,
       provider:    Option[PropertyProvider],
       visibility:  Visibility,
-      security:    Option[SecurityTag]
+      security:    Option[SecurityTag],
+      scope:       Option[RuleTarget] = None
   ): PureResult[GlobalParameter] = {
     GenericProperty
-      .parseConfig(name, rev, value, mode, provider, Some(description), Some(visibility), security)
+      .parseConfig(name, rev, value, mode, provider, Some(description), Some(visibility), security, scope)
       .map(c => new GlobalParameter(c))
   }
   def apply(
@@ -969,9 +1009,13 @@ object GlobalParameter {
       provider:    Option[PropertyProvider],
       visibility:  Visibility,
       // security so that in json is becomes: { "security": { "tenants": [...] }, ...}
-      security:    Option[SecurityTag] // optional for backward compat. None means "no tenant"
+      security:    Option[SecurityTag], // optional for backward compat. None means "no tenant"
+      // None means the parameter is distributed to all nodes (ADR 29409)
+      scope:       Option[RuleTarget] = None
   ): GlobalParameter = {
-    new GlobalParameter(GenericProperty.toConfig(name, rev, value, mode, provider, Some(description), Some(visibility), security))
+    new GlobalParameter(
+      GenericProperty.toConfig(name, rev, value, mode, provider, Some(description), Some(visibility), security, scope)
+    )
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
@@ -6,6 +6,7 @@ import cats.data.Ior
 import cats.syntax.semigroup.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.properties.ParentProperty.VertexParentProperty
 import com.normation.rudder.properties.GroupProp
 import enumeratum.Enum
@@ -21,6 +22,7 @@ sealed trait ParentPropertyKind(override val entryName: String) extends EnumEntr
 object ParentPropertyKind extends Enum[ParentPropertyKind] with EnumCodec[ParentPropertyKind] {
   case object Node   extends ParentPropertyKind("node")
   case object Group  extends ParentPropertyKind("group")
+  case object Target extends ParentPropertyKind("target")
   case object Global extends ParentPropertyKind("global")
 
   override def values: IndexedSeq[ParentPropertyKind] = findValues
@@ -78,6 +80,28 @@ object ParentProperty {
       case None    => value
       case Some(v) =>
         GroupProperty(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(using v.resolvedValue.inheritMode))
+    }
+  }
+
+  /*
+   * A global parameter restricted to a target (ADR 29409). It sits between the global
+   * level and the groups: it overrides the unscoped parameter of the same name, and is
+   * overridden by group and node properties.
+   * `value` is the already-combined value when several scopes contribute to that name
+   * (see MergeNodeProperties.combineScopedParams).
+   */
+  final case class Target(
+      scope:              RuleTarget,
+      override val value: GlobalParameter,
+      parentProperty:     Option[VertexParentProperty[?]]
+  ) extends VertexParentProperty[GlobalParameter] {
+    override val name:          String                           = value.name
+    override def id:            String                           = scope.target
+    override val kind:          ParentPropertyKind               = ParentPropertyKind.Target
+    override val resolvedValue: GenericProperty[GlobalParameter] = parentProperty match {
+      case None    => value
+      case Some(v) =>
+        GlobalParameter(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(using v.resolvedValue.inheritMode))
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
@@ -162,6 +162,25 @@ object GroupProp {
   }
 }
 
+/*
+ * The scoped parameters (ADR 29409) as seen from one node: the ones whose target contains it, and
+ * the *names* of the ones whose target does not.
+ *
+ * A scope defines the domain of definition of a property name, not merely a default value: outside
+ * its scope the name does not exist on that node at all. So we need both halves - the second one to
+ * drop group and node overrides of a name that is scoped away from this node.
+ *
+ * The caller resolves the targets once for the whole fleet, see NodePropertiesService.
+ */
+final case class NodeScopedParameters(
+    inScope:    List[ParentProperty.Target],
+    outOfScope: Set[String]
+)
+
+object NodeScopedParameters {
+  val empty: NodeScopedParameters = NodeScopedParameters(Nil, Set.empty)
+}
+
 object MergeNodeProperties {
 
   /**
@@ -171,11 +190,12 @@ object MergeNodeProperties {
   def forNode(
       node:         CoreNodeFact,
       groupTargets: Iterable[FullGroupTarget],
-      globalParams: Map[String, GlobalParameter]
+      globalParams: Map[String, GlobalParameter],
+      scoped:       NodeScopedParameters = NodeScopedParameters.empty
   ): ResolvedNodePropertyHierarchy = {
     val groupProps = groupTargets.map(_.nodeGroup.toGroupProp).map(g => (g.groupId, g)).toMap
 
-    val properties = checkPropertyMerge(groupProps, globalParams).map(props => {
+    val properties = checkPropertyMerge(groupProps, globalParams, scoped.inScope).map(props => {
       Chunk
         .fromIterable(
           mergeDefaultNode(
@@ -186,7 +206,38 @@ object MergeNodeProperties {
         )
         .sortBy(_.prop.name)
     })
-    ResolvedNodePropertyHierarchy.from(properties)
+    ResolvedNodePropertyHierarchy.from(dropOutOfScope(properties, scoped.outOfScope))
+  }
+
+  /*
+   * Enforce the domain of definition of scoped names on one node (ADR 29409): a name scoped away
+   * from that node is removed whichever level defined it - the scoped parameter is already absent,
+   * but a group or the node itself may define the same name, and that value must not reach the
+   * node either.
+   *
+   * Errors about those names go too: a node must not fail its whole property resolution - and
+   * therefore its policy generation - because of a property it does not have.
+   */
+  private def dropOutOfScope(
+      resolved: Ior[PropertyHierarchyError, Chunk[PropertyHierarchy]],
+      names:    Set[String]
+  ): Ior[PropertyHierarchyError, Chunk[PropertyHierarchy]] = {
+    if (names.isEmpty) resolved
+    else {
+      val filtered = resolved.bimap(
+        {
+          case err: PropertyHierarchyError.PropertyHierarchySpecificInheritanceConflicts => err.resolve(names)
+          case err => err
+        },
+        _.filterNot(p => names.contains(p.prop.name))
+      )
+      // dropping every conflict leaves an empty error, which is not an error anymore
+      filtered match {
+        case Ior.Both(PropertyHierarchyError.PropertyHierarchySpecificInheritanceConflicts.empty, ok) => Ior.Right(ok)
+        case Ior.Left(PropertyHierarchyError.PropertyHierarchySpecificInheritanceConflicts.empty)     => Ior.Right(Chunk.empty)
+        case other                                                                                    => other
+      }
+    }
   }
 
   /*
@@ -195,7 +246,11 @@ object MergeNodeProperties {
   def forGroup(
       group:        FullGroupTarget,
       allGroups:    Map[NodeGroupId, FullGroupTarget],
-      globalParams: Map[String, GlobalParameter]
+      globalParams: Map[String, GlobalParameter],
+      // scoped parameters are shown at group level like unscoped ones, so that a group overriding
+      // one displays what it overrides. This view is indicative: a group is not necessarily a
+      // subset of the scope, and the authoritative resolution is the per-node one (ADR 29409).
+      scopedParams: List[ParentProperty.Target] = Nil
   ): ResolvedNodePropertyHierarchy = {
     val groupProp     = group.nodeGroup.toGroupProp
     val allGroupProps = allGroups.map { case (id, g) => (id.serialize, g.nodeGroup.toGroupProp) }
@@ -251,15 +306,19 @@ object MergeNodeProperties {
           case n: ParentProperty.Node   => n.parentProperty.flatMap(findLastMatchingGroup)
           case g: ParentProperty.Group  =>
             g.parentProperty match {
-              case None                           => Some(g)
-              case Some(_: ParentProperty.Global) => Some(g)
-              case Some(parent)                   => findLastMatchingGroup(parent)
+              case None                                                            => Some(g)
+              // global and scoped parameters are roots: `g` is the last group of that line
+              case Some(_: ParentProperty.Global) | Some(_: ParentProperty.Target) => Some(g)
+              case Some(parent)                                                    => findLastMatchingGroup(parent)
             }
+          // a group is never resolved against scoped parameters (ADR 29409), so this is only
+          // reachable for defensive completeness
+          case _: ParentProperty.Target => None
           case _: ParentProperty.Global => None
         }
       }
 
-      checkPropertyMerge(otherProps, globalParams) match {
+      checkPropertyMerge(otherProps, globalParams, scopedParams) match {
         case Ior.Right(b) => Ior.Right(b)
         case withErr      =>
           withErr.left match {
@@ -387,7 +446,8 @@ object MergeNodeProperties {
    */
   def checkPropertyMerge(
       props:        Map[NodeGroupId, GroupProp],
-      globalParams: Map[String, GlobalParameter]
+      globalParams: Map[String, GlobalParameter],
+      scopedParams: List[ParentProperty.Target] = Nil
   ): Ior[PropertyHierarchyError, List[VertexParentProperty[?]]] = {
     /*
      * General strategy:
@@ -429,11 +489,16 @@ object MergeNodeProperties {
                 case Some(oldProp) => // merge prop and add old to parents
                   def recAppend(prop: VertexParentProperty[?]): VertexParentProperty[?] = {
                     prop match {
-                      case _:     ParentProperty.Global => oldProp
-                      case group: ParentProperty.Group  =>
+                      case _:      ParentProperty.Global => oldProp
+                      case group:  ParentProperty.Group  =>
                         group.parentProperty match {
                           case None    => group.copy(parentProperty = Some(oldProp))
                           case Some(g) => group.copy(parentProperty = Some(recAppend(g)))
+                        }
+                      case target: ParentProperty.Target =>
+                        target.parentProperty match {
+                          case None    => target.copy(parentProperty = Some(oldProp))
+                          case Some(p) => target.copy(parentProperty = Some(recAppend(p)))
                         }
                     }
                   }
@@ -502,11 +567,24 @@ object MergeNodeProperties {
                      case (n, v) =>
                        (n, ParentProperty.Global(v) -> v.inheritMode)
                    }
+      scoped     = scopedRoots(scopedParams)
     } yield {
-      // here, we add global parameters as a first default
+      // levels, from the most default to the most specific: global < scoped < groups
       val mergedProps = merged.map(p => (p.value.name, p -> p.value.inheritMode)).toMap
-      overrideValues(globals.toMap :: mergedProps :: Nil).values.toList
+      overrideValues(globals.toMap :: scoped :: mergedProps :: Nil).values.toList
     }
+  }
+
+  /**
+   * The scoped parameters, as the roots they form in the hierarchy (ADR 29409).
+   *
+   * There is nothing to arbitrate here: a global parameter's name is unique in storage (its LDAP
+   * RDN *is* the name), so a name carries at most one parameter and therefore at most one scope.
+   */
+  private def scopedRoots(
+      scopedParams: List[ParentProperty.Target]
+  ): Map[String, (VertexParentProperty[?], Option[InheritMode])] = {
+    scopedParams.map(t => (t.value.name, (t: VertexParentProperty[?], t.value.inheritMode))).toMap
   }
 
   /**
@@ -646,6 +724,9 @@ object MergeNodeProperties {
         case n:    ParentProperty.Node   =>
           s"Node '${n.name}' (${n.id}) with value '${n.value.value.render(ConfigRenderOptions.concise())}'" :: n.parentProperty.toList
             .flatMap(message)
+        case t:    ParentProperty.Target =>
+          s"Scope '${t.id}' with value '${t.value.value.render(ConfigRenderOptions.concise())}'" :: t.parentProperty.toList
+            .flatMap(message)
         case glob: ParentProperty.Global =>
           s"Global property with value '${glob.value.value.render(ConfigRenderOptions.concise())}'" :: Nil
       }
@@ -657,6 +738,8 @@ object MergeNodeProperties {
           g.parentProperty.map(check(_, valueType)).getOrElse(true)
         case n:    ParentProperty.Node   =>
           n.parentProperty.map(check(_, valueType)).getOrElse(true)
+        case t:    ParentProperty.Target =>
+          t.parentProperty.map(check(_, valueType)).getOrElse(true)
         case glob: ParentProperty.Global =>
           true
       })

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
@@ -38,14 +38,19 @@
 package com.normation.rudder.properties
 
 import com.normation.errors.*
+import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.NodePropertiesLoggerPure
 import com.normation.rudder.domain.properties.FailedNodePropertyHierarchy
+import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.domain.properties.ParentProperty
 import com.normation.rudder.domain.properties.SuccessNodePropertyHierarchy
 import com.normation.rudder.facts.nodes.NodeFactRepository
+import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.tenants.QueryContext
 import com.typesafe.config.ConfigRenderOptions
+import zio.*
 
 /*
  * This file contains a cache/in-memory repository for inherited node properties, ie the result
@@ -73,13 +78,16 @@ class NodePropertiesServiceImpl(
     given qc: QueryContext = QueryContext.systemQC
 
     for {
-      params      <- globalPropsRepo.getAllGlobalParameters().map(_.map(x => (x.name, x)).toMap)
-      groups      <- roNodeGroupRepository.getFullGroupLibrary()
-      nodes       <- nodeFactRepository.getAll().map(_.values)
-      mergedGroups = {
+      allParams       <- globalPropsRepo.getAllGlobalParameters()
+      groups          <- roNodeGroupRepository.getFullGroupLibrary()
+      nodes           <- nodeFactRepository.getAll().map(_.values)
+      // scopes are resolved to node ids once for the whole fleet, not once per node
+      splitParams     <- partitionScopedParams(allParams, groups)
+      (params, scoped) = splitParams
+      mergedGroups     = {
         groups.allGroups.map {
           case (gid, group) =>
-            val resolved = MergeNodeProperties.forGroup(group, groups.allGroups, params)
+            val resolved = MergeNodeProperties.forGroup(group, groups.allGroups, params, scoped.map(_._2))
             resolved match {
               case f: FailedNodePropertyHierarchy  =>
                 NodePropertiesLoggerPure.logEffect.debug(
@@ -98,10 +106,14 @@ class NodePropertiesServiceImpl(
             gid -> resolved
         }
       }
-      mergedNodes  = {
+      mergedNodes      = {
         nodes
           .map(n => {
-            val resolved = MergeNodeProperties.forNode(n, groups.getGroupTarget(n).values, params)
+            // a name scoped away from that node must not reach it through a group or node
+            // override either, so we carry both halves of the split (ADR 29409)
+            val (in, out)  = scoped.partition { case (nodeIds, _) => nodeIds.contains(n.id) }
+            val nodeScoped = NodeScopedParameters(in.map(_._2), out.map(_._2.value.name).toSet)
+            val resolved   = MergeNodeProperties.forNode(n, groups.getGroupTarget(n).values, params, nodeScoped)
             resolved match {
               case f: FailedNodePropertyHierarchy  =>
                 NodePropertiesLoggerPure.logEffect.debug(
@@ -120,8 +132,28 @@ class NodePropertiesServiceImpl(
             n.id -> resolved
           })
       }
-      _           <- propertiesRepository.saveNodeProps(mergedNodes.toMap)
-      _           <- propertiesRepository.saveGroupProps(mergedGroups.toMap)
+      _               <- propertiesRepository.saveNodeProps(mergedNodes.toMap)
+      _               <- propertiesRepository.saveGroupProps(mergedGroups.toMap)
     } yield ()
+  }
+
+  /*
+   * Split parameters between the unscoped ones - distributed to every node, as before - and the
+   * scoped ones, resolving each scope to its node ids once for the whole fleet (ADR 29409).
+   */
+  private def partitionScopedParams(
+      params: Seq[GlobalParameter],
+      groups: FullNodeGroupCategory
+  )(implicit qc: QueryContext): IOResult[(Map[String, GlobalParameter], List[(Set[NodeId], ParentProperty.Target)])] = {
+    // the qc does the tenant filtering, and policy servers are cached in the repository
+    nodeFactRepository.getNodeAndServerIds().map { ids =>
+      val split = params.toList.map { p =>
+        p.scope match {
+          case None    => Left((p.name, p))
+          case Some(t) => Right((groups.getNodeIds(Set(t), ids), ParentProperty.Target(t, p, None)))
+        }
+      }
+      (split.collect { case Left(x) => x }.toMap, split.collect { case Right(x) => x })
+    }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -561,6 +561,12 @@ class LDAPDiffMapper(
                         Some(SimpleDiff(Some(oldParam.visibility), Visibility.withNameInsensitiveEither(value).toOption))
                       )
                     }
+                  case A_PARAMETER_SCOPE   =>
+                    nonNull(diff, mod.getAttribute().getValue) { (d, value) =>
+                      // kept as the serialized target: the diff is only there to be displayed and
+                      // to trigger a deployment
+                      d.copy(modScope = Some(SimpleDiff(oldParam.scope.map(_.target), Some(value))))
+                    }
                   case "overridable"       => diff // ignore, it's for cleaning
                   case A_SECURITY_TAG      =>
                     updateSecurityTag(diff, mod.getAttribute.getValue) { (d, t) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -1158,8 +1158,22 @@ class LDAPEntityMapper(
                           }
                       }
         security    = e(A_SECURITY_TAG).flatMap(_.fromJson[SecurityTag].toOption)
+        // an unparsable scope is an error, never "no scope": that would silently distribute the
+        // parameter to the whole fleet (ADR 29409)
+        scope      <- e(A_PARAMETER_SCOPE) match {
+                        case None    => Right(None)
+                        case Some(t) =>
+                          RuleTarget
+                            .unser(t)
+                            .map(Some(_))
+                            .left
+                            .map(err => {
+                              InventoryMappingRudderError
+                                .UnexpectedObject(s"Parameter '${name}' has an unparsable scope '${t}': ${err.fullMsg}")
+                            })
+                      }
       } yield {
-        GlobalParameter(name, rev, parsed, mode, description, provider, visibility, security)
+        GlobalParameter(name, rev, parsed, mode, description, provider, visibility, security, scope)
       }
     } else {
       Left(
@@ -1180,6 +1194,7 @@ class LDAPEntityMapper(
     parameter.inheritMode.foreach(m => entry.resetValuesTo(A_INHERIT_MODE, m.value))
     entry.resetValuesTo(A_VISIBILITY, parameter.visibility.entryName)
     parameter.security.foreach(t => entry.resetValuesTo(A_SECURITY_TAG, t.toJson))
+    parameter.scope.foreach(t => entry.resetValuesTo(A_PARAMETER_SCOPE, t.target))
 
     entry
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -319,6 +319,9 @@ class GlobalParameterSerialisationImpl(xmlVersion: String) extends GlobalParamet
       ++ { param.inheritMode.map(m => <inheritMode>{m.value}</inheritMode>).getOrElse(NodeSeq.Empty) } ++
       <description>{param.description}</description>
       ++ { param.provider.map(p => <provider>{p.value}</provider>).getOrElse(NodeSeq.Empty) }
+      // the scope must survive an archive round-trip: losing it would silently widen the
+      // parameter back to the whole fleet (ADR 29409)
+      ++ { param.scope.map(t => <scope>{t.target}</scope>).getOrElse(NodeSeq.Empty) }
       ++ { SecurityXml.toXml(param) }
     )
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -785,8 +785,13 @@ class GlobalParameterUnserialisationImpl extends GlobalParameterUnserialisation 
                        .flatMap(x => Visibility.withNameInsensitiveOption(x.text))
                        .getOrElse(Visibility.default)
       security     = SecurityXml.getSecurity(entry)
+      scope       <- (globalParam \ "scope").headOption match {
+                       case None    => Right(None)
+                       case Some(x) => RuleTarget.unser(x.text).map(Some(_))
+                     }
       // TODO: no version in param for now
-      g           <- GlobalParameter.parse(name, GitVersion.DEFAULT_REV, value, mode, description, provider, visibility, security)
+      g           <-
+        GlobalParameter.parse(name, GitVersion.DEFAULT_REV, value, mode, description, provider, visibility, security, scope)
     } yield {
       g // TODO: no version in param for now
     }).chainError(s"${entryType} unserialisation failed")

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-1-rudder.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-1-rudder.ldif
@@ -322,6 +322,12 @@ attributeTypes: ( 1.3.6.1.4.1.35061.2.1.356
   EQUALITY caseExactMatch
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.359
+  NAME 'parameterScope'
+  DESC 'serialized rule target restricting the nodes a parameter is distributed to'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 attributeTypes: ( 1.3.6.1.4.1.35061.2.1.357
   NAME 'inheritMode'
   DESC 'inherit mode of a property or parameter'
@@ -463,7 +469,7 @@ objectClasses: ( 1.3.6.1.4.1.35061.2.2.120
   SUP top
   STRUCTURAL
   MUST ( parameterName )
-  MAY ( parameterValue $ description $ propertyProvider $ securityTag $ visibility $ inheritMode $ revision) )
+  MAY ( parameterValue $ description $ propertyProvider $ securityTag $ visibility $ inheritMode $ revision $ parameterScope) )
 #
 # Application properties
 #

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.apidata.RenderInheritedProperties
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.FullGroupTarget
 import com.normation.rudder.domain.policies.GroupTarget
+import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.properties.FailedNodePropertyHierarchy
 import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.domain.properties.GlobalParameter
@@ -69,6 +70,7 @@ import com.normation.rudder.domain.queries.ResultTransformation.*
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.properties.GroupProp.*
 import com.normation.rudder.properties.MergeNodeProperties
+import com.normation.rudder.properties.NodeScopedParameters
 import com.normation.rudder.services.policies.NodeConfigData
 import com.softwaremill.quicklens.*
 import com.typesafe.config.ConfigValue
@@ -121,6 +123,7 @@ class TestMergeGroupProperties extends Specification {
       def recAppendParent(prop: VertexParentProperty[?]): VertexParentProperty[?] = {
         prop match {
           case global: ParentProperty.Global => global
+          case target: ParentProperty.Target => target
           case group:  ParentProperty.Group  =>
             group.parentProperty match {
               case None        => group.copy(parentProperty = Some(ParentProperty.Global(globalParam)))
@@ -131,6 +134,7 @@ class TestMergeGroupProperties extends Specification {
       def recAppend(prop: ParentProperty[?]):             ParentProperty[?]       = {
         prop match {
           case global: ParentProperty.Global => global
+          case target: ParentProperty.Target => target
           case group:  ParentProperty.Group  =>
             group.parentProperty match {
               case None        => group.copy(parentProperty = Some(ParentProperty.Global(globalParam)))
@@ -516,6 +520,111 @@ class TestMergeGroupProperties extends Specification {
       .checkPropertyMerge(Map.empty, Map("foo" -> g.toGP("foo", None)))
       .map(_.map(n => NodePropertyHierarchy(nodeId1, n)))
     merged must beRight(List(g.toG("foo", None, nodeId1)))
+  }
+
+  /*
+   * Scoped global parameters (ADR 29409): a global parameter restricted to a target sits
+   * between the global level and the groups.
+   */
+  "scoped parameters" should {
+
+    val scope1 = GroupTarget(parent1.id)
+    val scope2 = GroupTarget(parent2.id)
+
+    def scoped(name: String, value: ConfigValue, target: RuleTarget, mode: Option[InheritMode] = None) =
+      ParentProperty.Target(target, value.toGP(name, mode).withScope(Some(target)), None)
+
+    "override the unscoped parameter of the same name" >> {
+      val merged = MergeNodeProperties
+        .checkPropertyMerge(
+          Map.empty,
+          Map("foo" -> "global".toConfigValue.toGP("foo", None)),
+          List(scoped("foo", "scoped".toConfigValue, scope1))
+        )
+      merged.toEither must beRight((l: List[VertexParentProperty[?]]) => {
+        (l.size must beEqualTo(1)) and
+        (l.head.resolvedValue.valueAsString must beEqualTo("scoped")) and
+        (l.head.kind.entryName must beEqualTo("target"))
+      })
+    }
+
+    "keep the unscoped parameter as the parent of the scoped one" >> {
+      val merged = MergeNodeProperties
+        .checkPropertyMerge(
+          Map.empty,
+          Map("foo" -> "global".toConfigValue.toGP("foo", None)),
+          List(scoped("foo", "scoped".toConfigValue, scope1))
+        )
+      merged.toEither must beRight((l: List[VertexParentProperty[?]]) => {
+        l.head must beLike { case t: ParentProperty.Target => t.parentProperty must beSome[VertexParentProperty[?]] }
+      })
+    }
+
+    // a node outside the scope simply gets no scoped parameter: the caller filters, and the
+    // engine then only sees the global one
+    "leave a node out of scope with the global value only" >> {
+      val merged = MergeNodeProperties
+        .checkPropertyMerge(Map.empty, Map("foo" -> "global".toConfigValue.toGP("foo", None)), Nil)
+      merged.toEither must beRight((l: List[VertexParentProperty[?]]) => {
+        (l.head.resolvedValue.valueAsString must beEqualTo("global")) and
+        (l.head.kind.entryName must beEqualTo("global"))
+      })
+    }
+
+    "be overridden by a group property" >> {
+      val merged = MergeNodeProperties
+        .checkPropertyMerge(
+          Map(parent1.id -> parent1.toGroupProp),
+          Map.empty,
+          List(scoped("foo", "scoped".toConfigValue, scope1))
+        )
+      // parent1 defines foo=bar1
+      merged.toEither must beRight((l: List[VertexParentProperty[?]]) => {
+        (l.head.resolvedValue.valueAsString must beEqualTo("bar1")) and
+        (l.head.kind.entryName must beEqualTo("group"))
+      })
+    }
+
+    // there is no "two scopes for one name" case to test: a global parameter's name is unique in
+    // storage (its LDAP RDN is the name), so a name carries at most one scope
+    "keep distinct names coming from distinct scopes" >> {
+      val merged = MergeNodeProperties.checkPropertyMerge(
+        Map.empty,
+        Map.empty,
+        List(scoped("foo", "a".toConfigValue, scope1), scoped("bar", "b".toConfigValue, scope2))
+      )
+      merged.toEither must beRight((l: List[VertexParentProperty[?]]) => l.size must beEqualTo(2))
+    }
+
+    /*
+     * A scope is the domain of definition of the *name*, not just a default value: a node outside
+     * the scope must not get that name from a group nor from itself. Otherwise a node excluded
+     * from a benchmark target still receives its configuration through an override.
+     */
+    def resolve(node: NodeFact, groups: List[NodeGroup], scoped: NodeScopedParameters) = {
+      MergeNodeProperties.forNode(node.toCore, groups.map(_.toTarget), Map.empty, scoped)
+    }
+
+    "drop a group override of a name scoped away from that node" >> {
+      // parent1 defines foo=bar1, and the node is not in foo's scope
+      val node     = NodeFact.fromCompat(nodeInfo.modify(_.node.properties).setTo(Nil), Left(AcceptedInventory), Seq(), None)
+      val resolved = resolve(node, List(parent1), NodeScopedParameters(Nil, Set("foo")))
+      resolved.resolved.exists(_.prop.name == "foo") must beFalse
+    }
+
+    "drop the node's own override of a name scoped away from that node" >> {
+      // nodeInfo carries its own `foo` property
+      val node     = NodeFact.fromCompat(nodeInfo, Left(AcceptedInventory), Seq(), None)
+      val resolved = resolve(node, Nil, NodeScopedParameters(Nil, Set("foo")))
+      resolved.resolved.exists(_.prop.name == "foo") must beFalse
+    }
+
+    "keep a group override for a node that is in scope" >> {
+      val node     = NodeFact.fromCompat(nodeInfo.modify(_.node.properties).setTo(Nil), Left(AcceptedInventory), Seq(), None)
+      val inScope  = NodeScopedParameters(List(scoped("foo", "scoped".toConfigValue, scope1)), Set.empty)
+      val resolved = resolve(node, List(parent1), inScope)
+      resolved.resolved.find(_.prop.name == "foo").map(_.prop.valueAsString) must beSome("bar1")
+    }
   }
 
   /*

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
@@ -87,10 +87,17 @@ type alias ParentNodeProperty =
     { id : String, name : String, valueType : String, parent : Maybe ParentProperty }
 
 
+{-| A global parameter restricted to a target: `id` is the serialized target (ADR 29409).
+-}
+type alias ParentTargetProperty =
+    { id : String, name : String, valueType : String, parent : Maybe ParentProperty }
+
+
 type ParentProperty
     = ParentGlobal ParentGlobalProperty
     | ParentGroup ParentGroupProperty
     | ParentNode ParentNodeProperty
+    | ParentTarget ParentTargetProperty
 
 
 type SortOrder
@@ -262,6 +269,18 @@ getPossibleFormatsFromPropertyName model propertyName =
 
                     else
                         parent
+
+                ParentTarget prop ->
+                    let
+                        parent =
+                            case prop.parent of
+                                Just par ->
+                                    getOtherHierarchyValueType par
+
+                                Nothing ->
+                                    []
+                    in
+                    prop.valueType :: parent
 
         mergedValueTypes =
             List.Extra.find (\p -> p.name == propertyName) model.properties

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/JsonDecoder.elm
@@ -82,6 +82,14 @@ decodeParentProperty =
                             |> optional "parent" (map Just decodeParentProperty) Nothing
                             |> map ParentNode
 
+                    "target" ->
+                        succeed ParentTargetProperty
+                            |> required "id" string
+                            |> required "name" string
+                            |> required "valueType" string
+                            |> optional "parent" (map Just decodeParentProperty) Nothing
+                            |> map ParentTarget
+
                     "global" ->
                         map ParentGlobalProperty
                             (field "valueType" string)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
@@ -162,6 +162,9 @@ getParentPropertyDisplay pp =
         ParentNode { id, name, valueType, parent } ->
             ("<span>Value of type: <strong>" ++ valueType ++ "</strong> in node " ++ "\"" ++ name ++ "\" with id <em>" ++ id ++ "</em></span>") :: (Maybe.withDefault [] <| Maybe.map getParentPropertyDisplay parent)
 
+        ParentTarget { id, name, valueType, parent } ->
+            ("<span>Value of type: <strong>" ++ valueType ++ "</strong> for global parameter " ++ "\"" ++ name ++ "\" scoped to <em>" ++ id ++ "</em></span>") :: (Maybe.withDefault [] <| Maybe.map getParentPropertyDisplay parent)
+
 
 getInheritedPropertyWarning : Property -> Html Msg
 getInheritedPropertyWarning property =

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
@@ -322,6 +322,12 @@ attributeTypes: ( 1.3.6.1.4.1.35061.2.1.356
   EQUALITY caseExactMatch
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.359
+  NAME 'parameterScope'
+  DESC 'serialized rule target restricting the nodes a parameter is distributed to'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 attributeTypes: ( 1.3.6.1.4.1.35061.2.1.357
   NAME 'inheritMode'
   DESC 'inherit mode of a property or parameter'
@@ -463,7 +469,7 @@ objectClasses: ( 1.3.6.1.4.1.35061.2.2.120
   SUP top
   STRUCTURAL
   MUST ( parameterName )
-  MAY ( parameterValue $ description $ propertyProvider $ securityTag $ visibility $ inheritMode $ revision) )
+  MAY ( parameterValue $ description $ propertyProvider $ securityTag $ visibility $ inheritMode $ revision $ parameterScope) )
 #
 # Application properties
 #


### PR DESCRIPTION
https://issues.rudder.io/issues/29409

Add a `scope` parameter to global properties so that they can be restricted to a given target. A scoped global property is thus only available on nodes that belong to the target, and not on all node. 

The ADR describes in details the chosen design, but in summary: 
- add a `Target` king of property in the merge algo, 
- for groups, it does change anything so that user 
- for a node, the merge is done and then we filter out any scoped properties is the node is not in the target. 



Note: a user which would override a scoped global property overridden on a group, if the node is not in the target, would not have the property after merge since it is filtered out. That's the desired behavior but could be surprising in the general case; 
For us and for now, it can't happen because only benchmark can use scoped global properties and the benchmark UI take care of that and benchmark properties are hidden. 