### PR TITLE
Fixes #29417: Rename the session cookie

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
   <session-config>
    <cookie-config>
+    <name>__Secure-RudderSID</name>
     <http-only>true</http-only>
     <secure>true</secure>
     <attribute>


### PR DESCRIPTION
https://issues.rudder.io/issues/29417

* Add the `__Secure-` prefix to harden a bit the cookie on the brwoser side, see https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Cookies#name
* Rename it to avoid being flagged at each audit.

Only in 9.2 as the security improvement is small, and the impact could not be totally invisible (tough we don't seem to hardcode `JSESSIONID` anywhere, which is good)