### PR TITLE
Fixes #29413: Remove interpolation of $rudder.parameters in webapp and rudderc

### DIFF
--- a/policies/rudderc/src/compiler.rs
+++ b/policies/rudderc/src/compiler.rs
@@ -388,6 +388,11 @@ fn lint_expression(s: &str) -> Result<()> {
             warn!("Error parsing '{}': {:?}", s, e);
         }
         Ok(e) => {
+            // unlike the other lints, using a removed global parameter fails the compilation
+            if let Err(err) = e.check_no_global_parameter() {
+                error!("Error checking '{}': {:?}", s, err);
+                user_error()
+            }
             if let Err(e) = e.lint() {
                 error!("Error checking '{}': {:?}", s, e);
             }

--- a/policies/rudderc/src/ir/value.rs
+++ b/policies/rudderc/src/ir/value.rs
@@ -15,7 +15,7 @@
 
 use std::{cmp::Ordering, fmt::Debug, str::FromStr, sync::OnceLock};
 
-use anyhow::{Error, Result, bail};
+use anyhow::{Error, Result, anyhow, bail};
 use nom::{
     Finish, IResult, Parser,
     branch::alt,
@@ -83,8 +83,12 @@ pub enum Expression {
     NcfConst(Box<Expression>),
     /// `${node.inventory[os]}`
     NodeInventory(Vec<Expression>),
-    // FIXME deprecated in techniques (in favor of technique parameters)
     /// `${rudder.parameters[NAME]}`
+    ///
+    /// Removed: global parameters can not be used in techniques anymore, technique parameters must
+    /// be used instead. The variant is kept so that the parser still recognizes the syntax and can
+    /// report an actionable error (see `check_no_global_parameter`) instead of silently treating it
+    /// as an unknown generic variable.
     GlobalParameter(Box<Expression>),
     // FIXME deprecated in techniques (in favor of technique parameters)
     /// `${node.property[KEY][SUBKEY]}`
@@ -214,6 +218,44 @@ impl Expression {
             }
         }
     }
+    /// Global parameters were removed from techniques, in favor of technique parameters.
+    ///
+    /// Both the server-side `${rudder.parameters[NAME]}` and the agent-side
+    /// `${rudder_parameters.NAME}` string-template bundle are refused. Unlike `lint`, whose findings
+    /// are only logged, this one is a hard error: a technique using them does not compile anymore.
+    pub fn check_no_global_parameter(&self) -> Result<()> {
+        // agent-side bundle, unknown to the parser, so it lands in a generic var
+        const AGENT_BUNDLE_PREFIX: &str = "rudder_parameters.";
+
+        fn removed(syntax: &str) -> Error {
+            anyhow!(
+                "'{syntax}' is not supported anymore: global parameters can not be used in techniques, use a technique parameter instead"
+            )
+        }
+
+        match self {
+            Self::GlobalParameter(_) => return Err(removed("${rudder.parameters[...]}")),
+            Self::GenericVar(v) => {
+                if let Some(Self::Scalar(name)) = v.first()
+                    && name.starts_with(AGENT_BUNDLE_PREFIX)
+                {
+                    return Err(removed("${rudder_parameters....}"));
+                }
+                for e in v {
+                    e.check_no_global_parameter()?
+                }
+            }
+            Self::Sequence(v) | Self::NodeProperty(v) | Self::NodeInventory(v) | Self::Sys(v) => {
+                for e in v {
+                    e.check_no_global_parameter()?
+                }
+            }
+            Self::Const(e) | Self::NcfConst(e) => e.check_no_global_parameter()?,
+            Self::Scalar(_) | Self::Empty => (),
+        }
+        Ok(())
+    }
+
     /// Look for errors in the expression
     //
     // A lot of unwrapping as we rely on the structure of the `vars.yml` static document
@@ -1086,5 +1128,37 @@ vars.bundle.plouf
 
         let e = Expression::from_str("${node.inventory[machine][machineType]}").unwrap();
         assert!(e.lint().is_ok());
+    }
+
+    #[test]
+    fn it_refuses_removed_global_parameters() {
+        for s in [
+            "${rudder.parameters[foo]}",
+            "prefix ${rudder.parameters[foo]} suffix",
+            "${rudder_parameters.rudder_file_edit_header}",
+            "${node.properties[${rudder.parameters[foo]}]}",
+        ] {
+            let e = Expression::from_str(s).unwrap();
+            assert!(
+                e.check_no_global_parameter().is_err(),
+                "'{s}' must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn it_accepts_expressions_without_global_parameters() {
+        for s in [
+            "${node.properties[foo]}",
+            "${sys.host}",
+            "${my_technique_parameter}",
+            "plain value",
+        ] {
+            let e = Expression::from_str(s).unwrap();
+            assert!(
+                e.check_no_global_parameter().is_ok(),
+                "'{s}' must be accepted"
+            );
+        }
     }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -163,6 +163,10 @@ object PropertyProvider {
 /*
  * Visibility of a property.
  * A property can be hidden or displayed. When hidden, it is skipped from API/UI list of properties.
+ * A hidden *global parameter* is moreover not written in the node `rudder-parameters.json` file:
+ * such a parameter is an internal one (typically set by a plugin), and it is already distributed to
+ * the node as a node property, so writing it there again is pure duplication - and these values can
+ * be big.
  */
 sealed abstract class Visibility(override val entryName: String) extends EnumEntry
 object Visibility                                                extends Enum[Visibility] {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
@@ -51,7 +51,6 @@ import com.normation.rudder.services.policies.PropertyParser
 import com.normation.rudder.services.policies.PropertyParserTokens.CharSeq
 import com.normation.rudder.services.policies.PropertyParserTokens.NodeAccessor
 import com.normation.rudder.services.policies.PropertyParserTokens.NonRudderVar
-import com.normation.rudder.services.policies.PropertyParserTokens.Param
 import com.normation.rudder.services.policies.PropertyParserTokens.Property
 import com.normation.rudder.services.policies.PropertyParserTokens.RudderEngine
 import com.normation.rudder.services.policies.PropertyParserTokens.Token
@@ -317,10 +316,6 @@ object ParameterType {
           )
         case NodeAccessor(path)              =>
           validatedPath(path).as(mkDatastate("rudder" :: "node" :: path))
-        case Param(path)                     =>
-          validatedPath(path).as(
-            mkDatastate("rudder" :: "param" :: path)
-          ) // "param" : same as in InterpolatedValueCompilerImpl#translate
         case Property(
               path,
               _ // templating options can be ignored because template is already rendered statically with default value when necessary

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -77,12 +77,12 @@ import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.PolicyTypes
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.reports.NodeModeConfig
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.reports.ComplianceMode
 import com.normation.rudder.schedule.JsonDirectiveSchedule
 import com.normation.rudder.tenants.SecurityTag
-import com.typesafe.config.ConfigValue
 import java.time.Instant
 import scala.collection.immutable.TreeMap
 import zio.Chunk
@@ -144,18 +144,10 @@ object BundleOrder {
   }
 }
 
-sealed trait GenericInterpolationContext[PARAM] {
+sealed trait GenericInterpolationContext {
   def nodeInfo:         CoreNodeFact
   def policyServerInfo: CoreNodeFact
   def globalPolicyMode: GlobalPolicyMode
-  // parameters for this node
-  // must be a case SENSITIVE Map !!!!
-  def parameters:       Map[String, PARAM]
-  // the depth of the interpolation context evaluation
-  // used as a lazy, trivial, mostly broken way to detect cycle in interpretation
-  // for ex: param a => param b => param c => ..... => param a
-  // should not be evaluated
-  def depth:            Int
 }
 
 /**
@@ -166,16 +158,8 @@ sealed trait GenericInterpolationContext[PARAM] {
 final case class ParamInterpolationContext(
     nodeInfo:         CoreNodeFact,
     policyServerInfo: CoreNodeFact,
-    globalPolicyMode: GlobalPolicyMode,                                           // parameters for this node
-    // must be a case SENSITIVE Map !!!!
-
-    parameters:       Map[String, ParamInterpolationContext => IOResult[String]], // the depth of the interpolation context evaluation
-    // used as a lazy, trivial, mostly broken way to detect cycle in interpretation
-    // for ex: param a => param b => param c => ..... => param a
-    // should not be evaluated
-
-    depth:            Int = 0
-) extends GenericInterpolationContext[ParamInterpolationContext => IOResult[String]]
+    globalPolicyMode: GlobalPolicyMode
+) extends GenericInterpolationContext
 
 final case class InterpolationContext(
     nodeInfo:         CoreNodeFact,
@@ -184,14 +168,13 @@ final case class InterpolationContext(
     // environment variable for that server
     // must be a case insensitive Map !!!!
     nodeContext:      TreeMap[String, Variable],
-    // parameters for this node
+    // global parameters for that node, with their value expanded for it.
+    // They are NOT interpolable anymore (see PropertyParser#removedParameter): they are only kept
+    // here to be written down in the node `rudder-parameters.json` file.
+    // Can be removed along with the `rudder-parameters.json` in Rudder 10.0.
     // must be a case SENSITIVE Map !!!!
-    parameters:       Map[String, ConfigValue], // the depth of the interpolation context evaluation
-    // used as a lazy, trivial, mostly broken way to detect cycle in interpretation
-    // for ex: param a => param b => param c => ..... => param a
-    // should not be evaluated
-    depth:            Int
-) extends GenericInterpolationContext[ConfigValue]
+    parameters:       Map[String, GlobalParameter]
+) extends GenericInterpolationContext
 
 object InterpolationContext {
   implicit val caseInsensitiveString: Ordering[String] = new Ordering[String] {
@@ -201,33 +184,25 @@ object InterpolationContext {
   def apply(
       nodeInfo:         CoreNodeFact,
       policyServerInfo: CoreNodeFact,
-      globalPolicyMode: GlobalPolicyMode,         // environment variable for that server
+      globalPolicyMode: GlobalPolicyMode,      // environment variable for that server
       // must be a case insensitive Map !!!!
 
-      nodeContext:      Map[String, Variable],    // parameters for this node
+      nodeContext:      Map[String, Variable], // global parameters for that node
       // must be a case SENSITIVE Map !!!!
 
-      parameters:       Map[String, ConfigValue], // the depth of the interpolation context evaluation
-      // used as a lazy, trivial, mostly broken way to detect cycle in interpretation
-      // for ex: param a => param b => param c => ..... => param a
-      // should not be evaluated
-
-      depth:            Int = 0
-  ) = new InterpolationContext(nodeInfo, policyServerInfo, globalPolicyMode, TreeMap(nodeContext.toSeq*), parameters, depth)
+      parameters:       Map[String, GlobalParameter]
+  ) = new InterpolationContext(nodeInfo, policyServerInfo, globalPolicyMode, TreeMap(nodeContext.toSeq*), parameters)
 }
 
+/*
+ * A global parameter, as it is written down in the node `rudder-parameters.json` file.
+ * Visibility is kept because hidden parameters are not written in that file.
+ */
 final case class ParameterForConfiguration(
-    name:  String,
-    value: String
+    name:       String,
+    value:      String,
+    visibility: Visibility = Visibility.default
 )
-
-case object ParameterForConfiguration {
-  def fromParameter(param: GlobalParameter): ParameterForConfiguration = {
-    // here, we need to go back to a string for resolution of
-    // things like ${rudder.param[foo] | default = ... }
-    ParameterForConfiguration(param.name, param.valueAsString)
-  }
-}
 
 /**
  * A Parameter Entry has a Name and a Value, and can be freely used within the promises
@@ -353,6 +328,7 @@ object NodeConfiguration {
 
     given JsonEncoder[NodeRunHook.ReportOn]      = DeriveJsonEncoder.gen[NodeRunHook.ReportOn]
     given JsonEncoder[NodeRunHook]               = DeriveJsonEncoder.gen[NodeRunHook]
+    given JsonEncoder[Visibility]                = JsonEncoder[String].contramap(_.entryName)
     given JsonEncoder[ParameterForConfiguration] =
       DeriveJsonEncoder.gen[ParameterForConfiguration]
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -832,7 +832,8 @@ object BuildNodeConfiguration extends BuildNodeConfigurationService {
                               policies = policies,
                               nodeContext = context.nodeContext,
                               parameters = context.parameters.map {
-                                case (k, v) => ParameterForConfiguration(k, GenericProperty.serializeToHocon(v))
+                                case (k, v) =>
+                                  ParameterForConfiguration(k, GenericProperty.serializeToHocon(v.value), v.visibility)
                               }.toSet,
                               schedules = nodeSchedules
                             )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
@@ -37,17 +37,12 @@
 
 package com.normation.rudder.services.policies
 
-import com.normation.box.*
 import com.normation.errors.*
-import com.normation.inventory.domain.AgentType
 import com.normation.rudder.domain.policies.PolicyModeOverrides
 import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.services.nodes.EngineOption
 import com.normation.rudder.services.nodes.PropertyEngineService
 import com.normation.rudder.services.policies.PropertyParserTokens.*
-import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigValue
-import net.liftweb.common.*
 import zio.*
 import zio.syntax.*
 
@@ -64,21 +59,14 @@ import zio.syntax.*
  * ${rudder.xxx}
  * were "xxx" is the parameter to lookup.
  *
- * We handle 3 kinds of parameterizations:
- * 1/ ${rudder.param.XXX}
- *    where:
- *    - XXX is a parameter configured in Rudder
- *      (for now global, but support for node-contextualised is implemented)
- *    - XXX is case sensisite
- *    - XXX's value can contains other interpolation
- *
- * 2/ ${rudder.node.ACCESSOR}
+ * We handle 2 kinds of parameterizations:
+ * 1/ ${rudder.node.ACCESSOR}
  *    where:
  *    - "node" is a keyword ;
  *    - ACCESSOR is an accessor for that node, explained below.
  *    - the value can not contains other interpolation
  *
- * 3/ ${node.properties[keyone][keytwo]} or
+ * 2/ ${node.properties[keyone][keytwo]} or
  *   ${node.properties[keyone][keytwo] | node } or
  *    ${node.properties[keyone][keytwo] | default = XXXX }
  *
@@ -102,8 +90,11 @@ import zio.syntax.*
  * Accessor are keywords which allows to reach value in a context, exactly like
  * properties in object oriented programming.
  *
- * Accessors for parameters
- *    ${rudder.param.ACCESSOR} : replace by the value for the parameter with the name ACCESSOR
+ * Global parameters can not be interpolated anymore: `${rudder.param.NAME}` and
+ * `${rudder.parameters[NAME]}` were removed. A global parameter is a node property
+ * (it is set as a default value on each node), so `${node.properties[NAME]}` must be
+ * used instead - with the standard property inheritance semantic, ie a group or node
+ * override of that name wins.
  *
  * Accessors for node
  * ------------------
@@ -135,15 +126,6 @@ trait InterpolatedValueCompiler {
   def compile(value:      String): PureResult[InterpolationContext => IOResult[String]]
   def compileParam(value: String): PureResult[ParamInterpolationContext => IOResult[String]]
 
-  /**
-   *
-   * Parse a value to translate token to a valid value for the agent passed as parameter.
-   *
-   * Return a Box, where Full denotes a successful
-   * parsing of all values, and EmptyBox. an error.
-   */
-  def translateToAgent(value: String, agentType: AgentType): Box[String]
-
 }
 
 object PropertyParserTokens {
@@ -154,7 +136,7 @@ object PropertyParserTokens {
    * A token can be a plain string with no variable, or something
    * to interpolate. For now, we can interpolate two kind of variables:
    * - node information (thanks to a pointed path to the interesting property)
-   * - rudder parameters (only globals for now)
+   * - node properties
    */
   sealed trait Token extends Any // could be Either[CharSeq, Interpolation]
 
@@ -179,8 +161,6 @@ object PropertyParserTokens {
 
   // everything is expected to be lower case
   final case class NodeAccessor(path: List[String])                                                    extends AnyVal with Interpolation
-  // everything is expected to be lower case
-  final case class Param(path: List[String])                                                           extends AnyVal with Interpolation
   // here, we keep the case as it is given
   final case class Property(path: List[String], opt: Option[PropertyOption])                           extends Interpolation
   final case class RudderEngine(engine: String, method: List[String], opt: Option[List[EngineOption]]) extends Interpolation
@@ -204,30 +184,9 @@ trait AnalyseInterpolationWithPropertyService {
   }
 }
 
-trait AnalyseInterpolation[T, I <: GenericInterpolationContext[T]] {
+trait AnalyseInterpolation[I <: GenericInterpolationContext] {
 
   def expandWithPropertyEngine(engineName: String, nameSpace: List[String], opt: Option[List[EngineOption]]): IOResult[String]
-
-  /*
-   * Number of time we allows to recurse for interpolated variable
-   * evaluated to other interpolated variables.
-   *
-   * It allows to detect cycle by brut force, but may raise false
-   * positive too:
-   *
-   * Ex: two variable calling the other one:
-   * a => b => a => b => a STOP
-   *
-   * Ex: a false positive:
-   *
-   * a => b => c => d => e => f => ... => "42"
-   *
-   * This is not a very big limitation, as we are not building
-   * a programming language, and users can easily resolve
-   * the problem by just making smaller cycle.
-   *
-   */
-  val maxEvaluationDepth = 5
 
   /*
    * The funny part that for each token adds the interpretation of the token
@@ -257,7 +216,6 @@ trait AnalyseInterpolation[T, I <: GenericInterpolationContext[T]] {
       case v: NonRudderVar => s"$${${v.indexedPath}}".succeed
       case UnsafeRudderVar(s)    => s"$${${s}}".succeed
       case NodeAccessor(path)    => getNodeAccessorTarget(context, path).toIO
-      case Param(path)           => getRudderGlobalParam(context, path)
       case RudderEngine(e, m, o) => expandWithPropertyEngine(e, m, o)
       case Property(path, opt)   =>
         opt match {
@@ -282,11 +240,6 @@ trait AnalyseInterpolation[T, I <: GenericInterpolationContext[T]] {
         }
     }
   }
-
-  /**
-   * Retrieve the global parameter from the node context.
-   */
-  def getRudderGlobalParam(context: I, path: List[String]): IOResult[String]
 
   /**
    * Get the targeted accessed node information, checking that it exists.
@@ -356,97 +309,21 @@ trait AnalyseInterpolation[T, I <: GenericInterpolationContext[T]] {
 
 }
 
-class AnalyseParamInterpolation(p: PropertyEngineService)
-    extends AnalyseInterpolation[ParamInterpolationContext => IOResult[String], ParamInterpolationContext]
-    with AnalyseInterpolationWithPropertyService {
-
-  /**
-   * Retrieve the global parameter from the node context.
-   */
-  override def getRudderGlobalParam(context: ParamInterpolationContext, path: List[String]): IOResult[String] = {
-    val errmsg = s"Missing parameter '$${node.parameter[${path.mkString("][")}]}'"
-    path match {
-      // we should not reach that case since we enforce at leat one match of [...] in the parser
-      case Nil       => Unexpected(s"The syntax $${rudder.parameters} is invalid, only $${rudder.parameters[name]} is accepted").fail
-      case h :: tail =>
-        context.parameters.get(h) match {
-          case Some(value) =>
-            if (context.depth >= maxEvaluationDepth) {
-              Unexpected(
-                s"""Can not evaluted global parameter "${h}" because it uses an interpolation variable that depends upon """
-                + s"""other interpolated variables in a stack more than ${maxEvaluationDepth} in depth. We fear it's a circular dependancy."""
-              ).fail
-            } else {
-              // we need to check if we were looking for a string or a json value
-              for {
-                firtLevel <- value(context.copy(depth = context.depth + 1))
-                res       <- (tail match {
-                               case Nil     => Right(firtLevel)
-                               case subpath =>
-                                 val config = ConfigFactory.parseString(s"""{"x":${firtLevel}}""")
-                                 val path   = ("x" :: subpath).mkString(".")
-                                 if (config.hasPath(path)) {
-                                   Right(GenericProperty.serializeToHocon(config.getValue(path)))
-                                 } else {
-                                   Left(Inconsistency(errmsg))
-                                 }
-                             }).toIO
-              } yield {
-                res
-              }
-            }
-          case _           => Unexpected(errmsg).fail
-        }
-    }
-  }
-
-  override def propertyEngineService: PropertyEngineService = p
-}
-
-class AnalyseNodeInterpolation(p: PropertyEngineService)
-    extends AnalyseInterpolation[ConfigValue, InterpolationContext] with AnalyseInterpolationWithPropertyService {
-
-  /**
-   * Retrieve the global parameter from the node context.
-   */
-  def getRudderGlobalParam(context: InterpolationContext, path: List[String]): IOResult[String] = {
-    val errmsg = s"Missing parameter '$${node.parameter[${path.mkString("][")}]}'"
-    path match {
-      // we should not reach that case since we enforce at leat one match of [...] in the parser
-      case Nil       => Left(Unexpected(s"The syntax $${rudder.parameters} is invalid, only $${rudder.parameters[name]} is accepted"))
-      case h :: tail =>
-        context.parameters.get(h) match {
-          case None       => Left(Unexpected(errmsg))
-          case Some(json) =>
-            tail match {
-              case Nil     => Right(GenericProperty.serializeToHocon(json))
-              // here, we need to parse the value in json and try to find the asked path
-              case subpath =>
-                {
-                  val path   = (GenericProperty.VALUE :: subpath).mkString(".")
-                  val config = GenericProperty.valueToConfig(json)
-                  if (config.hasPath(path)) {
-                    Right(GenericProperty.serializeToHocon(config.getValue(path)))
-                  } else {
-                    Left(
-                      Unexpected(
-                        s"Can not find property at paht ${subpath.mkString(".")} in '${GenericProperty.serializeToHocon(json)}'"
-                      )
-                    )
-                  }
-                }.chainError(errmsg)
-            }
-        }
-    }
-  }.toIO
+/*
+ * Both interpolation contexts (the one used to expand global parameter values, and the one used
+ * for node-facing values) are analysed exactly the same way: the only thing an analyser needs is
+ * the property engine service.
+ */
+class AnalyseInterpolationImpl[I <: GenericInterpolationContext](p: PropertyEngineService)
+    extends AnalyseInterpolation[I] with AnalyseInterpolationWithPropertyService {
 
   override def propertyEngineService: PropertyEngineService = p
 }
 
 class InterpolatedValueCompilerImpl(p: PropertyEngineService) extends InterpolatedValueCompiler {
 
-  val analyseNode  = new AnalyseNodeInterpolation(p)
-  val analyseParam = new AnalyseParamInterpolation(p)
+  val analyseNode  = new AnalyseInterpolationImpl[InterpolationContext](p)
+  val analyseParam = new AnalyseInterpolationImpl[ParamInterpolationContext](p)
 
   /*
    * just call the parser on a value, and in case of successful parsing, interprete
@@ -460,41 +337,22 @@ class InterpolatedValueCompilerImpl(p: PropertyEngineService) extends Interpolat
     PropertyParser.parse(value).map(t => analyseParam.parseToken(t))
   }
 
-  def translateToAgent(value: String, agent: AgentType): Box[String] = {
-    PropertyParser.parse(value).map(_.map(translate(agent, _)).mkString("")).toBox
-  }
-
-  // Transform a token to its correct value for the agent passed as parameter
-  def translate(agent: AgentType, token: Token): String = {
-    token match {
-      case CharSeq(s)         => s
-      case NodeAccessor(path) => s"$${rudder.node.${path.mkString(".")}}"
-      case v: NonRudderVar => s"$${${v.indexedPath}}"
-      case UnsafeRudderVar(s)    => s"$${${s}}"
-      case Param(name)           => s"$${rudder.param.${name}}" // FIXME: is this a bug ? name is a List[String]
-      case RudderEngine(e, m, o) =>
-        val opt = o match {
-          case Some(options) => options.map(o => s"| ${o.name} = ${o.value}").mkString(" ")
-          case None          => ""
-        }
-        // should not happen since a non expanded engine property should lead to an error
-        s"[missing value for: $${data.${e}[${m.mkString("][")}] ${opt}]"
-      case Property(path, opt)   =>
-        agent match {
-          case AgentType.Dsc          =>
-            s"$$($$node.properties[${path.mkString("][")}])"
-          case AgentType.CfeCommunity =>
-            s"$${node.properties[${path.mkString("][")}]}"
-        }
-    }
-  }
-
 }
 
 object PropertyParser {
 
   import fastparse.*
   import fastparse.NoWhitespace.*
+
+  /*
+   * Global parameters are not interpolable anymore, see `removedParameter`. A global parameter is
+   * set as a default property on each node, so `${node.properties[NAME]}` is the replacement -
+   * with the standard inheritance semantic, ie a group or node override of that name wins.
+   */
+  val removedParameterMessage: String = {
+    "global parameter interpolation was removed: use ${node.properties[NAME]} instead of " +
+    "${rudder.param.NAME} or ${rudder.parameters[NAME]}"
+  }
 
   def parse(value: String): PureResult[List[Token]] = {
     fastparse.parse(value, { case given P[?] => all }) match {
@@ -564,7 +422,7 @@ object PropertyParser {
   // an interpolated variable looks like: ${rudder.XXX}, or ${RuDder.xXx}
   // after "${rudder." there is no backtracking to an "otherProp" or string possible.
   def rudderVariable[A: P]: P[Interpolation] = P(
-    IgnoreCase("rudder") ~ space ~ "." ~ space ~/ (rudderNode | parameters | oldParameter)
+    IgnoreCase("rudder") ~ space ~ "." ~ space ~/ (rudderNode | removedParameter)
   )
 
   def rudderEngine[A: P]: P[Interpolation] = P(
@@ -584,13 +442,16 @@ object PropertyParser {
     case (name, methods, opt) => RudderEngine(name, methods, opt)
   }
 
-  // a parameter old syntax looks like: ${rudder.param.PARAM_NAME}
-  def oldParameter[A: P]: P[Interpolation] = P(IgnoreCase("param") ~ space ~ "." ~/ space ~/ variableId).map { p =>
-    Param(p :: Nil)
-  }
-
-  // a parameter new syntax looks like: ${rudder.parameters[PARAM_NAME][SUB_NAME]}
-  def parameters[A: P]: P[Interpolation] = P(IgnoreCase("parameters") ~/ arrayNames()).map(p => Param(p))
+  /*
+   * Global parameter interpolation was removed: both the old syntax `${rudder.param.PARAM_NAME}`
+   * and the new one `${rudder.parameters[PARAM_NAME][SUB_NAME]}` are now parsing errors.
+   * We still match them explicitly (instead of just dropping the rules) so that the user gets an
+   * actionable message telling what to use instead, and not a bare "expected one of ..." trace.
+   */
+  def removedParameter[A: P]: P[Interpolation] = P(
+    (IgnoreCase("parameters") ~ space ~ "[" | IgnoreCase("param") ~ space ~ ".") ~/
+    Fail(PropertyParser.removedParameterMessage)
+  )
 
   // a node property looks like: ${node.properties[.... Cut after "properties".
   def nodeProperty[A: P]: P[Interpolation] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/NodeContextBuilder.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/NodeContextBuilder.scala
@@ -140,16 +140,9 @@ class NodeContextBuilderImpl(
   ): IOResult[NodesContextResult] = {
 
     /*
-     * parameters have to be taken apart:
-     *
-     * - they can be overridden by node - not handled here, it will be in the resolution of node
-     *   when implemented. Most likely, we will have the information in the node info. And
-     *   in that case, we could just use an interpolation variable
-     *
-     * - they can be plain string => nothing to do
-     * - they can contains interpolated strings:
-     *   - to node info parameters: ok
-     *   - to parameters : hello loops!
+     * A global parameter value can still be interpolated (`${rudder.node.x}`,
+     * `${node.properties[x]}`, property engines), but it can not reference an other global
+     * parameter anymore, so there is no cycle to fear here.
      */
     def buildParams(
         parameters: List[GlobalParameter]
@@ -178,12 +171,7 @@ class NodeContextBuilderImpl(
               Box(
                 nodeFacts.get(info.rudderSettings.policyServerId)
               ) ?~! s"Policy server '${info.rudderSettings.policyServerId.value}' of Node '${nodeId.value}' was not found"
-            context            = ParamInterpolationContext(
-                                   info,
-                                   policyServer,
-                                   globalPolicyMode,
-                                   parameters.map { case (p, i) => (p.name, i) }
-                                 )
+            context            = ParamInterpolationContext(info, policyServer, globalPolicyMode)
             nodeParam         <- ZIO
                                    .foreach(parameters.toList) {
                                      case (param, interpol) =>
@@ -221,7 +209,7 @@ class NodeContextBuilderImpl(
                                    policyServer,
                                    globalPolicyMode,
                                    nodeContextBefore,
-                                   nodeParam.map { case (k, g) => (k, g.value) }.toMap
+                                   nodeParam.toMap
                                  )
             _                  = { timeNanoMergeProp = timeNanoMergeProp + System.nanoTime - timeMerge }
             propsCompiled     <- ZIO
@@ -261,7 +249,7 @@ class NodeContextBuilderImpl(
                 policyServer,
                 globalPolicyMode,
                 nodeContext,
-                nodeParam.map { case (k, g) => (k, g.value) }.toMap
+                nodeParam.toMap
               )
             )
           }) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.domain.logger.PolicyGenerationLoggerPure
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyTypeName
 import com.normation.rudder.domain.properties.NodeProperty
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.hooks.HookEnvPairs
@@ -320,8 +321,12 @@ class PolicyWriterServiceImpl(
     }
 
     val file             = File(agentNodeConfig.paths.newFolder, Constants.GENERATED_PARAMETER_FILE)
+    // hidden parameters are not written in that file: they are only used internally (typically by
+    // plugins) and are already distributed to the node as node properties, no need to duplicate them.
     val jsonParameters   = generateParametersJson(
-      agentNodeConfig.config.parameters.map(x => ParameterEntry(x.name, x.value, agentNodeConfig.agentInfo.agentType))
+      agentNodeConfig.config.parameters
+        .filter(_.visibility == Visibility.Displayed)
+        .map(x => ParameterEntry(x.name, x.value, agentNodeConfig.agentInfo.agentType))
     )
     val parameterContent = jsonParameters.toJsonPretty
 

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/common/1.0/rudder-parameters.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/common/1.0/rudder-parameters.cf
@@ -10,6 +10,7 @@ bundle common rudder_parameters {
   vars:
    "rudder_file_edit_header" string => "### Managed by Rudder, edit with care ###";
    "ntpserver" string => "pool.\"ntp\".org";
+   "hiddenParam" string => "hiddenParamValue";
 
 }
 

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/common/1.0/rudder-parameters.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/common/1.0/rudder-parameters.cf
@@ -10,6 +10,7 @@ bundle common rudder_parameters {
   vars:
    "rudder_file_edit_header" string => "### Managed by Rudder, edit with care ###";
    "ntpserver" string => "pool.\"ntp\".org";
+   "hiddenParam" string => "hiddenParamValue";
 
 }
 

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/clockConfiguration/3.0/clockConfiguration.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/clockConfiguration/3.0/clockConfiguration.cf
@@ -28,7 +28,7 @@ bundle agent check_clock_configuration
 {
 
   vars:
-      "ntpServers" slist => { "${rudder.param.ntpserver}"};
+      "ntpServers" slist => { "${node.properties[ntpserver]}"};
 
     windows::
       # For windows, we must extract both ip and domain name values

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/common/1.0/rudder-parameters.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/common/1.0/rudder-parameters.cf
@@ -10,6 +10,7 @@ bundle common rudder_parameters {
   vars:
    "rudder_file_edit_header" string => "### Managed by Rudder, edit with care ###";
    "ntpserver" string => "pool.\"ntp\".org";
+   "hiddenParam" string => "hiddenParamValue";
 
 }
 

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/clockConfiguration/3.0/clockConfiguration.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/clockConfiguration/3.0/clockConfiguration.cf
@@ -28,7 +28,7 @@ bundle agent check_clock_configuration
 {
 
   vars:
-      "ntpServers" slist => { "${rudder.param.ntpserver}"};
+      "ntpServers" slist => { "${node.properties[ntpserver]}"};
 
     windows::
       # For windows, we must extract both ip and domain name values

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -680,7 +680,7 @@ class MockDirectives(mockTechniques: MockTechniques, mockTenants: MockTenants) {
       Map(
         ("CLOCK_FQDNNTP", Seq("true")),
         ("CLOCK_HWSYNC_ENABLE", Seq("true")),
-        ("CLOCK_NTPSERVERS", Seq("${rudder.param.ntpserver}")),
+        ("CLOCK_NTPSERVERS", Seq("${node.properties[ntpserver]}")),
         ("CLOCK_SYNCSCHED", Seq("240")),
         ("CLOCK_TIMEZONE", Seq("dontchange"))
       ),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechnique.scala
@@ -82,16 +82,10 @@ class TestEditorTechnique extends Specification {
               |'@)""".stripMargin
           )
         }
-        "with rudder parameter interpolation" in {
-          translate("foo ${rudder.parameters[foo]} bar") must beRight(
-            """(@'
-              |foo 
-              |'@ + ([Rudder.Datastate]::Render('{{{' + @'
-              |vars.rudder.param.foo
-              |'@ + '}}}')) + @'
-              | bar
-              |'@)""".stripMargin
-          )
+        "with a removed rudder parameter interpolation" in {
+          // global parameters are not interpolable anymore, whatever the syntax
+          (translate("foo ${rudder.parameters[foo]} bar") must beLeft) and
+          (translate("foo ${rudder.param.foo} bar") must beLeft)
         }
         "with property interpolation" in {
           translate("foo ${node.properties[foo]} bar") must beRight(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -1150,7 +1150,7 @@ class TestNodeConfiguration(
       List(
         ("CLOCK_FQDNNTP", Seq("")), // testing mandatory value with default "true"
         ("CLOCK_HWSYNC_ENABLE", Seq("true")),
-        ("CLOCK_NTPSERVERS", Seq("${rudder.param.ntpserver}")),
+        ("CLOCK_NTPSERVERS", Seq("${node.properties[ntpserver]}")),
         ("CLOCK_SYNCSCHED", Seq("240")),
         ("CLOCK_TIMEZONE", Seq("dontchange"))
       )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
@@ -49,7 +49,6 @@ import com.normation.rudder.services.nodes.RudderPropertyEngine
 import com.normation.rudder.services.policies.fetchinfo.NodeContextBuilderImpl
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
-import com.typesafe.config.ConfigValue
 import net.liftweb.common.*
 import org.junit.runner.RunWith
 import org.specs2.matcher.Expectable
@@ -119,19 +118,19 @@ class TestNodeAndGlobalParameterLookup extends Specification {
   val buildContext  = new NodeContextBuilderImpl(compiler, data.systemVariableService)
 
   val context: ParamInterpolationContext = ParamInterpolationContext(
-    parameters = Map(),
     globalPolicyMode = defaultModesConfig.globalPolicyMode,
     nodeInfo = fact1,
     policyServerInfo = factRoot
   )
 
-  def toNodeContext(c: ParamInterpolationContext, params: Map[String, ConfigValue]): InterpolationContext = InterpolationContext(
-    parameters = params,
+  def toNodeContext(c: ParamInterpolationContext): InterpolationContext = InterpolationContext(
     nodeInfo = c.nodeInfo,
     globalPolicyMode = c.globalPolicyMode,
     policyServerInfo = c.policyServerInfo, // environment variable for that server
 
-    nodeContext = Map()
+    nodeContext = Map(),
+    // global parameters are not interpolable anymore, so they play no role in these tests
+    parameters = Map()
   )
 
   def lookup(
@@ -148,38 +147,19 @@ class TestNodeAndGlobalParameterLookup extends Specification {
       variables:   Seq[Variable],
       lookupParam: ParamInterpolationContext
   ): ZIO[Any, RudderError, Map[ComponentId, Variable]] = {
-    (for {
-      params <- ZIO.foreach(lookupParam.parameters.toList) { case (k, c) => c(lookupParam).map((k, _)) }
-      p      <- ZIO.foreach(params.toList) { case (k, value) => GenericProperty.parseValue(value).map(v => (k, v)).toIO }
-      res    <- lookupService.lookupNodeParameterization(variables.map(v => (ComponentId(v.spec.name, Nil, v.spec.id), v)).toMap)(
-                  toNodeContext(lookupParam, p.toMap)
-                )
-    } yield res)
+    lookupService.lookupNodeParameterization(variables.map(v => (ComponentId(v.spec.name, Nil, v.spec.id), v)).toMap)(
+      toNodeContext(lookupParam)
+    )
   }
 
   def jparse(s: String): Json = s.fromJson[Json].getOrElse(Str(s))
 
-  // two variables
-  val var1:              InputVariable = InputVariableSpec("var1", "", None, id = None).toVariable(Seq("== ${rudder.param.foo} =="))
-  val var1_double:       InputVariable =
-    InputVariableSpec("var1_double", "", None, id = None).toVariable(Seq("== ${rudder.param.foo}${rudder.param.bar} =="))
-  val var1_double_space: InputVariable = InputVariableSpec("var1_double_space", "", None, id = None).toVariable(
-    Seq("== ${rudder.param.foo} contains ${rudder.param.bar} ==")
-  )
+  // global parameter interpolation was removed, both syntaxes must now be refused
+  val oldSyntaxVariable: InputVariable =
+    InputVariableSpec("oldSyntax", "", None, id = None).toVariable(Seq("== ${rudder.param.foo} =="))
+  val newSyntaxVariable: InputVariable =
+    InputVariableSpec("newSyntax", "", None, id = None).toVariable(Seq("== ${rudder.parameters[foo]} =="))
 
-  val pathCaseInsensitive: InputVariable =
-    InputVariableSpec("pathCaseInsensitive", "", None, id = None).toVariable(Seq("== ${RudDer.paRam.foo} =="))
-
-  val paramNameCaseSensitive: InputVariable =
-    InputVariableSpec("paramNameCaseSensitive", "", None, id = None).toVariable(Seq("== ${rudder.param.Foo} =="))
-
-  val recurVariable: InputVariable =
-    InputVariableSpec("recurParam", "", None, id = None).toVariable(Seq("== ${rudder.param.recurToFoo} =="))
-
-  val dangerVariable: InputVariable = InputVariableSpec("danger", "", None, id = None).toVariable(Seq("${rudder.param.danger}"))
-
-  val multilineInputVariable:    InputVariable =
-    InputVariableSpec("multiInput", "", None, id = None).toVariable(Seq("=\r= \n${rudder.param.foo} =\n="))
   val multilineNodePropVariable: InputVariable =
     InputVariableSpec("multiNodeProp", "", None, id = None).toVariable(Seq("=\r= \n${node.properties[datacenter][Europe]} =\n="))
 
@@ -195,31 +175,7 @@ class TestNodeAndGlobalParameterLookup extends Specification {
   )
 
   val badEmptyRudder: InputVariable = InputVariableSpec("empty", "", None, id = None).toVariable(Seq("== ${rudder.} =="))
-  val badUnclosed:    InputVariable = InputVariableSpec("empty", "", None, id = None).toVariable(Seq("== ${rudder.param.foo =="))
   val badUnknown:     InputVariable = InputVariableSpec("empty", "", None, id = None).toVariable(Seq("== ${rudder.foo} =="))
-
-  val fooParam:   ParameterForConfiguration = ParameterForConfiguration("foo", "fooValue")
-  val barParam:   ParameterForConfiguration = ParameterForConfiguration("bar", "barValue")
-  val recurParam: ParameterForConfiguration = ParameterForConfiguration("recurToFoo", """${rudder.param.foo}""")
-
-  val badChars = """$¹ ${plop[]} (foo) \$ @ %plop & \\ | $[xas]^"""
-  val dangerousChars: ParameterForConfiguration = ParameterForConfiguration("danger", badChars)
-
-  def p(params: ParameterForConfiguration*): Map[String, ParamInterpolationContext => IOResult[String]] = {
-    import cats.implicits.*
-    params.toList.traverse { param =>
-      for {
-        p <- compiler
-               .compileParam(param.value)
-               .chainError(s"Error when looking for interpolation variable in global parameter '${param.name}'")
-      } yield {
-        (param.name, p)
-      }
-    }.map(seq => Map(seq*)).chainError("Error when parsing parameters for interpolated variables") match {
-      case Left(err)  => throw new RuntimeException(err.fullMsg)
-      case Right(res) => res
-    }
-  }
 
   import com.normation.rudder.services.policies.PropertyParser.*
   import com.normation.rudder.services.policies.PropertyParserTokens.*
@@ -230,6 +186,14 @@ class TestNodeAndGlobalParameterLookup extends Specification {
     fastparse.parse(value, p(_)) match {
       case Parsed.Success(x, index) => x === result
       case f: Parsed.Failure => ko(f.trace().longAggregateMsg)
+    }
+  }
+
+  // the value must not parse, and the failure must tell what to use instead
+  def testRemovedParameter[T](p: P[?] => P[T], value: String): MatchResult[Any] = {
+    fastparse.parse(value, p(_)) match {
+      case Parsed.Success(x, index) => ko(s"'${value}' must not parse anymore, but it gave: ${x}")
+      case f: Parsed.Failure => f.trace().longAggregateMsg must contain(PropertyParser.removedParameterMessage)
     }
   }
 
@@ -248,12 +212,12 @@ class TestNodeAndGlobalParameterLookup extends Specification {
       test({ case given P[?] => noVariableStart }, s, CharSeq(s))
     }
 
-    "parse a rudder param variable with old syntax" in {
-      test({ case given P[?] => variable }, """${rudder.param.foo}""", Param("foo" :: Nil))
+    "refuse a rudder param variable with old syntax" in {
+      testRemovedParameter({ case given P[?] => variable }, """${rudder.param.foo}""")
     }
 
-    "parse a rudder param variable with spaces with old syntax" in {
-      test({ case given P[?] => variable }, """${rudder . param . foo}""", Param("foo" :: Nil))
+    "refuse a rudder param variable with spaces with old syntax" in {
+      testRemovedParameter({ case given P[?] => variable }, """${rudder . param . foo}""")
     }
 
     "parse a rudder node variable" in {
@@ -264,16 +228,16 @@ class TestNodeAndGlobalParameterLookup extends Specification {
       test({ case given P[?] => variable }, """${rudder . node . foo . bar . baz}""", NodeAccessor(List("foo", "bar", "baz")))
     }
 
-    "parse a rudder param variable with all parser with old syntax" in {
-      test({ case given P[?] => all }, """${rudder.param.foo}""", List(Param("foo" :: Nil)))
+    "refuse a rudder param variable with all parser with old syntax" in {
+      testRemovedParameter({ case given P[?] => all }, """${rudder.param.foo}""")
     }
 
-    "parse a rudder param variable with new syntax" in {
-      test({ case given P[?] => all }, """${rudder.parameters[foo][bar]}""", List(Param("foo" :: "bar" :: Nil)))
+    "refuse a rudder param variable with new syntax" in {
+      testRemovedParameter({ case given P[?] => all }, """${rudder.parameters[foo][bar]}""")
     }
 
-    "parse a rudder param variable with all parser with spaces" in {
-      test({ case given P[?] => all }, """${rudder . param . foo}""", List(Param("foo" :: Nil)))
+    "refuse a rudder param variable with all parser with spaces" in {
+      testRemovedParameter({ case given P[?] => all }, """${rudder . param . foo}""")
     }
 
     "parse a non rudder param variable with all parser" in {
@@ -607,17 +571,9 @@ class TestNodeAndGlobalParameterLookup extends Specification {
       )
     }
 
-    "parse node properties 'default:param' option" in {
+    "refuse node properties 'default:param' option" in {
       val s = """some text and ${node.properties[datacenter][Europe]|default=${rudder.param.foo}}  and some more text"""
-      test(
-        { case given P[?] => all },
-        s,
-        List(
-          CharSeq("some text and "),
-          Property("datacenter" :: "Europe" :: Nil, Some(DefaultValue(Param("foo" :: Nil) :: Nil))),
-          CharSeq("  and some more text")
-        )
-      )
+      testRemovedParameter({ case given P[?] => all }, s)
     }
 
     "parse node properties 'default:node.hostname' option" in {
@@ -810,117 +766,29 @@ class TestNodeAndGlobalParameterLookup extends Specification {
       }
     }
 
-    "correctly interpret simple param with old syntax" in {
-      val res = "p1 replaced"
-      val i   = compileAndGet("${rudder.param.p1}")
-      val c   = context.copy(parameters = {
-        Map(
-          ("p1", (i: ParamInterpolationContext) => res.succeed)
-        )
-      })
-      i(c).either.runNow must beEqualTo(Right(res))
+    "refuse to compile a global parameter, whatever the syntax" in {
+      val values = List(
+        "${rudder.param.p1}",
+        "${rudder.parameters[p1]}",
+        "${rudder.parameters[p1][p2]}",
+        "${RudDer.paRam.p1}"
+      )
+      values.map { value =>
+        compiler.compileParam(value) match {
+          case Right(_)  => ko(s"'${value}' must not compile anymore")
+          case Left(err) => err.fullMsg must contain(PropertyParser.removedParameterMessage)
+        }
+      }.reduce(_ and _)
     }
 
-    "correctly interpret simple param with new syntax on string" in {
-      val res = "p1 replaced"
-      val i   = compileAndGet("${rudder.parameters[p1]}")
-      val c   = context.copy(parameters = {
-        Map(
-          ("p1", (i: ParamInterpolationContext) => res.succeed)
-        )
-      })
-      i(c).either.runNow must beEqualTo(Right(res))
-    }
-
-    "correctly interpret simple param with new syntax on json" in {
-      val res  = "p1 replaced"
-      val json = s"""{"p2": "${res}"}"""
-      val i    = compileAndGet("${rudder.parameters[p1][p2]}")
-      val c    = context.copy(parameters = {
-        Map(
-          ("p1", (i: ParamInterpolationContext) => json.succeed)
-        )
-      })
-      i(c).either.runNow must beEqualTo(Right(res))
-    }
-
-    "fails on missing param in context" in {
-      val i = compileAndGet("${rudder.param.p1}")
-      i(context).either.runNow match {
-        case Right(_) => ko("The parameter should not have been found")
-        case Left(_)  => ok
+    // a global parameter value can still use the other interpolations, it just can not
+    // reference an other global parameter anymore
+    "still interpolate node information in a global parameter value" in {
+      val i = compiler.compileParam("${rudder.node.hostname}") match {
+        case Left(err) => throw new RuntimeException(err.fullMsg)
+        case Right(i)  => i
       }
-    }
-
-    "correcly replace parameter with interpolated values" in {
-      val res     = "p1 replaced with p2 value"
-      val i       = compileAndGet("${rudder.param.p1}")
-      val p1value = compileAndGet("${rudder.param.p2}")
-      val c       = context.copy(parameters = {
-        Map(
-          ("p1", p1value),
-          ("p2", (i: ParamInterpolationContext) => res.succeed)
-        )
-      })
-      i(c).either.runNow must beEqualTo(Right(res))
-    }
-
-    "correctly replace maxDepth-1 parameter with interpolated values" in {
-      val res          = "p1 replaced with p2 value"
-      val i            = compileAndGet("${rudder.param.p1}")
-      val p1value      = compileAndGet("${rudder.param.p2}")
-      val p2value      = compileAndGet("${rudder.param.p3}")
-      val p3value      = compileAndGet("${rudder.param.p4}")
-      val analyseParam = new AnalyseParamInterpolation(propertyEngineService)
-      val c            = context.copy(parameters = {
-        Map(
-          ("p1", p1value),
-          ("p2", p2value),
-          ("p3", p3value),
-          ("p4", (i: ParamInterpolationContext) => res.succeed)
-        )
-      })
-
-      (analyseParam.maxEvaluationDepth == 5) and
-      (i(c).either.runNow must beEqualTo(Right(res)))
-    }
-
-    "fails to replace maxDepth parameter with interpolated values" in {
-      val res          = "p1 replaced with p2 value"
-      val i            = compileAndGet("${rudder.param.p1}")
-      val p1value      = compileAndGet("${rudder.param.p2}")
-      val p2value      = compileAndGet("${rudder.param.p3}")
-      val p3value      = compileAndGet("${rudder.param.p4}")
-      val analyseParam = new AnalyseParamInterpolation(propertyEngineService)
-      val c            = context.copy(parameters = {
-        Map(
-          ("p1", p1value),
-          ("p2", p2value),
-          ("p3", p3value),
-          ("p4", p3value),
-          ("p5", (i: ParamInterpolationContext) => res.succeed)
-        )
-      })
-
-      (analyseParam.maxEvaluationDepth == 5) and
-      (i(c).either.runNow match {
-        case Right(_) => ko("Was expecting an error due to too deep evaluation")
-        case Left(_)  => ok
-      })
-    }
-
-    "fails to replace recurring parameter value" in {
-      val i = compileAndGet("${rudder.param.p1}")
-      val c = context.copy(parameters = {
-        Map(
-          ("p1", i)
-        )
-      })
-
-      i(c).either.runNow match {
-        case Right(_) => ko("Was expecting an error due to too deep evaluation")
-        case Left(_)  => ok
-      }
+      i(context).either.runNow must beEqualTo(Right("node1.localhost"))
     }
 
     // utility class to help run the IOResult
@@ -944,8 +812,8 @@ class TestNodeAndGlobalParameterLookup extends Specification {
       val before2 =
         """{"login":"admin", "password":"${rudder-data.fakeEncryptorEngineTesting[password_test] | option1 = foo | option2 = bar}"}"""
       val after   = """{"login":"admin", "password":"encrypted-string-test"}"""
-      (runParseJValue(parseJson(before), toNodeContext(context, Map())) must beEqualTo(parseJson(after))) and
-      (runParseJValue(parseJson(before2), toNodeContext(context, Map())) must beEqualTo(parseJson(after)))
+      (runParseJValue(parseJson(before), toNodeContext(context)) must beEqualTo(parseJson(after))) and
+      (runParseJValue(parseJson(before2), toNodeContext(context)) must beEqualTo(parseJson(after)))
     }
 
     "interpolate unknown engine in JSON must raise en error" in {
@@ -967,8 +835,8 @@ class TestNodeAndGlobalParameterLookup extends Specification {
           |}
           |""".stripMargin
       }
-      (buildContext.parseJValue(parseJson(before), toNodeContext(context, Map())).either.runNow must beLeft) and
-      (buildContext.parseJValue(parseJson(before2), toNodeContext(context, Map())).either.runNow must beLeft)
+      (buildContext.parseJValue(parseJson(before), toNodeContext(context)).either.runNow must beLeft) and
+      (buildContext.parseJValue(parseJson(before2), toNodeContext(context)).either.runNow must beLeft)
     }
 
     "interpolate engine in nested JSON object" in {
@@ -1000,8 +868,8 @@ class TestNodeAndGlobalParameterLookup extends Specification {
           |""".stripMargin
       }
 
-      (runParseJValue(parseJson(before), toNodeContext(context, Map())) must beEqualTo(parseJson(after))) and
-      (runParseJValue(parseJson(before2), toNodeContext(context, Map())) must beEqualTo(parseJson(after)))
+      (runParseJValue(parseJson(before), toNodeContext(context)) must beEqualTo(parseJson(after))) and
+      (runParseJValue(parseJson(before2), toNodeContext(context)) must beEqualTo(parseJson(after)))
     }
 
     "interpolate engine in JSON array" in {
@@ -1026,8 +894,8 @@ class TestNodeAndGlobalParameterLookup extends Specification {
           |}
           |""".stripMargin
       }
-      (runParseJValue(parseJson(before), toNodeContext(context, Map())) must beEqualTo(parseJson(after))) and
-      (runParseJValue(parseJson(before2), toNodeContext(context, Map())) must beEqualTo(parseJson(after)))
+      (runParseJValue(parseJson(before), toNodeContext(context)) must beEqualTo(parseJson(after))) and
+      (runParseJValue(parseJson(before2), toNodeContext(context)) must beEqualTo(parseJson(after)))
     }
 
     "interpolate engine in nested JSON array" in {
@@ -1076,8 +944,8 @@ class TestNodeAndGlobalParameterLookup extends Specification {
           |}
           |""".stripMargin
       }
-      (runParseJValue(parseJson(before), toNodeContext(context, Map())) must beEqualTo(parseJson(after))) and
-      (runParseJValue(parseJson(before2), toNodeContext(context, Map())) must beEqualTo(parseJson(after)))
+      (runParseJValue(parseJson(before), toNodeContext(context)) must beEqualTo(parseJson(after))) and
+      (runParseJValue(parseJson(before2), toNodeContext(context)) must beEqualTo(parseJson(after)))
     }
 
     "interpolate engine multiple time" in {
@@ -1147,33 +1015,21 @@ class TestNodeAndGlobalParameterLookup extends Specification {
           |""".stripMargin
       }
 
-      (runParseJValue(parseJson(before), toNodeContext(context, Map())) must beEqualTo(parseJson(after))) and
-      (runParseJValue(parseJson(before2), toNodeContext(context, Map())) must beEqualTo(parseJson(after)))
+      (runParseJValue(parseJson(before), toNodeContext(context)) must beEqualTo(parseJson(after))) and
+      (runParseJValue(parseJson(before2), toNodeContext(context)) must beEqualTo(parseJson(after)))
     }
   }
 
-  "A single parameter" should {
-    "be replaced by its value" in {
-      lookup(Seq(var1), context.copy(parameters = p(fooParam)))(values =>
-        values must containTheSameElementsAs(Seq(Seq("== fooValue ==")))
+  "A global parameter in a directive value" should {
+    "be refused with the old syntax" in {
+      getError(lookupParam(Seq(oldSyntaxVariable), context).either.runNow) must contain(
+        PropertyParser.removedParameterMessage
       )
     }
 
-    "understand if its value is a parameter" in {
-      lookup(Seq(recurVariable), context.copy(parameters = p(fooParam, recurParam)))(values =>
-        values must containTheSameElementsAs(Seq(Seq("== fooValue ==")))
-      )
-    }
-
-    "correctly escape regex special chars" in {
-      lookup(Seq(dangerVariable), context.copy(parameters = p(dangerousChars)))(values =>
-        values must containTheSameElementsAs(Seq(Seq(badChars)))
-      )
-    }
-
-    "match when inputs are on multiline" in {
-      lookup(Seq(multilineInputVariable), context.copy(parameters = p(fooParam)))(values =>
-        values must containTheSameElementsAs(Seq(Seq("=\r= \nfooValue =\n=")))
+    "be refused with the new syntax" in {
+      getError(lookupParam(Seq(newSyntaxVariable), context).either.runNow) must contain(
+        PropertyParser.removedParameterMessage
       )
     }
 
@@ -1187,43 +1043,21 @@ class TestNodeAndGlobalParameterLookup extends Specification {
       val c = context
         .modify(_.nodeInfo.properties)
         .setTo(Chunk(NodeProperty("datacenter", v, None, None)))
-        .modify(_.parameters)
-        .setTo(p(fooParam))
 
       lookup(Seq(multilineNodePropVariable), c)(values => values must containTheSameElementsAs(Seq(Seq("=\r= \nParis =\n="))))
     }
 
-    "fails when the curly brace after ${rudder. is not closed" in {
-      getError(lookupParam(Seq(badUnclosed), context).either.runNow) must beMatching(
-        """.*\Q'== ${rudder.param.foo =='. Error message is: Expected "}":1:23, found "=="\E.*""".r
-      )
-    }
-
     "fails when the part after ${rudder.} is empty" in {
       getError(lookupParam(Seq(badEmptyRudder), context).either.runNow) must beMatching(
-        """.*\Q'== ${rudder.} =='. Error message is: Expected (rudderNode | parameters | oldParameter):1:13, found "} =="\E.*""".r
+        """.*\Q'== ${rudder.} =='. Error message is: Expected (rudderNode | removedParameter):1:13, found "} =="\E.*""".r
       )
     }
 
     "fails when the part after ${rudder.} is not recognised" in {
-      getError(lookupParam(Seq(badUnknown), context.copy(parameters = p(fooParam))).either.runNow) must beMatching(
-        """.*\Q'== ${rudder.foo} =='. Error message is: Expected (rudderNode | parameters | oldParameter):1:13, found "foo} =="\E.*""".r
+      getError(lookupParam(Seq(badUnknown), context).either.runNow) must beMatching(
+        """.*\Q'== ${rudder.foo} =='. Error message is: Expected (rudderNode | removedParameter):1:13, found "foo} =="\E.*""".r
       )
     }
-  }
-
-  "A double parameter" should {
-    "be replaced by its value" in {
-      lookup(Seq(var1_double), context.copy(parameters = p(fooParam, barParam)))(values =>
-        values must containTheSameElementsAs(Seq(Seq("== fooValuebarValue ==")))
-      )
-    }
-    "accept space between values" in {
-      lookup(Seq(var1_double_space), context.copy(parameters = p(fooParam, barParam)))(values =>
-        values must containTheSameElementsAs(Seq(Seq("== fooValue contains barValue ==")))
-      )
-    }
-
   }
 
   "Node parameters" should {
@@ -1335,37 +1169,9 @@ class TestNodeAndGlobalParameterLookup extends Specification {
   }
 
   "Case" should {
-    "not matter in the path" in {
-      lookup(Seq(pathCaseInsensitive), context.copy(parameters = p(fooParam)))(values =>
-        values must containTheSameElementsAs(Seq(Seq("== fooValue ==")))
-      )
-    }
-
     "not matter in nodes path accessor" in {
       val i = compileAndGet("${rudder.node.HoStNaMe}")
       i(context).either.runNow must beEqualTo(Right("node1.localhost"))
-    }
-
-    "matter for parameter names" in {
-      getError(lookupParam(Seq(paramNameCaseSensitive), context).either.runNow) must beMatching(
-        """.*\QMissing parameter '${node.parameter[Foo]}\E.*""".r
-      )
-    }
-
-    "matter in param names" in {
-      val i = compileAndGet("${rudder.param.xX}")
-      val c = context.copy(parameters = {
-        Map(
-          // test all combination
-          ("XX", (i: ParamInterpolationContext) => "bad".succeed),
-          ("Xx", (i: ParamInterpolationContext) => "bad".succeed),
-          ("xx", (i: ParamInterpolationContext) => "bad".succeed)
-        )
-      })
-      i(c).either.runNow match {
-        case Right(_)  => ko("No, case must matter!")
-        case Left(err) => err.msg must beEqualTo("Missing parameter '${node.parameter[xX]}'")
-      }
     }
 
     "matter in node properties" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -377,7 +377,11 @@ class WriteSystemTechniquesTest extends TechniquesTest {
       val rnc = cfg.copy(
         policies = policies(cfg.nodeInfo, baseRootDrafts ++ userDrafts), // testing escape of "
 
-        parameters = cfg.parameters + ParameterForConfiguration("ntpserver", """pool."ntp".org""")
+        // the hidden parameter must be in the `rudder_parameters` string-template bundle
+        // (common/1.0/rudder-parameters.cf) but NOT in rudder-parameters.json
+        parameters = cfg.parameters
+          + ParameterForConfiguration("ntpserver", """pool."ntp".org""")
+          + ParameterForConfiguration("hiddenParam", "hiddenParamValue", Hidden)
       )
 
       // Actually write the promise files for the root node

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
@@ -317,7 +317,7 @@ response:
             "longDescription":"",
             "techniqueName":"clockConfiguration",
             "techniqueVersion":"3.0",
-            "parameters":{"section":{"name":"sections","sections":[{"section":{"name":"Hardware clock (RTC)","vars":[{"var":{"name":"CLOCK_HWSYNC_ENABLE","value":"true"}},{"var":{"name":"CLOCK_SYNCSCHED","value":"240"}}]}},{"section":{"name":"Time synchronization (NTP)","vars":[{"var":{"name":"CLOCK_FQDNNTP","value":"true"}}],"sections":[{"section":{"name":"clock ntpservers","vars":[{"var":{"name":"CLOCK_NTPSERVERS","value":"${rudder.param.ntpserver}"}}]}}]}},{"section":{"name":"Time zone","vars":[{"var":{"name":"CLOCK_TIMEZONE","value":"dontchange"}}]}}]}},
+            "parameters":{"section":{"name":"sections","sections":[{"section":{"name":"Hardware clock (RTC)","vars":[{"var":{"name":"CLOCK_HWSYNC_ENABLE","value":"true"}},{"var":{"name":"CLOCK_SYNCSCHED","value":"240"}}]}},{"section":{"name":"Time synchronization (NTP)","vars":[{"var":{"name":"CLOCK_FQDNNTP","value":"true"}}],"sections":[{"section":{"name":"clock ntpservers","vars":[{"var":{"name":"CLOCK_NTPSERVERS","value":"${node.properties[ntpserver]}"}}]}}]}},{"section":{"name":"Time zone","vars":[{"var":{"name":"CLOCK_TIMEZONE","value":"dontchange"}}]}}]}},
             "priority":5,
             "enabled":true,
             "system":false,
@@ -2186,7 +2186,7 @@ response:
                                               {
                                                 "var": {
                                                   "name": "CLOCK_NTPSERVERS",
-                                                  "value": "${rudder.param.ntpserver}"
+                                                  "value": "${node.properties[ntpserver]}"
                                                 }
                                               }
                                             ]


### PR DESCRIPTION
https://issues.rudder.io/issues/29413

So, this is the first part of the 9.2 and 10.0 migration out of rudder parameters to only keep inherited node properties, both in server side and on agent side. 

It handles the removing of the different kind of ${rudder.parameters} syntax interpolation in webapp and rudderc. 
In that first step, we keep `rudder-parameters.json` so that on the agent side, nothing change. 

# rudderc

On rudderc, it's rather simple and mechanic: it means transforming the parsing of `${rudder.parameters` and `${rudder_parameters` (a new one) into technique compilation error - they should go up to rudder policy generation notification zone. 

# webapp

On webapp, it's much more impactful, but in a good way: we can clean a lot of code. 

## Erroring on parsing

The real correction is replacing the parsing case for `${rudder.param.X}` and `${rudder.parameters[X]}` as error failing the policy generation, like for rudderc. 

## Interpolation value compiler simplification

But most of it is in [‎webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala‎](https://github.com/Normation/rudder/pull/7350/changes#diff-19db967ed8a6fae2a6eb1c7d6ebb0ec2285e32a0c0268854209243a888a496e8) where lives the logic to do something with `${rudder.param.X}` and `${rudder.parameters[X]}`. 

This was interpolated in the resolution of global parameters (because a global parameters used to be able to use the expanded value of another parameter) and in directive parameters. 

All that code is now useless and removed. 
`translateToAgent` is a special case: it was already dead code and is now cleaned-up. 

# visibility == hidden case

In addition since it's the same code logic and as a side effect, we remove hidden global properties to end up in `rudder-parameters.json`. This only impact benchmarks properties, which are huge and in any case the one used live in `properties.d/properties.json` because we need the overridden ones. So we just remove a useless, almost duplication. 