### PR TITLE
Fixes #29507: changelog includes the hash of the token of API account

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountDiff.scala
@@ -45,9 +45,9 @@ import org.joda.time.DateTime
 
 sealed trait ApiAccountDiff
 
-final case class AddApiAccountDiff(apiAccount: ApiAccount) extends ApiAccountDiff
+final case class AddApiAccountDiff(apiAccount: ApiAccountNoToken) extends ApiAccountDiff
 
-final case class DeleteApiAccountDiff(apiAccount: ApiAccount) extends ApiAccountDiff
+final case class DeleteApiAccountDiff(apiAccount: ApiAccountNoToken) extends ApiAccountDiff
 
 final case class ModifyApiAccountDiff(
     id:                     ApiAccountId,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
@@ -55,6 +55,7 @@ import com.normation.rudder.repository.ldap.LDAPDiffMapper
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.services.user.PersonIdentService
 import com.normation.zio.*
+import io.scalaland.chimney.syntax.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import zio.*
@@ -271,7 +272,7 @@ final class WoLDAPApiAccountRepository(
                       }
       oldAccount   <- mapper.entry2ApiAccount(entry).toIO
       deleted      <- ldap.delete(rudderDit.API_ACCOUNTS.API_ACCOUNT.dn(id))
-      diff          = DeleteApiAccountDiff(oldAccount)
+      diff          = DeleteApiAccountDiff(oldAccount.transformInto[ApiAccountNoToken])
       loggedAction <- actionLogger.saveDeleteApiAccount(modId, principal = actor, deleteDiff = diff, None)
     } yield {
       id

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -42,6 +42,7 @@ import com.normation.errors.Inconsistency
 import com.normation.errors.PureResult
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import enumeratum.*
+import io.scalaland.chimney.Transformer
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import org.bouncycastle.util.encoders.Hex
@@ -486,6 +487,26 @@ final case class ApiAccount(
   }
 }
 
+object ApiAccount {
+  given transformer: Transformer[ApiAccount, ApiAccountNoToken] = {
+    Transformer
+      .define[ApiAccount, ApiAccountNoToken]
+      .buildTransformer
+  }
+}
+
+case class ApiAccountNoToken(
+    id:                  ApiAccountId,
+    kind:                ApiAccountKind, // Authentication token. It is a mandatory value, and can't be ""
+    // If a token should be revoked, use isEnabled = false.
+    name:                ApiAccountName, // used in event log to know who did actions.
+    description:         String,
+    isEnabled:           Boolean,
+    creationDate:        DateTime,
+    tokenGenerationDate: DateTime,
+    tenants:             NodeSecurityContext
+) {}
+
 /**
  * An API principal, containing the secret, to be used just after creation, and never stored.
  */
@@ -500,18 +521,4 @@ final case class NewApiAccount(
     creationDate:        DateTime,
     tokenGenerationDate: DateTime,
     tenants:             NodeSecurityContext
-) {
-  def toApiAccount(): ApiAccount = {
-    ApiAccount(
-      id,
-      kind,
-      name,
-      token.map(_.toHash()),
-      description,
-      isEnabled,
-      creationDate,
-      tokenGenerationDate,
-      tenants
-    )
-  }
-}
+) {}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -71,6 +71,7 @@ import com.unboundid.ldif.LDIFAddChangeRecord
 import com.unboundid.ldif.LDIFChangeRecord
 import com.unboundid.ldif.LDIFModifyChangeRecord
 import com.unboundid.ldif.LDIFModifyDNChangeRecord
+import io.scalaland.chimney.syntax.*
 import net.liftweb.common.*
 import scala.util.control.NonFatal
 
@@ -568,7 +569,7 @@ class LDAPDiffMapper(
           val e = LDAPEntry(add.toAddRequest().toEntry)
           for {
             param <- mapper.entry2ApiAccount(e)
-          } yield AddApiAccountDiff(param)
+          } yield AddApiAccountDiff(param.transformInto[ApiAccountNoToken])
         case _ => Left(Err.UnexpectedObject(s"Bad change record type for requested action 'Add Api Account': ${change}"))
       }
     } else {
@@ -597,7 +598,14 @@ class LDAPDiffMapper(
                                 }
                               case A_API_TOKEN                   =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>
-                                  d.copy(modToken = Some(SimpleDiff(oldAccount.token.flatMap(_.exposeHash()).getOrElse(""), value)))
+                                  d.copy(modToken = {
+                                    Some(
+                                      SimpleDiff(
+                                        (oldAccount.token.flatMap(_.exposeHash()).getOrElse("").substring(0, 6) ++ "******"),
+                                        (value.substring(0, 6) ++ "******")
+                                      )
+                                    )
+                                  })
                                 }
                               case A_DESCRIPTION                 =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -867,7 +867,7 @@ class EventLogDetailsServiceImpl(
   }
 
   // API Account
-  def getApiAccountFromXML(xml: NodeSeq, changeType: String): Box[ApiAccount] = {
+  def getApiAccountFromXML(xml: NodeSeq, changeType: String): Box[ApiAccountNoToken] = {
     for {
       entry           <- getEntryContent(xml)
       account         <- (entry \ XML_TAG_API_ACCOUNT).headOption ?~! (s"Entry type is not an API Account: ${entry}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -945,6 +945,7 @@ class EventLogFactoryImpl(
       scala.xml.Utility.trim(<apiAccount changeType="modify" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
         <id>{diff.id.value}</id>{
         diff.modName.map(x => SimpleDiff.stringToXml(<name/>, x)) ++
+        // fixme
         diff.modToken.map(x => SimpleDiff.stringToXml(<token/>, x)) ++
         diff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x)) ++
         diff.modIsEnabled.map(x => SimpleDiff.booleanToXml(<enabled/>, x)) ++

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -946,7 +946,20 @@ class EventLogFactoryImpl(
         <id>{diff.id.value}</id>{
         diff.modName.map(x => SimpleDiff.stringToXml(<name/>, x)) ++
         // fixme
-        diff.modToken.map(x => SimpleDiff.stringToXml(<token/>, x)) ++
+        // diff.modToken.map(x => SimpleDiff.stringToXml(<token/>, x)) ++
+        (diff.modToken.map {
+          case SimpleDiff(oldVal, newVal) =>
+            SimpleDiff
+              .stringToXml(<token/>, SimpleDiff((oldVal.substring(0, 7) ++ "******"), (newVal.substring(0, 7) ++ "******")))
+        }) ++
+        /*
+        (diff.modToken match {
+          case Some(_) =>
+            <token>Token value regenerated</token>
+          case None    =>
+            <token>Token value unchanged</token>
+        }) ++
+         */
         diff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x)) ++
         diff.modIsEnabled.map(x => SimpleDiff.booleanToXml(<enabled/>, x)) ++
         diff.modTokenGenerationDate.map(x =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -945,32 +945,16 @@ class EventLogFactoryImpl(
       scala.xml.Utility.trim(<apiAccount changeType="modify" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
         <id>{diff.id.value}</id>{
         diff.modName.map(x => SimpleDiff.stringToXml(<name/>, x)) ++
-        // fixme
-        // diff.modToken.map(x => SimpleDiff.stringToXml(<token/>, x)) ++
-        (diff.modToken.map {
-          case SimpleDiff(oldVal, newVal) =>
-            SimpleDiff
-              .stringToXml(<token/>, SimpleDiff((oldVal.substring(0, 7) ++ "******"), (newVal.substring(0, 7) ++ "******")))
-        }) ++
-        /*
-        (diff.modToken match {
-          case Some(_) =>
-            <token>Token value regenerated</token>
-          case None    =>
-            <token>Token value unchanged</token>
-        }) ++
-         */
+        diff.modToken.map(x => SimpleDiff.stringToXml(<token/>, x)) ++
         diff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x)) ++
         diff.modIsEnabled.map(x => SimpleDiff.booleanToXml(<enabled/>, x)) ++
         diff.modTokenGenerationDate.map(x =>
           SimpleDiff.toXml[DateTime](<tokenGenerationDate/>, x)(x => Text(x.toString(ISODateTimeFormat.dateTime())))
         ) ++
         diff.modExpirationDate.map(x => {
-          SimpleDiff.toXml[Option[DateTime]](<expirationDate/>, x) { x =>
-            x match {
-              case None    => NodeSeq.Empty
-              case Some(d) => Text(d.toString(ISODateTimeFormat.dateTime()))
-            }
+          SimpleDiff.toXml[Option[DateTime]](<expirationDate/>, x) {
+            case None    => NodeSeq.Empty
+            case Some(d) => Text(d.toString(ISODateTimeFormat.dateTime()))
           }
         }) ++
         diff.modAccountKind.map(x => SimpleDiff.stringToXml(<accountKind/>, x)) ++

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisation.scala
@@ -371,7 +371,6 @@ trait APIAccountSerialisation {
      <apiAccount fileFormat="4">
        <id>{account.id.value}</id>
        <name>{account.name.value}</name>
-       <token>{account.token.value}</token>
        <description>{account.description}</description>
        <isEnabled>{account.isEnabled}</isEnabled>
        <creationDate>{account.creationDate.toString(ISODateTimeFormat.dateTime)}</creationDate>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisation.scala
@@ -39,7 +39,7 @@ package com.normation.rudder.services.marshalling
 
 import com.normation.cfclerk.domain.SectionSpec
 import com.normation.cfclerk.domain.TechniqueName
-import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.batch.CurrentDeploymentStatus
 import com.normation.rudder.domain.appconfig.RudderWebProperty
 import com.normation.rudder.domain.nodes.NodeGroup
@@ -377,7 +377,7 @@ trait APIAccountSerialisation {
        <tokenGenerationDate>{account.tokenGenerationDate.toString(ISODateTimeFormat.dateTime)}</tokenGenerationDate>
      </apiAccount>
    */
-  def serialise(account: ApiAccount): Elem
+  def serialise(account: ApiAccountNoToken): Elem
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -533,7 +533,6 @@ class APIAccountSerialisationImpl(xmlVersion: String) extends APIAccountSerialis
       (
         <id>{account.id.value}</id>
        <name>{account.name.value}</name>
-       <token>{account.token.flatMap(_.exposeHash()).getOrElse("")}</token>
        <description>{account.description}</description>
        <isEnabled>{account.isEnabled}</isEnabled>
        <creationDate>{account.creationDate.toString(ISODateTimeFormat.dateTime)}</creationDate>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -43,8 +43,8 @@ import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.cfclerk.xmlwriters.SectionSpecWriter
-import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.api.ApiAccountKind
+import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.api.ApiAuthorization
 import com.normation.rudder.batch.CurrentDeploymentStatus
 import com.normation.rudder.batch.ErrorStatus

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -43,7 +43,7 @@ import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.cfclerk.xmlwriters.SectionSpecWriter
-import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.api.ApiAccountKind
 import com.normation.rudder.api.ApiAuthorization
 import com.normation.rudder.batch.CurrentDeploymentStatus
@@ -506,7 +506,7 @@ class ChangeRequestChangesSerialisationImpl(
  */
 class APIAccountSerialisationImpl(xmlVersion: String) extends APIAccountSerialisation {
 
-  def serialise(account: ApiAccount): Elem = {
+  def serialise(account: ApiAccountNoToken): Elem = {
     val kind = account.kind match {
       case ApiAccountKind.User | ApiAccountKind.System =>
         <kind>{account.kind.kind.name}</kind>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
@@ -315,6 +315,7 @@ trait ApiAccountUnserialisation {
      <apiAccount fileFormat="4">
        <id>{account.id.value}</id>
        <name>{account.name.value}</name>
+       <token>{account.token.value}</token>
        <description>{account.description}</description>
        <isEnabled>{account.isEnabled}</isEnabled>
        <creationDate>{account.creationDate.toString(ISODateTimeFormat.dateTime)}</creationDate>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
@@ -315,7 +315,6 @@ trait ApiAccountUnserialisation {
      <apiAccount fileFormat="4">
        <id>{account.id.value}</id>
        <name>{account.name.value}</name>
-       <token>{account.token.value}</token>
        <description>{account.description}</description>
        <isEnabled>{account.isEnabled}</isEnabled>
        <creationDate>{account.creationDate.toString(ISODateTimeFormat.dateTime)}</creationDate>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
@@ -39,7 +39,7 @@ package com.normation.rudder.services.marshalling
 
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.errors.PureResult
-import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.batch.CurrentDeploymentStatus
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategory
@@ -321,7 +321,7 @@ trait ApiAccountUnserialisation {
        <tokenGenerationDate>{account.tokenGenerationDate.toString(ISODateTimeFormat.dateTime)}</tokenGenerationDate>
      </apiAccount>
    */
-  def unserialise(xml: XNode): Box[ApiAccount]
+  def unserialise(xml: XNode): Box[ApiAccountNoToken]
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -838,6 +838,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
       _              <- TestFileFormat(apiAccount)
       id             <- (apiAccount \ "id").headOption.map(_.text) ?~! (s"Missing attribute 'id' in entry type API Account : ${entry}")
       name           <- (apiAccount \ "name").headOption.map(_.text) ?~! (s"Missing attribute 'name' in entry type API Account : ${entry}")
+      // fixme
       token          <-
         (apiAccount \ "token").headOption.map(_.text) ?~! (s"Missing attribute 'token' in entry type API Account : ${entry}")
       description    <- (apiAccount \ "description").headOption.map(
@@ -890,7 +891,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
         ApiAccountId(id),
         kind,
         ApiAccountName(name),
-        Some(ApiTokenHash.fromHashValue(token)),
+        None,
         description,
         isEnabled,
         creationDate,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -838,6 +838,8 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
       _              <- TestFileFormat(apiAccount)
       id             <- (apiAccount \ "id").headOption.map(_.text) ?~! (s"Missing attribute 'id' in entry type API Account : ${entry}")
       name           <- (apiAccount \ "name").headOption.map(_.text) ?~! (s"Missing attribute 'name' in entry type API Account : ${entry}")
+      token          <-
+        (apiAccount \ "token").headOption.map(_.text) ?~! (s"Missing attribute 'token' in entry type API Account : ${entry}")
       description    <- (apiAccount \ "description").headOption.map(
                           _.text
                         ) ?~! (s"Missing attribute 'description' in entry type API Account : ${entry}")
@@ -888,7 +890,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
         ApiAccountId(id),
         kind,
         ApiAccountName(name),
-        None,
+        Some(ApiTokenHash.fromHashValue(token)),
         description,
         isEnabled,
         creationDate,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -838,9 +838,6 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
       _              <- TestFileFormat(apiAccount)
       id             <- (apiAccount \ "id").headOption.map(_.text) ?~! (s"Missing attribute 'id' in entry type API Account : ${entry}")
       name           <- (apiAccount \ "name").headOption.map(_.text) ?~! (s"Missing attribute 'name' in entry type API Account : ${entry}")
-      // fixme
-      token          <-
-        (apiAccount \ "token").headOption.map(_.text) ?~! (s"Missing attribute 'token' in entry type API Account : ${entry}")
       description    <- (apiAccount \ "description").headOption.map(
                           _.text
                         ) ?~! (s"Missing attribute 'description' in entry type API Account : ${entry}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -838,8 +838,6 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
       _              <- TestFileFormat(apiAccount)
       id             <- (apiAccount \ "id").headOption.map(_.text) ?~! (s"Missing attribute 'id' in entry type API Account : ${entry}")
       name           <- (apiAccount \ "name").headOption.map(_.text) ?~! (s"Missing attribute 'name' in entry type API Account : ${entry}")
-      token          <-
-        (apiAccount \ "token").headOption.map(_.text) ?~! (s"Missing attribute 'token' in entry type API Account : ${entry}")
       description    <- (apiAccount \ "description").headOption.map(
                           _.text
                         ) ?~! (s"Missing attribute 'description' in entry type API Account : ${entry}")
@@ -890,7 +888,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
         ApiAccountId(id),
         kind,
         ApiAccountName(name),
-        Some(ApiTokenHash.fromHashValue(token)),
+        None,
         description,
         isEnabled,
         creationDate,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -829,7 +829,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
     })
   }
 
-  def unserialise(entry: XNode): Box[ApiAccount] = {
+  def unserialise(entry: XNode): Box[ApiAccountNoToken] = {
     for {
       apiAccount     <- {
         if (entry.label == XML_TAG_API_ACCOUNT) Full(entry)
@@ -884,11 +884,10 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
         case ApiAccountType.PublicApi => ApiAccountKind.PublicApi(authz, expirationDate)
       }
 
-      ApiAccount(
+      ApiAccountNoToken(
         ApiAccountId(id),
         kind,
         ApiAccountName(name),
-        None,
         description,
         isEnabled,
         creationDate,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
@@ -16,7 +16,7 @@ import com.normation.cfclerk.xmlparsers.VariableSpecParser
 import com.normation.cfclerk.xmlwriters.SectionSpecWriterImpl
 import com.normation.eventlog.EventActor
 import com.normation.rudder.api.AclPath
-import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.api.ApiAccountId
 import com.normation.rudder.api.ApiAccountKind
 import com.normation.rudder.api.ApiAccountName
@@ -342,16 +342,15 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
 
     val actual = new ApiAccountUnserialisationImpl().unserialise(serialized)
 
-    actual.map(_.copy(token = None)) must beEqualTo(
+    actual must beEqualTo(
       Full(
-        ApiAccount(
+        ApiAccountNoToken(
           id = ApiAccountId("c331c718-db0e-429e-b800-20b055ca6a67"),
           kind = ApiAccountKind.PublicApi(
             authorizations = ApiAuthorization.RW,
             expirationDate = Some(ISODateTimeFormat.dateTime.parseDateTime("2025-06-06T15:59:35.297+02:00"))
           ),
           name = ApiAccountName("Test account with some acl scala 3"),
-          token = None,
           description = "",
           isEnabled = true,
           creationDate = ISODateTimeFormat.dateTime.parseDateTime("2025-05-06T13:59:59.613+02:00"),
@@ -387,9 +386,9 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
 
     val actual = new ApiAccountUnserialisationImpl().unserialise(serialized)
 
-    actual.map(_.copy(token = None)) must beEqualTo(
+    actual must beEqualTo(
       Full(
-        ApiAccount(
+        ApiAccountNoToken(
           id = ApiAccountId("c331c718-db0e-429e-b800-20b055ca6a67"),
           kind = ApiAccountKind.PublicApi(
             authorizations = ApiAuthorization.ACL(
@@ -405,7 +404,6 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
             expirationDate = Some(ISODateTimeFormat.dateTime.parseDateTime("2025-06-06T15:59:35.297+02:00"))
           ),
           name = ApiAccountName("Test account with some acl scala 3"),
-          token = None,
           description = "",
           isEnabled = true,
           creationDate = ISODateTimeFormat.dateTime.parseDateTime("2025-05-06T13:59:59.613+02:00"),
@@ -441,9 +439,9 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
 
     val actual = new ApiAccountUnserialisationImpl().unserialise(serialized)
 
-    actual.map(_.copy(token = None)) must beEqualTo(
+    actual must beEqualTo(
       Full(
-        ApiAccount(
+        ApiAccountNoToken(
           id = ApiAccountId("c331c718-db0e-429e-b800-20b055ca6a67"),
           kind = ApiAccountKind.PublicApi(
             authorizations = ApiAuthorization.ACL(
@@ -461,7 +459,6 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
             expirationDate = Some(ISODateTimeFormat.dateTime.parseDateTime("2025-06-06T15:59:35.297+02:00"))
           ),
           name = ApiAccountName("Test account with some acl scala 3"),
-          token = None,
           description = "",
           isEnabled = true,
           creationDate = ISODateTimeFormat.dateTime.parseDateTime("2025-05-06T13:59:59.613+02:00"),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
@@ -16,10 +16,10 @@ import com.normation.cfclerk.xmlparsers.VariableSpecParser
 import com.normation.cfclerk.xmlwriters.SectionSpecWriterImpl
 import com.normation.eventlog.EventActor
 import com.normation.rudder.api.AclPath
-import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.api.ApiAccountId
 import com.normation.rudder.api.ApiAccountKind
 import com.normation.rudder.api.ApiAccountName
+import com.normation.rudder.api.ApiAccountNoToken
 import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.api.ApiAuthorization
 import com.normation.rudder.api.HttpAction

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -260,8 +260,6 @@ class EventLogDetailsGenerator(
     }
   }
 
-  // todo start
-
   def displayDetails(event: EventLog, changeRequestId: Option[ChangeRequestId])(implicit qc: QueryContext): NodeSeq = {
 
     (for {
@@ -1155,8 +1153,6 @@ class EventLogDetailsGenerator(
     }).merge.runNow
 
   }
-
-  // todo end
 
   def nodePropertiesDiff(event: EventLog): Option[SimpleDiff[List[NodeProperty]]] = {
     event match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -260,6 +260,8 @@ class EventLogDetailsGenerator(
     }
   }
 
+  // todo start
+
   def displayDetails(event: EventLog, changeRequestId: Option[ChangeRequestId])(implicit qc: QueryContext): NodeSeq = {
 
     (for {
@@ -944,7 +946,14 @@ class EventLogDetailsGenerator(
                     </ul>{
                     (
                       "#name" #> mapSimpleDiff(apiAccountDiff.modName) &
-                      "#token" #> mapSimpleDiff(apiAccountDiff.modToken) &
+                      "#token" #> {
+                        apiAccountDiff.modToken match {
+                          case Some(_) =>
+                            <ul class="evlogviewpad"><li><b>Token regenerated</b></li></ul>
+                          case None    =>
+                            <ul class="evlogviewpad"><li><b>Token unchanged</b></li></ul>
+                        }
+                      } &
                       "#description *" #> mapSimpleDiff(apiAccountDiff.modDescription) &
                       "#isEnabled *" #> mapSimpleDiff(apiAccountDiff.modIsEnabled) &
                       "#tokenGenerationDate *" #> mapSimpleDiff(apiAccountDiff.modTokenGenerationDate) &
@@ -1146,6 +1155,8 @@ class EventLogDetailsGenerator(
     }).merge.runNow
 
   }
+
+  // todo end
 
   def nodePropertiesDiff(event: EventLog): Option[SimpleDiff[List[NodeProperty]]] = {
     event match {
@@ -1500,7 +1511,6 @@ class EventLogDetailsGenerator(
       <ul class="evlogviewpad">
         <li><b>Rudder ID: </b><value id="id"/></li>
         <li><b>Name:&nbsp;</b><value id="name"/></li>
-        <li><b>Token:&nbsp;</b><value id="token"/></li>
         <li><b>Description:&nbsp;</b><value id="description"/></li>
         <li><b>Enabled:&nbsp;</b><value id="isEnabled"/></li>
         <li><b>Creation date:&nbsp;</b><value id="creationDate"/></li>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -949,7 +949,7 @@ class EventLogDetailsGenerator(
                           case Some(_) =>
                             <ul class="evlogviewpad"><li><b>Token regenerated</b></li></ul>
                           case None    =>
-                            <ul class="evlogviewpad"><li><b>Token unchanged</b></li></ul>
+                            <ul class="evlogviewpad"><li><b>Token value unchanged</b></li></ul>
                         }
                       } &
                       "#description *" #> mapSimpleDiff(apiAccountDiff.modDescription) &
@@ -1331,7 +1331,7 @@ class EventLogDetailsGenerator(
       "#description" #> globalParameter.description
   )(xml)
 
-  private def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = {
+  private def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccountNoToken) = {
     val (expiration, kind, authz) = apiAccount.kind match {
       case ApiAccountKind.System                                    => ("N/A", "system", Text("N/A"))
       case ApiAccountKind.User                                      => ("N/A", "user", Text("N/A"))
@@ -1350,7 +1350,6 @@ class EventLogDetailsGenerator(
 
     ("#id" #> apiAccount.id.value &
     "#name" #> apiAccount.name.value &
-    "#token" #> apiAccount.token.flatMap(_.exposeHash()).getOrElse("") &
     "#description" #> apiAccount.description &
     "#isEnabled" #> apiAccount.isEnabled &
     "#creationDate" #> DateFormaterService.getDisplayDate(apiAccount.creationDate) &


### PR DESCRIPTION
https://issues.rudder.io/issues/29507

### api account added : 

<img width="891" height="560" alt="image" src="https://github.com/user-attachments/assets/7eb6e677-023a-4547-97ff-fce75d13a666" />

### api account deleted : 

<img width="879" height="559" alt="image" src="https://github.com/user-attachments/assets/fca00593-2813-418e-8229-adfd5bedf875" />

### api account modified when the token is not regenerated : 

<img width="878" height="599" alt="image" src="https://github.com/user-attachments/assets/13e4fef7-05ad-4a17-95ef-a75a9e5c6657" />

### api accound modified when the token is regenerated : 

<img width="877" height="511" alt="image" src="https://github.com/user-attachments/assets/8babd76b-b93a-440d-88ef-203a11711917" />
