### PR TITLE
Fixes #29529: Users table query has wrong column userid

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -39,6 +39,8 @@ package com.normation.rudder.users
 
 import cats.ApplicativeError
 import cats.data.NonEmptyList
+import cats.syntax.applicative.*
+import cats.syntax.functor.*
 import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
 import com.normation.errors.SystemError
@@ -1065,6 +1067,17 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
       email:     Option[Option[String]],
       otherInfo: Option[Json.Obj]
   ): IOResult[Unit] = {
+    transactIOResult(s"Error when updating user information for '${userId}'")(xa =>
+      updateUserInfo(userId, name, email, otherInfo).transact(xa)
+    ).unit
+  }
+
+  private[users] def updateUserInfo(
+      userId:    String,
+      name:      Option[Option[String]],
+      email:     Option[Option[String]],
+      otherInfo: Option[Json.Obj]
+  ): ConnectionIO[Unit] = {
     val params = {
       List(
         name.map((x => fr"name = ${x}")),
@@ -1073,11 +1086,11 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
       ).flatten
     }
     params match {
-      case Nil       => ZIO.unit
+      case Nil       => ().pure[ConnectionIO]
       case h :: tail =>
-        val sql = fr"""update users""" ++ Fragments.set(h, tail*) ++ fr"""where userId = ${userId}"""
+        val sql = fr"""update users""" ++ Fragments.set(h, tail*) ++ fr"""where id = ${userId}"""
 
-        transactIOResult(s"Error when updating user information for '${userId}'")(xa => sql.update.run.transact(xa)).unit
+        sql.update.run.void
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
@@ -236,6 +236,7 @@ class InMemoryUserRepositoryTest extends UserRepositoryTest {
 // this one use postgres and will run only with -Dtest.postgres="true"
 @RunWith(classOf[JUnitRunner])
 class JdbcUserRepositoryTest extends UserRepositoryTest with DBCommon {
+
   import doobie.*
 
   override def doJdbcTest = doDatabaseConnection
@@ -243,6 +244,7 @@ class JdbcUserRepositoryTest extends UserRepositoryTest with DBCommon {
   // format: off
   org.slf4j.LoggerFactory.getLogger("sql").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
   org.slf4j.LoggerFactory.getLogger("application.user").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+
   // format: on
   override def afterAll(): Unit = {
     cleanDb()
@@ -321,6 +323,23 @@ class JdbcUserRepositoryTest extends UserRepositoryTest with DBCommon {
       ).map(_.map(_._1)) must beRight(
         containTheSameElementsAs(users)
       )
+    }
+  }
+
+  "update query" >> {
+
+    "for user info" in {
+      transactRunEither(
+        repo.updateUserInfo("user1", None, None, None).transact(_)
+      ) must beRight
+
+      transactRunEither(
+        repo.updateUserInfo("user1", Some(None), Some(None), None).transact(_)
+      ) must beRight
+
+      transactRunEither(
+        repo.updateUserInfo("user1", Some(Some("name")), Some(Some("email")), None).transact(_)
+      ) must beRight
     }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/29529

An `id` has been replaced by `userId`. Just revert it back, and add a covering postgres test with sample cases