### PR TITLE
Fixes #29540: Use latest release of bouncycastle

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,4 @@
  # Scala
-CVE-2026-5588 # bouncycastle: BC-JAVA: PKIX draft CompositeVerifier accepts empty signature sequence as valid
 CVE-2025-11226 # ch.qos.logback/logback-core: Conditional arbitrary code execution in logback-core
 CVE-2025-58369 # FS2 half-shutdown of socket during TLS handshake may result in spin loop
 CVE-2025-48976 # apache-commons-fileupload: Apache Commons FileUpload DoS via part headers

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -397,7 +397,10 @@ limitations under the License.
     <asm-version>9.8</asm-version>
     <!-- Level of Java compatibility, here 1.8+ -->
     <bouncycastle-compat>jdk18on</bouncycastle-compat>
-    <bouncycastle-version>1.80</bouncycastle-version>
+    <bouncycastle-bcprov-version>1.85.2</bouncycastle-bcprov-version>
+    <bouncycastle-bcpkix-version>1.85</bouncycastle-bcpkix-version>
+    <bouncycastle-bcpg-version>1.85</bouncycastle-bcpg-version>
+    <bouncycastle-bcutil-version>1.85</bouncycastle-bcutil-version>
     <better-files-version>3.9.2</better-files-version>
     <sourcecode-version>0.4.2</sourcecode-version>
     <quicklens-version>1.9.12</quicklens-version>
@@ -632,17 +635,17 @@ limitations under the License.
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-${bouncycastle-compat}</artifactId>
-        <version>${bouncycastle-version}</version>
+        <version>${bouncycastle-bcprov-version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-${bouncycastle-compat}</artifactId>
-        <version>${bouncycastle-version}</version>
+        <version>${bouncycastle-bcpkix-version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpg-${bouncycastle-compat}</artifactId>
-        <version>${bouncycastle-version}</version>
+        <version>${bouncycastle-bcpg-version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.alonsodomin.cron4s</groupId>


### PR DESCRIPTION
https://issues.rudder.io/issues/29540

Add version property for each bouncycastle actual dependency: bcprov, bcpkix, ...

This requires update in plugins too: https://github.com/Normation/rudder-plugins/pull/1016