### PR TITLE
Fixes #29501: The rules' recent changes tab may contain an empty "recent changes" dropdown

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRepairedReports.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRepairedReports.elm
@@ -1,6 +1,6 @@
 module Rules.ViewRepairedReports exposing (..)
 
-import Dict
+import Dict exposing (Dict)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -27,9 +27,9 @@ columns model =
         :: []
 
 
-options : RuleId -> Model -> List (Html Msg)
-options ruleId model =
-    List.reverse <| List.indexedMap (\id c -> option [ value (String.fromInt id) ] [ text (showChanges c) ]) <| Maybe.withDefault [] (Dict.get ruleId.value model.changes)
+options : List Changes -> List (Html Msg)
+options changes =
+    List.reverse <| List.indexedMap (\id c -> option [ value (String.fromInt id) ] [ text (showChanges c) ]) <| changes
 
 
 technicalLogsTab : Model -> RuleDetails -> Html Msg
@@ -37,10 +37,22 @@ technicalLogsTab model details =
     let
         col =
             columns model
+
+        tableTitle =
+            case Dict.get details.rule.id.value model.changes of
+                Just changes ->
+                    div [ class "table-title" ]
+                        [ div [ class "input-group w-auto" ]
+                            [ label [ class "input-group-text", for "dateRange" ] [ i [ class "fa fa-calendar" ] [] ]
+                            , select [ id "dateRange", onInput (\s -> GetRepairedReport details.rule.id (Maybe.withDefault 0 (String.toInt s))), class "form-select" ] (options changes)
+                            ]
+                        ]
+
+                Nothing ->
+                    text ""
     in
     div [ class "tab-table-content" ]
-        [ div [ class "table-title" ]
-            [ h4 [] [ text "Recent changes ", select [ onInput (\s -> GetRepairedReport details.rule.id (Maybe.withDefault 0 (String.toInt s))), class "form-control" ] (options details.rule.id model) ] ]
+        [ tableTitle
         , div [ class "table-header" ]
             [ input
                 [ type_ "text"


### PR DESCRIPTION
https://issues.rudder.io/issues/29501

The form is hidden if there are no recent changes, and its appearance has been improved:

<img width="1137" height="219" alt="Capture d’écran du 2026-08-13 11-31-06" src="https://github.com/user-attachments/assets/3de4db1a-8307-40a9-b886-ac54ca6355c7" />
