### PR TITLE
Fixes #29411: Restrict session tracking mode to cookie

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/WEB-INF/web.xml
@@ -43,6 +43,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <secure>true</secure>
     <comment>__SAME_SITE_LAX__</comment>
    </cookie-config>
+   <tracking-mode>COOKIE</tracking-mode>
   </session-config>
 
   <context-param>


### PR DESCRIPTION
https://issues.rudder.io/issues/29411

Prevent fallback to URL, as default is cookie or URL (https://runebook.dev/en/docs/spring_boot/application-properties/application-properties.server.server.servlet.session.tracking-modes for example)