### PR TITLE
Fixes #29515: Use dedicated event log endpoint in directives recent activity tab

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -272,6 +272,13 @@ object EventLogApi extends Enum[EventLogApi] with ApiModuleProvider[EventLogApi]
     val authz: List[AuthorizationType] = AuthorizationType.Rule.Read :: Nil
   }
 
+  case object GetDirectiveEventLogs extends EventLogApi with InternalApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get directive-related event logs based on filters"
+    val (action, path) = POST / "eventlog" / "directives"
+    val authz: List[AuthorizationType] = AuthorizationType.Directive.Read :: Nil
+  }
+
   def endpoints: List[EventLogApi] = values.toList.sortBy(_.z)
 
   def values = findValues

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -40,9 +40,7 @@ package com.normation.rudder.rest.internal
 import com.normation.errors.*
 import com.normation.eventlog.*
 import com.normation.rudder.api.ApiVersion
-import com.normation.rudder.domain.eventlog.AddRuleEventType
-import com.normation.rudder.domain.eventlog.DeleteRuleEventType
-import com.normation.rudder.domain.eventlog.ModifyRuleEventType
+import com.normation.rudder.domain.eventlog.*
 import com.normation.rudder.domain.logger.EventLogsLoggerPure
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.repository.EventLogRepository
@@ -77,10 +75,11 @@ class EventLogAPI(
 
   override def getLiftEndpoints(): List[LiftApiModule] = {
     EventLogApi.endpoints.map {
-      case EventLogApi.GetEventLogs       => GetEventLogs
-      case EventLogApi.GetEventLogDetails => GetEventLogDetails
-      case EventLogApi.RollbackEventLog   => RollbackEventLog
-      case EventLogApi.GetRuleEventLogs   => GetRuleEventLogs
+      case EventLogApi.GetEventLogs          => GetEventLogs
+      case EventLogApi.GetEventLogDetails    => GetEventLogDetails
+      case EventLogApi.RollbackEventLog      => RollbackEventLog
+      case EventLogApi.GetRuleEventLogs      => GetRuleEventLogs
+      case EventLogApi.GetDirectiveEventLogs => GetDirectiveEventLogs
     }
   }
 
@@ -187,6 +186,62 @@ class EventLogAPI(
     }
   }
 
+  def getEventLogsOfGivenTypes(req: Req, params: DefaultParams, include: NonEmptyChunk[EventLogType])(using
+      qc: QueryContext
+  ): LiftResponse = {
+
+    given prettify: Boolean = params.prettify
+
+    (for {
+      restFilter  <- req.fromJson[RestEventLogFilter].toIO
+      // the value of the typeFilter field in the query is unused
+      queryFilter  = restFilter.toEventLogRequest
+      // typeFilter is replaced with a filter that includes all event logs whose types belong to the 'include' list
+      filter       = queryFilter.copy(typeFilter = {
+                       Some(EventLogRequest.TypeFilter(include = Some(include), exclude = None))
+                     })
+      totalRecord <- coreService.getUserEventLogCount(filter = None)
+      totalFilter <- coreService.getUserEventLogCount(filter = Some(filter))
+      events      <- coreService.getUserEventLogs(filter = Some(filter))
+      res          = EventLogSlice(events, totalRecord, totalFilter)
+    } yield {
+      (restFilter.draw, res)
+    }).chainError(s"Error when fetching event logs of types ${include.mkString(",")}")
+      .either
+      .runNow
+      .fold(
+        err => RudderJsonResponse.generic.internalError(RestEventLogError(err.fullMsg)),
+        {
+          case (draw, EventLogSlice(events, totalRecord, totalFilter)) =>
+            RudderJsonResponse.LiftJsonResponse(
+              RestEventLogSuccess(draw, totalRecord, totalFilter, events.map(_.transformInto[RestEventLog])),
+              params.prettify,
+              200
+            )
+        }
+      )
+  }
+
+  object GetDirectiveEventLogs extends LiftApiModule0 {
+    val schema: EventLogApi.GetDirectiveEventLogs.type = EventLogApi.GetDirectiveEventLogs
+
+    def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      getEventLogsOfGivenTypes(
+        req,
+        params,
+        NonEmptyChunk(AddDirectiveEventType, DeleteDirectiveEventType, ModifyDirectiveEventType)
+      )
+    }
+  }
+
   object GetRuleEventLogs extends LiftApiModule0 {
     val schema: EventLogApi.GetRuleEventLogs.type = EventLogApi.GetRuleEventLogs
 
@@ -197,42 +252,13 @@ class EventLogAPI(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      implicit val prettify: Boolean      = params.prettify
-      implicit val qc:       QueryContext = authzToken.qc
+      given qc: QueryContext = authzToken.qc
 
-      (for {
-        restFilter  <- req.fromJson[RestEventLogFilter].toIO
-        // the value of the typeFilter field in the query is unused
-        queryFilter  = restFilter.toEventLogRequest
-        // typeFilter is replaced with the list of eventlog types that concern rules
-        filter       = queryFilter.copy(typeFilter = {
-                         Some(
-                           EventLogRequest.TypeFilter(
-                             include = Some(NonEmptyChunk(AddRuleEventType, DeleteRuleEventType, ModifyRuleEventType)),
-                             exclude = None
-                           )
-                         )
-                       })
-        totalRecord <- coreService.getUserEventLogCount(filter = None)
-        totalFilter <- coreService.getUserEventLogCount(filter = Some(filter))
-        events      <- coreService.getUserEventLogs(filter = Some(filter))
-        res          = EventLogSlice(events, totalRecord, totalFilter)
-      } yield {
-        (restFilter.draw, res)
-      }).chainError("Error when fetching event logs")
-        .either
-        .runNow
-        .fold(
-          err => RudderJsonResponse.generic.internalError(RestEventLogError(err.fullMsg)),
-          {
-            case (draw, EventLogSlice(events, totalRecord, totalFilter)) =>
-              RudderJsonResponse.LiftJsonResponse(
-                RestEventLogSuccess(draw, totalRecord, totalFilter, events.map(_.transformInto[RestEventLog])),
-                params.prettify,
-                200
-              )
-          }
-        )
+      getEventLogsOfGivenTypes(
+        req,
+        params,
+        NonEmptyChunk(AddRuleEventType, DeleteRuleEventType, ModifyRuleEventType)
+      )
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
@@ -14,10 +14,10 @@ getActivities bodyParameters (ContextPath contextPath) resourceTypeOpt =
         url =
             case resourceTypeOpt of
                 Just resourceType ->
-                    contextPath :: "secure" :: "api" :: "eventlog" :: [ resourceType ]
+                    [ contextPath, "secure", "api", "eventlog", resourceType ]
 
                 Nothing ->
-                    contextPath :: "secure" :: "api" :: [ "eventlog" ]
+                    [ contextPath, "secure", "api", "eventlog" ]
 
         req =
             request

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
@@ -72,7 +72,7 @@ init flags =
             }
 
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath Nothing) ]
+            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath (Just "directives")) ]
     in
     ( initModel, Cmd.batch initActions )
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29515

This PR aims to use a new `POST eventlog/directives` endpoint in the directives' recent activity page.
This endpoint is identical to `POST eventlog`, except `POST eventlog/directives` only returns directive-related event logs, which removes the need for the event logs to be filtered by type in the elm app.
in addition, the directives' recent activity page can now be viewed so long as the user has the `directive_read` authorization, while it could previously only be viewed by `administrator`s