### PR TITLE
Fixes #29477: Make the argon2 implementation more reliable

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/Argon2.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/Argon2.scala
@@ -40,6 +40,7 @@
 
 package com.normation.rudder.users
 
+import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Base64
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator
@@ -50,6 +51,8 @@ import zio.Chunk
 // * RFC9106: https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice
 // * OWASP Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
 // * Argon2 1.3 specs: https://www.cryptolux.org/images/0/0d/Argon2.pdf
+
+// Below are the settings used for encoding new passwords.
 
 /// Argon2 hash type. Use "id", the recommended variant in most cases.
 private val variant = Argon2Variant(Argon2Parameters.ARGON2_id)
@@ -177,7 +180,7 @@ object Argon2EncoderParams {
 
   // Build parameters for Bouncy Castle
   def buildParams(param: Argon2EncoderParams, salt: Array[Byte]): Argon2Parameters = {
-    new Argon2Parameters.Builder(variant.toInt)
+    new Argon2Parameters.Builder(param.variant.toInt)
       .withVersion(param.version.toInt)
       .withIterations(param.iterations.toInt)
       .withMemoryAsKB(param.memory.toInt)
@@ -211,6 +214,15 @@ case class Argon2Hash(
 object Argon2Hash {
   private val pattern = """\$argon2id\$v=(\d+)\$m=(\d+),t=(\d+),p=(\d+)\$([^$]+)\$([^$]+)""".r
 
+  /*
+   * `String#getBytes` without a charset uses the platform default, which depends on the JVM and its
+   * options (and changed with JDK 18), and a non-ASCII password hashed on one setup would then stop
+   * matching on another.
+   */
+  private def passwordBytes(password: CharSequence): Array[Byte] = {
+    password.toString.getBytes(StandardCharsets.UTF_8)
+  }
+
   def toShadowString(hash: Argon2Hash): Argon2HashString = {
     val encoder     = Base64.getEncoder.withoutPadding
     val encodedSalt = encoder.encodeToString(hash.params.salt.toArray)
@@ -230,10 +242,13 @@ object Argon2Hash {
             Argon2Hash(
               Argon2HashParams(
                 Argon2EncoderParams(
+                  variant = variant,
+                  version = Argon2Version(version.toInt),
                   memory = Argon2Memory(memory.toInt),
                   iterations = Argon2Iterations(iterations.toInt),
                   parallelism = Argon2Parallelism(parallelism.toInt),
-                  version = Argon2Version(version.toInt)
+                  hashSize = Argon2HashSize(hash.length),
+                  saltSize = Argon2SaltSize(salt.length)
                 ),
                 Chunk.fromArray(salt)
               ),
@@ -242,14 +257,15 @@ object Argon2Hash {
           )
         } catch {
           case e: Exception =>
-            Left(s"Invalid password hash format $hashString: ${e.getMessage}")
+            Left(s"Invalid password hash format: ${e.getMessage}")
         }
-      case _                                                                           => Left(s"Could not parse argon2id hash string: $hashString")
+      // the hash is not in the message: it is logged, and a password hash is a secret
+      case _                                                                           => Left("Could not parse argon2id hash string")
     }
   }
 
-  def generate(params: Argon2HashParams, password: Array[Byte]): Argon2HashString = {
-    val hashValue = Argon2HashParams.computeHash(params, password)
+  def generate(params: Argon2HashParams, password: CharSequence): Argon2HashString = {
+    val hashValue = Argon2HashParams.computeHash(params, passwordBytes(password))
     val hash      = Argon2Hash(params, Chunk.fromArray(hashValue))
     Argon2Hash.toShadowString(hash)
   }
@@ -259,9 +275,18 @@ object Argon2Hash {
     MessageDigest.isEqual(storedHash.value.toArray, presentedHash)
   }
 
-  def checkPassword(rawPassword: Array[Byte], argon2String: Argon2HashString): Either[String, Boolean] = {
+  def checkPassword(rawPassword: CharSequence, argon2String: Argon2HashString): Either[String, Boolean] = {
     for {
       storedHash <- parseShadowString(argon2String)
-    } yield comparePassword(rawPassword, storedHash)
+      // The cost parameters are read from the stored hash, and BouncyCastle refuses some of them by
+      // throwing (`p=0`, `t=0`; note that a too small memory is clamped, not refused). Like the bcrypt
+      // encoder, a hash we can't compute must fail the password check, not the whole request.
+      // The message purposely does not include the hash, so it stays out of the logs.
+      isValid    <- try {
+                      Right(comparePassword(passwordBytes(rawPassword), storedHash))
+                    } catch {
+                      case e: Exception => Left(s"Could not check password against argon2id hash: ${e.getMessage}")
+                    }
+    } yield isValid
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -129,6 +129,9 @@ object RudderPasswordEncoder {
   private val secureRandom = new SecureRandom()
 
   // Proper password hash functions
+  // Both take the password as chars and own the conversion to bytes: `OpenBSDBCrypt` via
+  // `Strings.toUTF8ByteArray`, `Argon2Hash` via its own `passwordBytes`. Neither ever sees the
+  // platform default charset.
   class bcryptEncoder(cost: Int)                          extends PasswordEncoder {
     override def encode(rawPassword: CharSequence):                           String  = {
       val salt: Array[Byte] = new Array(16)
@@ -157,10 +160,10 @@ object RudderPasswordEncoder {
         encoderParams,
         salt = Chunk.fromArray(salt)
       )
-      Argon2Hash.generate(hashParams, rawPassword.toString.getBytes)
+      Argon2Hash.generate(hashParams, rawPassword)
     }
     override def matches(rawPassword: CharSequence, encodedPassword: String): Boolean = {
-      Argon2Hash.checkPassword(rawPassword.toString.getBytes, encodedPassword) match {
+      Argon2Hash.checkPassword(rawPassword, encodedPassword) match {
         case Left(e)                  =>
           ApplicationLoggerPure.Auth.logEffect.warn(s"Error while checking Argon2 hash: $e")
           false

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/Argon2Test.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/Argon2Test.scala
@@ -38,6 +38,7 @@
 package bootstrap.liftweb
 
 import com.normation.rudder.users.*
+import java.nio.charset.StandardCharsets
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -50,27 +51,77 @@ class Argon2Test extends ZIOSpecDefault {
     suiteAll("Local password hash algorithms") {
       val encoderParams = Argon2EncoderParams(Argon2Memory(19), Argon2Iterations(3), Argon2Parallelism(1))
       val shadowString  = "$argon2id$v=19$m=19,t=3,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"
-      val hash          = Argon2Hash(
-        Argon2HashParams(encoderParams, salt = Chunk.fromArray("azertyuiop".getBytes)),
-        Chunk.fromArray("bobmaurane".getBytes)
+      val salt          = "azertyuiop".getBytes(StandardCharsets.UTF_8)
+      val tag           = "bobmaurane".getBytes(StandardCharsets.UTF_8)
+      val hash          = Argon2Hash(Argon2HashParams(encoderParams, salt = Chunk.fromArray(salt)), Chunk.fromArray(tag))
+      // parsing takes the sizes from the string being parsed, so they are the ones of this salt and tag,
+      // not the defaults carried by `encoderParams`
+      val parsedHash    = Argon2Hash(
+        Argon2HashParams(
+          encoderParams.copy(hashSize = Argon2HashSize(tag.length), saltSize = Argon2SaltSize(salt.length)),
+          salt = Chunk.fromArray(salt)
+        ),
+        Chunk.fromArray(tag)
       )
 
       test("stores as shadow string") {
         assert(Argon2Hash.toShadowString(hash))(equalTo(shadowString))
       }
       test("parses shadow string") {
-        val parsedHash = Argon2Hash.parseShadowString(shadowString)
-        assert(parsedHash)(isRight(equalTo(hash)))
+        assert(Argon2Hash.parseShadowString(shadowString))(isRight(equalTo(parsedHash)))
       }
-      test("fails to parse malformed shadow string") {
-        val invalid    = "$argon2id$invalid=3v=19$m=19,t=3,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"
-        val parsedHash = Argon2Hash.parseShadowString(invalid)
-        assert(parsedHash)(isLeft(equalTo(s"Could not parse argon2id hash string: $invalid")))
+      // the tag length has to be read from the stored hash: assuming our own default would make any
+      // hash created with another size impossible to verify
+      test("verifies a hash whose tag is not the default 32 bytes") {
+        val params = Argon2HashParams(
+          encoderParams.copy(hashSize = Argon2HashSize(64)),
+          salt = Chunk.fromArray("azertyuiop123456".getBytes(StandardCharsets.UTF_8))
+        )
+        val shadow = Argon2Hash.generate(params, "secret")
+        assert(Argon2Hash.checkPassword("secret", shadow))(isRight(isTrue)) &&
+        assert(Argon2Hash.checkPassword("wrong", shadow))(isRight(isFalse))
       }
-      test("fails to parse invalid shadow string") {
-        val invalid    = "$argon2id$v=19$m=19,t=3,p=1$invalid&base64$Ym9ibWF1cmFuZQ"
-        val parsedHash = Argon2Hash.parseShadowString(invalid)
-        assert(parsedHash)(isLeft(equalTo(s"Invalid password hash format $invalid: Illegal base64 character 26")))
+      // `generate` owns the password encoding, so pin it: the bytes it hashes must be the UTF-8 ones,
+      // not whatever the platform default charset would produce for a non-ASCII password.
+      test("hashes the password as UTF-8") {
+        val nonAscii   = "pâßwörd-日本語"
+        val hashParams = Argon2HashParams(
+          encoderParams,
+          salt = Chunk.fromArray("azertyuiop123456".getBytes(StandardCharsets.UTF_8))
+        )
+        val expected   = Argon2Hash.toShadowString(
+          Argon2Hash(
+            hashParams,
+            Chunk.fromArray(Argon2HashParams.computeHash(hashParams, nonAscii.getBytes(StandardCharsets.UTF_8)))
+          )
+        )
+        assert(Argon2Hash.generate(hashParams, nonAscii))(equalTo(expected)) &&
+        assert(Argon2Hash.checkPassword(nonAscii, expected))(isRight(isTrue))
+      }
+      // a password hash is a secret and these messages are logged, so they must not carry the value
+      test("fails to parse malformed shadow string, without echoing it") {
+        val invalid = "$argon2id$invalid=3v=19$m=19,t=3,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"
+        assert(Argon2Hash.parseShadowString(invalid))(isLeft(equalTo("Could not parse argon2id hash string")))
+      }
+      test("fails to parse invalid shadow string, without echoing it") {
+        val invalid = "$argon2id$v=19$m=19,t=3,p=1$invalid&base64$Ym9ibWF1cmFuZQ"
+        assert(Argon2Hash.parseShadowString(invalid))(
+          isLeft(equalTo("Invalid password hash format: Illegal base64 character 26"))
+        )
+      }
+      // these parse, but BouncyCastle refuses to compute with them: we must get a Left, not an exception
+      test("fails on a well-formed shadow string with cost parameters BouncyCastle refuses") {
+        val unusable = List(
+          "$argon2id$v=19$m=19,t=3,p=0$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ", // no lane
+          "$argon2id$v=19$m=19,t=0,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"  // no iteration
+        )
+        assert(unusable.map(Argon2Hash.checkPassword("secret", _)))(forall(isLeft(anything)))
+      }
+      // BouncyCastle clamps a memory below its minimum instead of refusing it, so this one computes
+      // normally. We accept whatever cost parameters the stored hash carries: see finding M2.
+      test("computes a hash whose memory is below the BouncyCastle minimum") {
+        val weak = "$argon2id$v=19$m=1,t=3,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"
+        assert(Argon2Hash.checkPassword("secret", weak))(isRight(isFalse))
       }
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderPasswordEncoderTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderPasswordEncoderTest.scala
@@ -134,6 +134,16 @@ class RudderPasswordEncoderTest extends ZIOSpecDefault {
           val altEncoder       = RudderPasswordEncoder.argon2Encoder(altEncoderParams)
           assert(altEncoder.matches(pass, pass_argon2))(isTrue)
         }
+        // like the bcrypt encoder: an unusable stored hash fails the login, it does not fail the request
+        test("fails instead of throwing on a hash with cost parameters BouncyCastle refuses") {
+          assert(encoder.matches(pass, "$argon2id$v=19$m=19,t=3,p=0$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"))(isFalse)
+        }
+        // the encoding itself is `Argon2Hash`'s job and is pinned in Argon2Test; here we only check
+        // a non-ASCII password survives the encoder end to end
+        test("round-trips a non-ASCII password") {
+          val nonAscii = "pâßwörd-日本語"
+          assert(encoder.matches(nonAscii, encoder.encode(nonAscii)))(isTrue)
+        }
       }
     )
   }


### PR DESCRIPTION
- read the tag and salt sizes from the stored hash instead of assuming the current defaults, so a hash created with other sizes can still be verified
- return a Left instead of letting BouncyCastle exceptions escape when the stored cost parameters are unusable, like the bcrypt encoder already does
- encode the password as UTF-8 inside Argon2Hash rather than leaving the conversion, and the platform default charset, to callers
- build the BouncyCastle parameters with the variant of the parameters given, which was silently overridden by the global one
- keep the hash out of the parse error messages, they are logged