### PR TITLE
Fixes #29514: Use dedicated event log endpoint in rules recent activity tab

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
@@ -59,6 +59,7 @@ import doobie.free.connection
 import doobie.free.preparedstatement
 import doobie.implicits.*
 import doobie.postgres.implicits.*
+import doobie.util.fragment
 import doobie.util.fragments
 import doobie.util.log.LoggingInfo
 import doobie.util.log.Parameters.NonBatch

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -265,6 +265,13 @@ object EventLogApi extends Enum[EventLogApi] with ApiModuleProvider[EventLogApi]
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
+  case object GetRuleEventLogs extends EventLogApi with InternalApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get rule-related event logs based on filters"
+    val (action, path) = POST / "eventlog" / "rules"
+    val authz: List[AuthorizationType] = AuthorizationType.Rule.Read :: Nil
+  }
+
   def endpoints: List[EventLogApi] = values.toList.sortBy(_.z)
 
   def values = findValues

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -40,6 +40,9 @@ package com.normation.rudder.rest.internal
 import com.normation.errors.*
 import com.normation.eventlog.*
 import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.domain.eventlog.AddRuleEventType
+import com.normation.rudder.domain.eventlog.DeleteRuleEventType
+import com.normation.rudder.domain.eventlog.ModifyRuleEventType
 import com.normation.rudder.domain.logger.EventLogsLoggerPure
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.repository.EventLogRepository
@@ -57,6 +60,7 @@ import com.normation.zio.UnsafeRun
 import io.scalaland.chimney.syntax.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
+import zio.NonEmptyChunk
 import zio.ZIO
 import zio.syntax.*
 
@@ -76,6 +80,7 @@ class EventLogAPI(
       case EventLogApi.GetEventLogs       => GetEventLogs
       case EventLogApi.GetEventLogDetails => GetEventLogDetails
       case EventLogApi.RollbackEventLog   => RollbackEventLog
+      case EventLogApi.GetRuleEventLogs   => GetRuleEventLogs
     }
   }
 
@@ -178,6 +183,55 @@ class EventLogAPI(
           params,
           schema,
           None
+        )
+    }
+  }
+
+  object GetRuleEventLogs extends LiftApiModule0 {
+    val schema: EventLogApi.GetRuleEventLogs.type = EventLogApi.GetRuleEventLogs
+
+    def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      implicit val prettify: Boolean      = params.prettify
+      implicit val qc:       QueryContext = authzToken.qc
+
+      (for {
+        restFilter  <- req.fromJson[RestEventLogFilter].toIO
+        // the value of the typeFilter field in the query is unused
+        queryFilter  = restFilter.toEventLogRequest
+        // typeFilter is replaced with the list of eventlog types that concern rules
+        filter       = queryFilter.copy(typeFilter = {
+                         Some(
+                           EventLogRequest.TypeFilter(
+                             include = Some(NonEmptyChunk(AddRuleEventType, DeleteRuleEventType, ModifyRuleEventType)),
+                             exclude = None
+                           )
+                         )
+                       })
+        totalRecord <- coreService.getUserEventLogCount(filter = None)
+        totalFilter <- coreService.getUserEventLogCount(filter = Some(filter))
+        events      <- coreService.getUserEventLogs(filter = Some(filter))
+        res          = EventLogSlice(events, totalRecord, totalFilter)
+      } yield {
+        (restFilter.draw, res)
+      }).chainError("Error when fetching event logs")
+        .either
+        .runNow
+        .fold(
+          err => RudderJsonResponse.generic.internalError(RestEventLogError(err.fullMsg)),
+          {
+            case (draw, EventLogSlice(events, totalRecord, totalFilter)) =>
+              RudderJsonResponse.LiftJsonResponse(
+                RestEventLogSuccess(draw, totalRecord, totalFilter, events.map(_.transformInto[RestEventLog])),
+                params.prettify,
+                200
+              )
+          }
         )
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
@@ -8,14 +8,22 @@ import Http.Detailed as Detailed
 import Url.Builder exposing (QueryParameter)
 
 
-getActivities : BodyParameters -> ContextPath -> Cmd ActivityMsg
-getActivities bodyParameters (ContextPath contextPath) =
+getActivities : BodyParameters -> ContextPath -> Maybe String -> Cmd ActivityMsg
+getActivities bodyParameters (ContextPath contextPath) resourceTypeOpt =
     let
+        url =
+            case resourceTypeOpt of
+                Just resourceType ->
+                    contextPath :: "secure" :: "api" :: "eventlog" :: [ resourceType ]
+
+                Nothing ->
+                    contextPath :: "secure" :: "api" :: [ "eventlog" ]
+
         req =
             request
                 { method = "POST"
                 , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
-                , url = Url.Builder.relative (contextPath :: "secure" :: "api" :: [ "eventlog" ]) []
+                , url = Url.Builder.relative url []
                 , body = encodeRestEventLogFilter bodyParameters |> jsonBody
                 , expect = Detailed.expectJson GetActivities decodeGetActivities
                 , timeout = Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard.elm
@@ -84,7 +84,7 @@ init flags =
 
         initActions : List (Cmd Msg)
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initModel.contextPath))
+            [ Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initModel.contextPath) Nothing)
             , initTooltips ""
             , Task.perform Tick Time.now
             ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
@@ -72,7 +72,7 @@ init flags =
             }
 
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath) ]
+            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath Nothing) ]
     in
     ( initModel, Cmd.batch initActions )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -199,7 +199,7 @@ mainInit initValues =
         , getTechniquesCategories model
         , getDirectives model
         , getPolicyMode model
-        , Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initValues.contextPath))
+        , Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initValues.contextPath) Nothing)
         ]
     )
 
@@ -447,10 +447,10 @@ update msg model =
                         ( { model | mode = Introduction }, initInputs "" )
 
                     else
-                        ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath)) )
+                        ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) Nothing) )
 
                 _ ->
-                    ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath)) )
+                    ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) Nothing) )
 
         SelectDraft id ->
             let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GlobalPropertiesRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GlobalPropertiesRecentActivity.elm
@@ -75,7 +75,7 @@ init flags =
             }
 
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath) ]
+            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath Nothing) ]
     in
     ( initModel, Cmd.batch initActions )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
@@ -106,7 +106,7 @@ init flags =
             }
 
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath) ]
+            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath Nothing) ]
     in
     ( initModel, Cmd.batch initActions )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -521,7 +521,7 @@ update msg model =
                             ContextPath model.contextPath
 
                         callGetActivities =
-                            getActivities (bodyParameters (Just details.rule.id.value)) contextPath
+                            getActivities (bodyParameters (Just details.rule.id.value)) contextPath (Just "rules")
                     in
                     ( { model | mode = RuleForm details }
                     , Cmd.batch


### PR DESCRIPTION
https://issues.rudder.io/issues/29514

This PR aims to use a new `POST eventlog/rules` endpoint in the rules' recent activity page.
This endpoint is identical to `POST eventlog`, except `POST eventlog/rules` only returns rule-related event logs, which removes the need for the event logs to be filtered by type in the elm app.
in addition, the rules' recent activity page can now be viewed so long as the user has the `rule_read` authorization, while it could previously only be viewed by `administrator`s