### PR TITLE
Fixes #29497: Filter input and search icon are misaligned in the Target rules tab

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
@@ -242,7 +242,7 @@ class RuleDisplayer(
                         <div>
                           <div class="filterTag">
                             <div class="input-group search-addon">
-                              <label for="searchStr" class="input-group-text search-addon"><span class="ion ion-search"></span></label>
+                              <label for="searchStr" class="input-group-text search-addon mb-0"><span class="ion ion-search"></span></label>
                               <input type="text" id="searchStr" class="input-sm form-control" placeholder="Filter" onkeyup="searchTargetRules(this)"/>
                             </div>
                             <!--


### PR DESCRIPTION
https://issues.rudder.io/issues/29497