### PR TITLE
Fixes #29521: Rename the ‘Activity’ card in the dashboard to ‘Recent Activity’

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
@@ -110,7 +110,7 @@
                             <div class="row h-100">
                                 <div class="col">
                                     <div class="card h-100">
-                                        <h4 class="card-title py-2 px-3 mb-0">Activity</h4>
+                                        <h4 class="card-title py-2 px-3 mb-0">Recent activity</h4>
                                         <div class="card-body">
                                             <div id="activity-app"></div>
                                         </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/29521