### PR TITLE
Fixes #29477: Make the argon2 implementation more reliable

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/Argon2.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/Argon2.scala
@@ -40,6 +40,7 @@
 
 package com.normation.rudder.users
 
+import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Base64
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator
@@ -50,6 +51,8 @@ import zio.Chunk
 // * RFC9106: https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice
 // * OWASP Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
 // * Argon2 1.3 specs: https://www.cryptolux.org/images/0/0d/Argon2.pdf
+
+// Below are the settings used for encoding new passwords.
 
 /// Argon2 hash type. Use "id", the recommended variant in most cases.
 private val variant = Argon2Variant(Argon2Parameters.ARGON2_id)
@@ -177,7 +180,7 @@ object Argon2EncoderParams {
 
   // Build parameters for Bouncy Castle
   def buildParams(param: Argon2EncoderParams, salt: Array[Byte]): Argon2Parameters = {
-    new Argon2Parameters.Builder(variant.toInt)
+    new Argon2Parameters.Builder(param.variant.toInt)
       .withVersion(param.version.toInt)
       .withIterations(param.iterations.toInt)
       .withMemoryAsKB(param.memory.toInt)
@@ -211,6 +214,15 @@ case class Argon2Hash(
 object Argon2Hash {
   private val pattern = """\$argon2id\$v=(\d+)\$m=(\d+),t=(\d+),p=(\d+)\$([^$]+)\$([^$]+)""".r
 
+  /*
+   * `String#getBytes` without a charset uses the platform default, which depends on the JVM and its
+   * options (and changed with JDK 18), and a non-ASCII password hashed on one setup would then stop
+   * matching on another.
+   */
+  private def passwordBytes(password: CharSequence): Array[Byte] = {
+    password.toString.getBytes(StandardCharsets.UTF_8)
+  }
+
   def toShadowString(hash: Argon2Hash): Argon2HashString = {
     val encoder     = Base64.getEncoder.withoutPadding
     val encodedSalt = encoder.encodeToString(hash.params.salt.toArray)
@@ -230,10 +242,13 @@ object Argon2Hash {
             Argon2Hash(
               Argon2HashParams(
                 Argon2EncoderParams(
+                  variant = variant,
+                  version = Argon2Version(version.toInt),
                   memory = Argon2Memory(memory.toInt),
                   iterations = Argon2Iterations(iterations.toInt),
                   parallelism = Argon2Parallelism(parallelism.toInt),
-                  version = Argon2Version(version.toInt)
+                  hashSize = Argon2HashSize(hash.length),
+                  saltSize = Argon2SaltSize(salt.length)
                 ),
                 Chunk.fromArray(salt)
               ),
@@ -242,14 +257,15 @@ object Argon2Hash {
           )
         } catch {
           case e: Exception =>
-            Left(s"Invalid password hash format $hashString: ${e.getMessage}")
+            Left(s"Invalid password hash format: ${e.getMessage}")
         }
-      case _                                                                           => Left(s"Could not parse argon2id hash string: $hashString")
+      // the hash is not in the message: it is logged, and a password hash is a secret
+      case _                                                                           => Left("Could not parse argon2id hash string")
     }
   }
 
-  def generate(params: Argon2HashParams, password: Array[Byte]): Argon2HashString = {
-    val hashValue = Argon2HashParams.computeHash(params, password)
+  def generate(params: Argon2HashParams, password: CharSequence): Argon2HashString = {
+    val hashValue = Argon2HashParams.computeHash(params, passwordBytes(password))
     val hash      = Argon2Hash(params, Chunk.fromArray(hashValue))
     Argon2Hash.toShadowString(hash)
   }
@@ -259,9 +275,18 @@ object Argon2Hash {
     MessageDigest.isEqual(storedHash.value.toArray, presentedHash)
   }
 
-  def checkPassword(rawPassword: Array[Byte], argon2String: Argon2HashString): Either[String, Boolean] = {
+  def checkPassword(rawPassword: CharSequence, argon2String: Argon2HashString): Either[String, Boolean] = {
     for {
       storedHash <- parseShadowString(argon2String)
-    } yield comparePassword(rawPassword, storedHash)
+      // The cost parameters are read from the stored hash, and BouncyCastle refuses some of them by
+      // throwing (`p=0`, `t=0`; note that a too small memory is clamped, not refused). Like the bcrypt
+      // encoder, a hash we can't compute must fail the password check, not the whole request.
+      // The message purposely does not include the hash, so it stays out of the logs.
+      isValid    <- try {
+                      Right(comparePassword(passwordBytes(rawPassword), storedHash))
+                    } catch {
+                      case e: Exception => Left(s"Could not check password against argon2id hash: ${e.getMessage}")
+                    }
+    } yield isValid
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -84,17 +84,23 @@ sealed abstract class PasswordEncoderType(override val entryName: String) extend
 object PasswordEncoderType extends Enum[PasswordEncoderType] {
   case object BCRYPT   extends PasswordEncoderType("BCRYPT")   {
     val defaultCost = 12
+    // From OWASP recommendations
+    val minimumCost = 10
 
     // 16 bytes = 128 bits
     val saltSize = 16
   }
   case object ARGON2ID extends PasswordEncoderType("ARGON2ID") {
-    // Defaults for user-controlled settings
+    // Defaults and minimums for user-controlled settings. The minimums are the ones of the
+    // lowest configuration OWASP considers acceptable (m=19MiB, t=2, p=1), and they are also
+    // above the values BouncyCastle refuses outright (t=0 and p=0 make it throw).
     // 19 MiB, from OWASP recommendations
     val minimumMemory      = Argon2Memory(19 * 1024)
     // 128 MiB
     val defaultMemory      = Argon2Memory(128 * 1024)
+    val minimumIterations  = Argon2Iterations(2)
     val defaultIterations  = Argon2Iterations(3)
+    val minimumParallelism = Argon2Parallelism(1)
     val defaultParallelism = Argon2Parallelism(1)
   }
 
@@ -161,10 +167,10 @@ object RudderPasswordEncoder {
         encoderParams,
         salt = Chunk.fromArray(salt)
       )
-      Argon2Hash.generate(hashParams, rawPassword.toString.getBytes)
+      Argon2Hash.generate(hashParams, rawPassword)
     }
     override def matches(rawPassword: CharSequence, encodedPassword: String): Boolean = {
-      Argon2Hash.checkPassword(rawPassword.toString.getBytes, encodedPassword) match {
+      Argon2Hash.checkPassword(rawPassword, encodedPassword) match {
         case Left(e)                  =>
           ApplicationLoggerPure.Auth.logEffect.warn(s"Error while checking Argon2 hash: $e")
           false
@@ -199,7 +205,7 @@ case class RudderPasswordEncoder(
 
     // We could (and likely should) use RudderPasswordProvider for encoding but we need to store the algorithm to use
     // (as DelegatingPasswordEncoder does) based on the user configuration.
-    subPasswordEncoder(rawPassword.toString).encode(rawPassword)
+    passwordEncoderDispatcher.dispatch(PasswordEncoderType.DEFAULT).encode(rawPassword)
   }
 
   override def matches(rawPassword: CharSequence, encodedPassword: String): Boolean = {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/users/RudderPasswordEncoderTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/users/RudderPasswordEncoderTest.scala
@@ -166,6 +166,16 @@ class RudderPasswordEncoderTest extends ZIOSpecDefault {
           val altEncoder       = RudderPasswordEncoder.argon2Encoder(altEncoderParams)
           assert(altEncoder.matches(pass, pass_argon2))(isTrue)
         }
+        // like the bcrypt encoder: an unusable stored hash fails the login, it does not fail the request
+        test("fails instead of throwing on a hash with cost parameters BouncyCastle refuses") {
+          assert(encoder.matches(pass, "$argon2id$v=19$m=19,t=3,p=0$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"))(isFalse)
+        }
+        // the encoding itself is `Argon2Hash`'s job and is pinned in Argon2Test; here we only check
+        // a non-ASCII password survives the encoder end to end
+        test("round-trips a non-ASCII password") {
+          val nonAscii = "pâßwörd-日本語"
+          assert(encoder.matches(nonAscii, encoder.encode(nonAscii)))(isTrue)
+        }
       }
     )
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -790,74 +790,68 @@ object RudderParsedProperties {
     }
   }
 
-  val RUDDER_BCRYPT_COST: Int = {
-    val defaultValue = PasswordEncoderType.BCRYPT.defaultCost
+  /*
+   * Cost parameters of password hashes: every one of them makes the hashes we create weaker when
+   * set too low, and some values are plainly refused by BouncyCastle (a `p=0` argon2 parallelism
+   * makes it throw when hashing). A value below the minimum is way more likely to be a
+   * configuration mistake (a unit confusion, a value copied from a test setup) than a deliberate
+   * choice, so keep the default and tell the user, like for a missing value.
+   */
+  private def passwordCostParam(property: String, defaultValue: Int, minimumValue: Int, unit: String = ""): Int = {
+    val u = if (unit.isEmpty) "" else s" ${unit}"
     try {
-      val cost = config.getInt("rudder.bcrypt.cost")
-      // avoid user insecure misconfiguration
-      if (cost <= 10) {
+      val value = config.getInt(property)
+      if (value < minimumValue) {
         ApplicationLogger.warn(
-          s"Property 'rudder.bcrypt.cost' was configured to value ${cost} <= 10 which is insecure. Reverting to default cost: $defaultValue."
+          s"Property '${property}' is configured to ${value}${u}, which is lower than the minimum secure value of ${minimumValue}${u}. Using the default value instead: ${defaultValue}${u}."
         )
         defaultValue
-      } else cost
+      } else value
     } catch {
-      case ex: ConfigException =>
-        ApplicationLogger.debug(
-          s"Property 'rudder.bcrypt.cost' is absent or empty in rudder.configFile. Default cost to $defaultValue."
-        )
-        defaultValue
-    }
-  }
-
-  val RUDDER_ARGON2_MEMORY: Argon2Memory = {
-    val defaultValue = PasswordEncoderType.ARGON2ID.defaultMemory
-    val minimumValue = PasswordEncoderType.ARGON2ID.minimumMemory
-    try {
-      val value = config.getInt("rudder.argon2.memory")
-      // There is a high likelihood of units confusion.
-      if (value < minimumValue.toInt) {
+      // an empty or non-numeric value is a configuration mistake, like a value below the minimum
+      case _: ConfigException.WrongType =>
         ApplicationLogger.warn(
-          s"Property 'rudder.argon2.memory' has a value lower than $minimumValue KiB. This is likely a configuration mistake, using $defaultValue KiB instead"
+          s"Property '${property}' is empty or is not an integer in rudder.configFile. Using the default value instead: ${defaultValue}${u}."
         )
         defaultValue
-      } else {
-        Argon2Memory(value)
-      }
-    } catch {
-      case ex: ConfigException =>
-        ApplicationLogger.debug(
-          s"Property 'rudder.argon2.memory' is absent or empty in rudder.configFile. Default memory to $defaultValue bytes."
+      case _: ConfigException =>
+        ApplicationLogger.info(
+          s"Property '${property}' is absent in rudder.configFile. Using the default value: ${defaultValue}${u}."
         )
         defaultValue
     }
   }
 
-  val RUDDER_ARGON2_ITERATIONS: Argon2Iterations = {
-    val defaultValue = PasswordEncoderType.ARGON2ID.defaultIterations
-    try {
-      Argon2Iterations(config.getInt("rudder.argon2.iterations"))
-    } catch {
-      case ex: ConfigException =>
-        ApplicationLogger.debug(
-          s"Property 'rudder.argon2.iterations' is absent or empty in rudder.configFile. Default iterations to $defaultValue."
-        )
-        defaultValue
-    }
-  }
+  val RUDDER_BCRYPT_COST: Int = passwordCostParam(
+    "rudder.bcrypt.cost",
+    PasswordEncoderType.BCRYPT.defaultCost,
+    PasswordEncoderType.BCRYPT.minimumCost
+  )
 
-  val RUDDER_ARGON2_PARALLELISM: Argon2Parallelism = {
-    val defaultValue = PasswordEncoderType.ARGON2ID.defaultParallelism
-    try {
-      Argon2Parallelism(config.getInt("rudder.argon2.parallelism"))
-    } catch {
-      case ex: ConfigException =>
-        ApplicationLogger.debug(
-          s"Property 'rudder.argon2.parallelism' is absent or empty in rudder.configFile. Default parallelism to $defaultValue."
-        )
-        defaultValue
-    }
-  }
+  val RUDDER_ARGON2_MEMORY: Argon2Memory = Argon2Memory(
+    passwordCostParam(
+      "rudder.argon2.memory",
+      PasswordEncoderType.ARGON2ID.defaultMemory.toInt,
+      PasswordEncoderType.ARGON2ID.minimumMemory.toInt,
+      "KiB"
+    )
+  )
+
+  val RUDDER_ARGON2_ITERATIONS: Argon2Iterations = Argon2Iterations(
+    passwordCostParam(
+      "rudder.argon2.iterations",
+      PasswordEncoderType.ARGON2ID.defaultIterations.toInt,
+      PasswordEncoderType.ARGON2ID.minimumIterations.toInt
+    )
+  )
+
+  val RUDDER_ARGON2_PARALLELISM: Argon2Parallelism = Argon2Parallelism(
+    passwordCostParam(
+      "rudder.argon2.parallelism",
+      PasswordEncoderType.ARGON2ID.defaultParallelism.toInt,
+      PasswordEncoderType.ARGON2ID.minimumParallelism.toInt
+    )
+  )
 
   val RUDDER_ARGON2_PARAMS = Argon2EncoderParams(
     RUDDER_ARGON2_MEMORY,

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/Argon2Test.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/Argon2Test.scala
@@ -38,6 +38,7 @@
 package bootstrap.liftweb
 
 import com.normation.rudder.users.*
+import java.nio.charset.StandardCharsets
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -50,27 +51,71 @@ class Argon2Test extends ZIOSpecDefault {
     suiteAll("Local password hash algorithms") {
       val encoderParams = Argon2EncoderParams(Argon2Memory(19), Argon2Iterations(3), Argon2Parallelism(1))
       val shadowString  = "$argon2id$v=19$m=19,t=3,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"
-      val hash          = Argon2Hash(
-        Argon2HashParams(encoderParams, salt = Chunk.fromArray("azertyuiop".getBytes)),
-        Chunk.fromArray("bobmaurane".getBytes)
+      val salt          = "azertyuiop".getBytes(StandardCharsets.UTF_8)
+      val tag           = "bobmaurane".getBytes(StandardCharsets.UTF_8)
+      val hash          = Argon2Hash(Argon2HashParams(encoderParams, salt = Chunk.fromArray(salt)), Chunk.fromArray(tag))
+      // parsing takes the sizes from the string being parsed, so they are the ones of this salt and tag,
+      // not the defaults carried by `encoderParams`
+      val parsedHash    = Argon2Hash(
+        Argon2HashParams(
+          encoderParams.copy(hashSize = Argon2HashSize(tag.length), saltSize = Argon2SaltSize(salt.length)),
+          salt = Chunk.fromArray(salt)
+        ),
+        Chunk.fromArray(tag)
       )
 
       test("stores as shadow string") {
         assert(Argon2Hash.toShadowString(hash))(equalTo(shadowString))
       }
       test("parses shadow string") {
-        val parsedHash = Argon2Hash.parseShadowString(shadowString)
-        assert(parsedHash)(isRight(equalTo(hash)))
+        assert(Argon2Hash.parseShadowString(shadowString))(isRight(equalTo(parsedHash)))
       }
-      test("fails to parse malformed shadow string") {
-        val invalid    = "$argon2id$invalid=3v=19$m=19,t=3,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"
-        val parsedHash = Argon2Hash.parseShadowString(invalid)
-        assert(parsedHash)(isLeft(equalTo(s"Could not parse argon2id hash string: $invalid")))
+      // the tag length has to be read from the stored hash: assuming our own default would make any
+      // hash created with another size impossible to verify
+      test("verifies a hash whose tag is not the default 32 bytes") {
+        val params = Argon2HashParams(
+          encoderParams.copy(hashSize = Argon2HashSize(64)),
+          salt = Chunk.fromArray("azertyuiop123456".getBytes(StandardCharsets.UTF_8))
+        )
+        val shadow = Argon2Hash.generate(params, "secret")
+        assert(Argon2Hash.checkPassword("secret", shadow))(isRight(isTrue)) &&
+        assert(Argon2Hash.checkPassword("wrong", shadow))(isRight(isFalse))
       }
-      test("fails to parse invalid shadow string") {
-        val invalid    = "$argon2id$v=19$m=19,t=3,p=1$invalid&base64$Ym9ibWF1cmFuZQ"
-        val parsedHash = Argon2Hash.parseShadowString(invalid)
-        assert(parsedHash)(isLeft(equalTo(s"Invalid password hash format $invalid: Illegal base64 character 26")))
+      // `generate` owns the password encoding, so pin it: the bytes it hashes must be the UTF-8 ones,
+      // not whatever the platform default charset would produce for a non-ASCII password.
+      test("hashes the password as UTF-8") {
+        val nonAscii   = "pâßwörd-日本語"
+        val hashParams = Argon2HashParams(
+          encoderParams,
+          salt = Chunk.fromArray("azertyuiop123456".getBytes(StandardCharsets.UTF_8))
+        )
+        val expected   = Argon2Hash.toShadowString(
+          Argon2Hash(
+            hashParams,
+            Chunk.fromArray(Argon2HashParams.computeHash(hashParams, nonAscii.getBytes(StandardCharsets.UTF_8)))
+          )
+        )
+        assert(Argon2Hash.generate(hashParams, nonAscii))(equalTo(expected)) &&
+        assert(Argon2Hash.checkPassword(nonAscii, expected))(isRight(isTrue))
+      }
+      // a password hash is a secret and these messages are logged, so they must not carry the value
+      test("fails to parse malformed shadow string, without echoing it") {
+        val invalid = "$argon2id$invalid=3v=19$m=19,t=3,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"
+        assert(Argon2Hash.parseShadowString(invalid))(isLeft(equalTo("Could not parse argon2id hash string")))
+      }
+      test("fails to parse invalid shadow string, without echoing it") {
+        val invalid = "$argon2id$v=19$m=19,t=3,p=1$invalid&base64$Ym9ibWF1cmFuZQ"
+        assert(Argon2Hash.parseShadowString(invalid))(
+          isLeft(equalTo("Invalid password hash format: Illegal base64 character 26"))
+        )
+      }
+      // these parse, but BouncyCastle refuses to compute with them: we must get a Left, not an exception
+      test("fails on a well-formed shadow string with cost parameters BouncyCastle refuses") {
+        val unusable = List(
+          "$argon2id$v=19$m=19,t=3,p=0$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ", // no lane
+          "$argon2id$v=19$m=19,t=0,p=1$YXplcnR5dWlvcA$Ym9ibWF1cmFuZQ"  // no iteration
+        )
+        assert(unusable.map(Argon2Hash.checkPassword("secret", _)))(forall(isLeft(anything)))
       }
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/29477

- Catch exceptions from bouncy castle (like bcrypt does)
- Read the tag and salt sizes from the stored hash instead of assuming the current defaults, so a hash created with other sizes can still be verified
- Enforce UTF-8 when encoding the password to avoid variability depending on the JVM config as it would break password matching
- Remove the actual hash value from error messages
- Enforce minimal values for all parameters