### PR TITLE
Fixes #29154: nodelastcompliance table can get *really* big

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/JdbcMaintenanceSchedule.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/JdbcMaintenanceSchedule.scala
@@ -1,0 +1,95 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.batch
+
+import com.normation.rudder.domain.logger.ScheduledJobLoggerPure
+import com.normation.rudder.repository.jdbc.JdbcVacuum
+import com.normation.utils.CronParser.*
+import com.normation.zio.*
+import zio.*
+
+/**
+ * A scheduler which runs database maintenance operations (vacuum)
+ * on the tables listed in [[JdbcVacuum.all]]
+ */
+class JdbcMaintenanceSchedule(
+    vacuums:        List[JdbcVacuum],
+    schedule:       Schedule[Any, Any, Any],
+    scheduleString: String
+) {
+
+  private val progAction: UIO[Unit] = {
+    for {
+      _ <- ScheduledJobLoggerPure.debug("Starting database maintenance (vacuum)")
+      _ <- ZIO.foreach(vacuums) { vacuum =>
+             vacuum
+               .vacuum()
+               .catchAll(err => ScheduledJobLoggerPure.error(s"Error when vacuuming database table: ${err.fullMsg}"))
+           }
+      _ <- ScheduledJobLoggerPure.debug("Database maintenance (vacuum) completed")
+    } yield ()
+  }
+
+  // create the schedule vacuum cron or nothing if disabled.
+  // Must not fail.
+  val prog: UIO[Unit] = {
+    ScheduledJobLoggerPure.info(
+      s"Automatic database maintenance (vacuum) is ${scheduleString}"
+    ) *>
+    progAction.schedule(schedule).unit
+  }
+
+  // start cron
+  def start(): Fiber.Runtime[Nothing, Unit] = {
+    ZioRuntime.unsafeRun(prog.forkDaemon)
+  }
+}
+
+object JdbcMaintenanceSchedule {
+  /*
+   * It is assumed to run daily, and take hour and minute
+   */
+  def make(vacuums: List[JdbcVacuum], hour: Int, minute: Int): JdbcMaintenanceSchedule = {
+    val dailyCronString            = s"0 ${minute} ${hour} * * ?"
+    val cron                       = dailyCronString.toCron
+    // never schedule if it fails
+    val (schedule, scheduleString) = cron
+      .map(c => (c.toSchedule, s"scheduled every day at hour ${hour} and minute ${minute}"))
+      .getOrElse((Schedule.stop, "not scheduled"))
+    new JdbcMaintenanceSchedule(vacuums, schedule, scheduleString)
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/JdbcVacuum.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/JdbcVacuum.scala
@@ -1,0 +1,82 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.repository.jdbc
+
+import cats.syntax.apply.*
+import com.normation.errors.IOResult
+import com.normation.rudder.db.Doobie
+import doobie.*
+import doobie.implicits.*
+import zio.*
+import zio.interop.catz.*
+
+/**
+ * Interface for vacuuming/maintaining a table:
+ * this is a Postgres-specific maintenance operation, which can be combined,
+ * e.g. as batch database maintenance operations defined in the webapp
+ */
+sealed trait JdbcVacuum {
+  def vacuum(): IOResult[Unit]
+}
+
+object JdbcVacuum {
+  // all the vacuum operations to run in the database maintenance schedule
+  def all(doobie: Doobie): List[JdbcVacuum] = List(
+    new JdbcVacuumFull("NodeLastCompliance")(doobie)
+  )
+}
+
+/**
+ * Postgres VACUUM FULL implementation: rewrites the entire table, acquiring a lock,
+ * but clears more disk space.
+ *
+ * Regular VACUUM only flags reusable (dead) tuples which makes the table keep its size.
+ * VACUUM FULL actually rewrites the table and truncates the file, which is what
+ * reclaims the actual disk space on disk.
+ */
+class JdbcVacuumFull(table: String)(doobie: Doobie) extends JdbcVacuum {
+
+  import doobie.*
+
+  override def vacuum(): IOResult[Unit] = {
+    val query = s"VACUUM FULL ${table}"
+
+    transactIOResult(s"error when vacuuming full table ${table}")(xa =>
+      (FC.setAutoCommit(true) *> Update0(query, None).run <* FC.setAutoCommit(false)).transact(xa)
+    ).unit
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -204,17 +204,17 @@ rudder.batch.reportscleaner.frequency=daily
 # Defaults: minute=0, hour=0, day=Sunday
 
 
-# Which minute the cleaner should be run on.
+# Which minute database cleaners (reports, vacuum) should be run on.
 # Values  : [0-59]
 # Default : 0
 rudder.batch.databasecleaner.runtime.minute=0
 
-# Which hour the cleaner should be run on.
+# Which hour database cleaners (reports, vacuum) should be run on.
 # Values : [0-23]
 # Default : 0
 rudder.batch.databasecleaner.runtime.hour=0
 
-# Which day the cleaner should be run on.
+# Which day reports cleaner should be run on.
 # Values : monday | tuesday | wednesday | thursday | friday | saturday | sunday
 # Default : sunday
 rudder.batch.databasecleaner.runtime.day=sunday

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3431,6 +3431,14 @@ object RudderConfigInit {
       )
     }
 
+    lazy val jdbcMaintenanceSchedule: JdbcMaintenanceSchedule = {
+      JdbcMaintenanceSchedule.make(
+        JdbcVacuum.all(doobie),
+        hour = RUDDER_BATCH_DATABASECLEANER_RUNTIME_HOUR,
+        minute = RUDDER_BATCH_DATABASECLEANER_RUNTIME_MINUTE
+      )
+    }
+
     lazy val techniqueLibraryUpdater = new CheckTechniqueLibrary(
       techniqueRepositoryImpl,
       techniqueStatusService,
@@ -3980,6 +3988,7 @@ object RudderConfigInit {
     cleanOldInventoryBatch.start()
     gitFactRepoGC.start()
     gitConfigRepoGC.start()
+    jdbcMaintenanceSchedule.start()
     rudderUserListProvider.registerCallback(UserRepositoryUpdateOnFileReload.createCallback(userRepository))
     userCleanupBatch.start()
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29154

Schedule a "vacuum full" every day, using existing `databasecleaner` configuration values (by default at midnight)

The architecture of the change is about:
* adding a generic `JdbcVacuum` generic trait, which may be useful for other future vacuum on other tables
* adding a `JdbcVacuumFull` generic implementation with `VACUUM FULL` command
* adding an implementation with 'vacuum full' for nodelastcompliance