### PR TITLE
Fixes #29533: Bump spring-ldap-core version

### DIFF
--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -298,6 +298,20 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>${spring-security-version}</version>
     </dependency>
 
+    <!-- specific version for security patches, pulled by spring-security-ldap -->
+    <dependency>
+      <groupId>org.springframework.ldap</groupId>
+      <artifactId>spring-ldap-core</artifactId>
+      <version>3.3.8</version>
+    </dependency>
+
+    <!-- specific version for security patches, pulled by spring-ldap-core -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.16.6</version>
+    </dependency>
+
     <!-- this is needed for doobie/cats/zio compat in scala 3 - it must be at compile level else rudder breaks -->
     <dependency>
       <groupId>org.typelevel</groupId>


### PR DESCRIPTION
https://issues.rudder.io/issues/29533

Needs an override of transitive dependencies, it appears that `micrometer-core` is also a dependency of `spring-ldap-core` and needs an override 