### PR TITLE
Fixes #29476: We allow to use empty passwords

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -56,6 +56,7 @@ import com.normation.zio.*
 import enumeratum.*
 import java.io.InputStream
 import java.security.SecureRandom
+import org.apache.commons.lang3.StringUtils
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.xml.sax.SAXParseException
 import scala.collection.immutable.SortedMap
@@ -104,7 +105,11 @@ object PasswordEncoderType extends Enum[PasswordEncoderType] {
 }
 
 class PasswordEncoderDispatcher(bcryptCost: Int, argon2Params: Argon2EncoderParams) {
-  def dispatch(encoderType: PasswordEncoderType): PasswordEncoder = {
+  /*
+   * The returned encoders are the raw hash algorithms: they don't enforce any Rudder password policy
+   * They must only be used through `RudderPasswordEncoder`, which is why this stays package-private.
+   */
+  private[users] def dispatch(encoderType: PasswordEncoderType): PasswordEncoder = {
     encoderType match {
       case PasswordEncoderType.BCRYPT   => RudderPasswordEncoder.bcryptEncoder(bcryptCost)
       case PasswordEncoderType.ARGON2ID =>
@@ -128,8 +133,7 @@ object RudderPasswordEncoder {
 
   private val secureRandom = new SecureRandom()
 
-  // Proper password hash functions
-  class bcryptEncoder(cost: Int)                          extends PasswordEncoder {
+  private[users] class bcryptEncoder(cost: Int)                          extends PasswordEncoder {
     override def encode(rawPassword: CharSequence):                           String  = {
       val salt: Array[Byte] = new Array(16)
       secureRandom.nextBytes(salt)
@@ -148,7 +152,7 @@ object RudderPasswordEncoder {
       }
     }
   }
-  class argon2Encoder(encoderParams: Argon2EncoderParams) extends PasswordEncoder {
+  private[users] class argon2Encoder(encoderParams: Argon2EncoderParams) extends PasswordEncoder {
     override def encode(rawPassword: CharSequence):                           String  = {
       val salt: Array[Byte] = new Array(encoderParams.saltSize.toInt)
       secureRandom.nextBytes(salt)
@@ -199,6 +203,8 @@ case class RudderPasswordEncoder(
   }
 
   override def matches(rawPassword: CharSequence, encodedPassword: String): Boolean = {
+    // Defense in depth: a blank password must never authenticate, whatever is stored for the user.
+    !StringUtils.isBlank(rawPassword) &&
     subPasswordEncoder(encodedPassword).matches(rawPassword, encodedPassword)
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -47,6 +47,7 @@ import com.normation.utils.DateFormaterService
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.syntax.*
 import net.liftweb.common.Logger
+import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -460,13 +461,19 @@ final case class JsonUserFormData(
 object JsonUserFormData {
   given (using encoder: PasswordEncoder): UserPasswordEncoder[SecretUserPassword] = encoder.encode(_)
 
+  /*
+   * A blank password means "keep the password unchanged"
+   */
+  private def isPasswordUnchanged(json: JsonUserFormData): Boolean = StringUtils.isBlank(json.password)
+
   given transformer(using passwordEncoder: UserPasswordEncoder[SecretUserPassword]): Transformer[JsonUserFormData, User]           = {
     Transformer
       .define[JsonUserFormData, User]
       .withFieldComputed(
         _.password,
         json => {
-          if (json.isPreHashed) UserPassword.unsafeHashed(json.password)
+          if (isPasswordUnchanged(json)) UserPassword.unknown
+          else if (json.isPreHashed) UserPassword.unsafeHashed(json.password)
           else UserPassword.fromSecret(json.password).transformInto[HashedUserPassword]
         }
       )
@@ -479,7 +486,11 @@ object JsonUserFormData {
       .define[JsonUserFormData, UpdateUserFile]
       .withFieldComputed(
         _.password,
-        json => if (json.isPreHashed) UserPassword.unsafeHashed(json.password) else UserPassword.fromSecret(json.password)
+        json => {
+          if (isPasswordUnchanged(json)) UserPassword.unknown
+          else if (json.isPreHashed) UserPassword.unsafeHashed(json.password)
+          else UserPassword.fromSecret(json.password)
+        }
       )
       .buildTransformer
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/users/RudderPasswordEncoderTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/users/RudderPasswordEncoderTest.scala
@@ -35,9 +35,8 @@
  *************************************************************************************
  */
 
-package bootstrap.liftweb
+package com.normation.rudder.users
 
-import com.normation.rudder.users.*
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -85,6 +84,39 @@ class RudderPasswordEncoderTest extends ZIOSpecDefault {
           encoderType <- PasswordEncoderType.values
         } yield testEncoder(dispatcher, encoderType)
       ),
+      suiteAll("RudderPasswordEncoder blank password") {
+        val encoder = RudderPasswordEncoder(dispatcher)
+
+        test("refuses an empty password against a hash of the empty password") {
+          val checks = PasswordEncoderType.values.map(t => encoder.matches("", dispatcher.dispatch(t).encode("")))
+          assert(checks)(forall(isFalse))
+        }
+        test("refuses a whitespace-only password against a hash of that same password") {
+          val checks = for {
+            pass        <- List(" ", "   ", "\t", " \n ")
+            encoderType <- PasswordEncoderType.values
+          } yield encoder.matches(pass, dispatcher.dispatch(encoderType).encode(pass))
+          assert(checks)(forall(isFalse))
+        }
+        test("refuses an empty password against an unparseable stored hash") {
+          assert(encoder.matches("", "not-a-hash"))(isFalse)
+        }
+        test("refuses a null password") {
+          assert(encoder.matches(null, dispatcher.dispatch(PasswordEncoderType.BCRYPT).encode("")))(isFalse)
+        }
+        test("still accepts a correct non-blank password") {
+          val pass = "ue4Eep1oth3mie0aev7fi4oop.aef1eNa4AiDoh2"
+          assert(PasswordEncoderType.values.map(t => encoder.matches(pass, dispatcher.dispatch(t).encode(pass))))(
+            forall(isTrue)
+          )
+        }
+        test("still accepts a correct password with leading and trailing spaces") {
+          val pass = "  ue4Eep1oth3mie0aev7fi4oop.aef1eNa4AiDoh2  "
+          assert(PasswordEncoderType.values.map(t => encoder.matches(pass, dispatcher.dispatch(t).encode(pass))))(
+            forall(isTrue)
+          )
+        }
+      },
       suiteAll("BCRYPT specific") {
         val encoder       = RudderPasswordEncoder.bcryptEncoder(10)
         val pass          = "admin"

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/users/UserManagementServiceTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/users/UserManagementServiceTest.scala
@@ -151,6 +151,88 @@ class UserManagementServiceTest extends Specification with XmlMatchers {
       )
     }
 
+    // an empty password must never be hashed and stored: it would be a valid hash of the empty
+    // string, and anybody could then log in as that user with an empty password.
+    "keep the password already in the file when the new one is an empty cleartext password" in {
+      val exec = UserManagementIO.replaceXml(
+        userXml,
+        UserManagementService.updateUserXmlRewriteRule(
+          "user1",
+          JsonUserFormData("user1", "", Some(List("perm1")), isPreHashed = false, None, None, None),
+          passwordEncoder
+        ),
+        "test"
+      )
+      exec must beRight(
+        beEqualToIgnoringSpace(
+          <authentication hash="sha-1" case-sensitivity="true">
+            <user name="user1" password="1234" permissions="perm1" tenants="zoneA" />
+            <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
+          </authentication>
+        )
+      )
+    }
+
+    "keep the password already in the file when the new one is a blank cleartext password" in {
+      val exec = UserManagementIO.replaceXml(
+        userXml,
+        UserManagementService.updateUserXmlRewriteRule(
+          "user1",
+          JsonUserFormData("user1", "   ", Some(List("perm1")), isPreHashed = false, None, None, None),
+          passwordEncoder
+        ),
+        "test"
+      )
+      exec must beRight(
+        beEqualToIgnoringSpace(
+          <authentication hash="sha-1" case-sensitivity="true">
+            <user name="user1" password="1234" permissions="perm1" tenants="zoneA" />
+            <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
+          </authentication>
+        )
+      )
+    }
+
+    "keep the password already in the file when the new one is an empty pre-hashed password" in {
+      val exec = UserManagementIO.replaceXml(
+        userXml,
+        UserManagementService.updateUserXmlRewriteRule(
+          "user1",
+          JsonUserFormData("user1", "", Some(List("perm1")), isPreHashed = true, None, None, None),
+          passwordEncoder
+        ),
+        "test"
+      )
+      exec must beRight(
+        beEqualToIgnoringSpace(
+          <authentication hash="sha-1" case-sensitivity="true">
+            <user name="user1" password="1234" permissions="perm1" tenants="zoneA" />
+            <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
+          </authentication>
+        )
+      )
+    }
+
+    "keep the password already in the file when the new one is a blank pre-hashed password" in {
+      val exec = UserManagementIO.replaceXml(
+        userXml,
+        UserManagementService.updateUserXmlRewriteRule(
+          "user1",
+          JsonUserFormData("user1", " \t ", Some(List("perm1")), isPreHashed = true, None, None, None),
+          passwordEncoder
+        ),
+        "test"
+      )
+      exec must beRight(
+        beEqualToIgnoringSpace(
+          <authentication hash="sha-1" case-sensitivity="true">
+            <user name="user1" password="1234" permissions="perm1" tenants="zoneA" />
+            <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
+          </authentication>
+        )
+      )
+    }
+
     "lead to an error is user doesn't exists" in {
       val exec = UserManagementIO.replaceXml(
         userXml,


### PR DESCRIPTION
https://issues.rudder.io/issues/29476

* Prevent any blank password to be accepted on the encoder side
* Correctly consider blank passwords as not modified in the user management backend