### PR TITLE
Fixes #29503: Fix otp serialization and error notification

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/Totp.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/Totp.scala
@@ -38,7 +38,7 @@ package com.normation.rudder.users
 import com.normation.errors.*
 import com.normation.utils.DateFormaterService
 import enumeratum.*
-import enumeratum.EnumEntry.Lowercase
+import enumeratum.EnumEntry.LowerCamelcase
 import java.time.Instant
 import zio.*
 import zio.json.enumeratum.EnumCodec
@@ -89,7 +89,7 @@ object TotpEnforcementLevel {
  * Per-user enrollment state.
  * This is the one exposed where we need to know if user OTP is defined or not yet
  */
-sealed trait TotpUserStatus extends EnumEntry with Lowercase
+sealed trait TotpUserStatus extends EnumEntry with LowerCamelcase
 object TotpUserStatus       extends Enum[TotpUserStatus] with EnumCodec[TotpUserStatus] {
   case object EnrollmentNeeded    extends TotpUserStatus
   // derived from global enforcement level

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -1847,14 +1847,14 @@ sealed trait OtpApi extends EnumEntry with EndpointSchema with InternalApi with 
 }
 object OtpApi       extends Enum[OtpApi] with ApiModuleProvider[OtpApi]                   {
 
-  case object OtpStatus extends OtpApi with ZeroParam with StartsAtVersion24 with SortIndex {
+  case object GetOtpStatus extends OtpApi with ZeroParam with StartsAtVersion24 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get OTP status for current user"
     val (action, path) = GET / "otp" / "status"
     val authz: List[AuthorizationType] = Nil
   }
 
-  case object OtpGenerate extends OtpApi with ZeroParam with StartsAtVersion24 with SortIndex {
+  case object GenerateOtp extends OtpApi with ZeroParam with StartsAtVersion24 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Generate a new OTP secret for current user"
     val (action, path) = POST / "otp" / "generate"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/OtpApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/OtpApi.scala
@@ -55,13 +55,13 @@ class OtpApi(
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map {
-      case API.OtpStatus   => OtpStatus
-      case API.OtpGenerate => OtpGenerate
+      case API.GetOtpStatus => GetOtpStatus
+      case API.GenerateOtp  => GenerateOtp
     }
   }
 
-  object OtpStatus extends LiftApiModule0 {
-    val schema: API.OtpStatus.type = API.OtpStatus
+  object GetOtpStatus extends LiftApiModule0 {
+    val schema: API.GetOtpStatus.type = API.GetOtpStatus
 
     override def process0(
         version:    ApiVersion,
@@ -76,8 +76,8 @@ class OtpApi(
     }
   }
 
-  object OtpGenerate extends LiftApiModule0 {
-    val schema: API.OtpGenerate.type = API.OtpGenerate
+  object GenerateOtp extends LiftApiModule0 {
+    val schema: API.GenerateOtp.type = API.GenerateOtp
 
     override def process0(
         version:    ApiVersion,

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/TotpService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/TotpService.scala
@@ -96,6 +96,17 @@ case class TotpSecretData(
     value: TotpSecret,
     uri:   URI
 ) derives JsonEncoder
+object TotpSecretData {
+  def make(userId: UserId, secret: TotpSecret): IOResult[TotpSecretData] = {
+    val uri: IOResult[URI] = {
+      val query = s"secret=${secret.exposeSecret()}&issuer=Rudder"
+      // this URI constructor handles encoding
+      IOResult.attempt(URI("otpauth", "totp", s"/Rudder:${userId.value}", query, null))
+    }
+
+    uri.map(TotpSecretData(secret, _))
+  }
+}
 
 case class TotpSecretContainer(
     secret: TotpSecretData
@@ -132,9 +143,9 @@ class InMemoryVerificationTotpService(
       _      <- validator.validateUserCanCreateTotp(userId)
       secret <- generator.generate
       _      <- in.update(_.updated(userId, secret)) // just forget previously generated secret
-      uri    <- totpUri(userId.value, secret)
+      res    <- TotpSecretData.make(userId, secret)
     } yield {
-      TotpSecretData(secret, uri)
+      res
     }
   }
 
@@ -190,12 +201,6 @@ class InMemoryVerificationTotpService(
       .getByUserId(userId)
       .map(_.as(TotpUserStatus.Enrolled).getOrElse(TotpUserStatus.default(globalLevel)))
   }
-}
-
-private def totpUri(userId: String, secret: TotpSecret): IOResult[URI] = {
-  val query = s"secret=${secret.exposeSecret()}&issuer=Rudder"
-  // this URI constructor handles encoding
-  IOResult.attempt(URI("otpauth", "totp", s"/Rudder:${userId}", query, null))
 }
 
 object OtpJavaTotpService {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_otp.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_otp.yml
@@ -1,0 +1,28 @@
+description: Get OTP status for current user
+method: GET
+url: /secure/api/otp/status
+response:
+  code: 200
+  content: >-
+    {
+      "action":"getOtpStatus",
+      "result":"success",
+      "data":"enrollmentNotNeeded"
+    }
+---
+description: Generate a new OTP secret for current user
+method: POST
+url: /secure/api/otp/generate
+response:
+  code: 200
+  content: >-
+    {
+      "action":"generateOtp",
+      "result":"success",
+      "data":{
+        "secret":{
+          "value":"secret",
+          "uri":"otpauth://totp/Rudder:test-user?secret=secret&issuer=Rudder"
+        }
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -1084,11 +1084,11 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     override def getAllUserStatus(): IOResult[Map[UserId, TotpUserStatus]] = Map.empty.succeed
     override def getUserStatus(userId: UserId): IOResult[TotpUserStatus] = TotpUserStatus.EnrollmentNotNeeded.succeed
     override def getGlobalStatus(): IOResult[Boolean] = false.succeed
+    override def generateUserSecret(userId: UserId): IOResult[TotpSecretData] = TotpSecretData.make(userId, TotpSecret("secret"))
 
-    override def generateUserSecret(userId: UserId): IOResult[TotpSecretData] = ???
-    override def verifyGenerated(userId:    UserId, code: String): IOResult[Totp] = ???
-    override def reset(userId:              UserId): IOResult[Unit] = ???
-    override def verify(userId:             UserId, code: String): IOResult[Unit] = ???
+    override def verifyGenerated(userId: UserId, code: String): IOResult[Totp] = ???
+    override def reset(userId:           UserId): IOResult[Unit] = ???
+    override def verify(userId:          UserId, code: String): IOResult[Unit] = ???
   }
 
   val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema & SortIndex]] = List(
@@ -1159,7 +1159,8 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     new PluginInternalApi(pluginsSystemService),
     new InventoryApi(mockInventoryFileWatcher, mockInventoryDir),
     new QuicksearchApi(quickSearchService, linkUtil),
-    new RecentChangesAPI(fakeNodeChangesService, mockRules.ruleRepo)
+    new RecentChangesAPI(fakeNodeChangesService, mockRules.ruleRepo),
+    new OtpApi(otpService)
   )
 
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, userService)

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/otp.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/otp.html
@@ -16,6 +16,7 @@
 
     <!-- ELM -->
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/jquery.min.js"></script>
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-main.css" />
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-notifications.css" />
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-notifications.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-otp.js"></script>


### PR DESCRIPTION
https://issues.rudder.io/issues/29503

Elm app was expecting camelCase, the culprit was the enum which was lowercase.

* Add API tests which cover the default enum case serialization
* refactor a bit to ease testing and be consistent in API responses
* CSS fix: just add `rudder-main.css` for the error notification