### PR TITLE
Fixes #29516: Use dedicated event log endpoint in techniques recent activity tab

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -286,6 +286,14 @@ object EventLogApi extends Enum[EventLogApi] with ApiModuleProvider[EventLogApi]
     val authz: List[AuthorizationType] = AuthorizationType.Group.Read :: Nil
   }
 
+  case object GetEditorTechniqueEventLogs
+      extends EventLogApi with InternalApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get editor technique-related event logs based on filters"
+    val (action, path) = POST / "eventlog" / "editorTechniques"
+    val authz: List[AuthorizationType] = AuthorizationType.Technique.Read :: Nil
+  }
+
   def endpoints: List[EventLogApi] = values.toList.sortBy(_.z)
 
   def values = findValues

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -75,12 +75,13 @@ class EventLogAPI(
 
   override def getLiftEndpoints(): List[LiftApiModule] = {
     EventLogApi.endpoints.map {
-      case EventLogApi.GetEventLogs          => GetEventLogs
-      case EventLogApi.GetEventLogDetails    => GetEventLogDetails
-      case EventLogApi.RollbackEventLog      => RollbackEventLog
-      case EventLogApi.GetRuleEventLogs      => GetRuleEventLogs
-      case EventLogApi.GetDirectiveEventLogs => GetDirectiveEventLogs
-      case EventLogApi.GetGroupEventLogs     => GetGroupEventLogs
+      case EventLogApi.GetEventLogs                => GetEventLogs
+      case EventLogApi.GetEventLogDetails          => GetEventLogDetails
+      case EventLogApi.RollbackEventLog            => RollbackEventLog
+      case EventLogApi.GetRuleEventLogs            => GetRuleEventLogs
+      case EventLogApi.GetDirectiveEventLogs       => GetDirectiveEventLogs
+      case EventLogApi.GetGroupEventLogs           => GetGroupEventLogs
+      case EventLogApi.GetEditorTechniqueEventLogs => GetEditorTechniqueEventLogs
     }
   }
 
@@ -279,6 +280,26 @@ class EventLogAPI(
         req,
         params,
         NonEmptyChunk(AddNodeGroupEventType, DeleteNodeGroupEventType, ModifyNodeGroupEventType)
+      )
+    }
+  }
+
+  object GetEditorTechniqueEventLogs extends LiftApiModule0 {
+    val schema: EventLogApi.GetEditorTechniqueEventLogs.type = EventLogApi.GetEditorTechniqueEventLogs
+
+    def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      getEventLogsOfGivenTypes(
+        req,
+        params,
+        NonEmptyChunk(AddEditorTechniqueEventType, DeleteEditorTechniqueEventType, ModifyEditorTechniqueEventType)
       )
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -199,7 +199,7 @@ mainInit initValues =
         , getTechniquesCategories model
         , getDirectives model
         , getPolicyMode model
-        , Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initValues.contextPath) Nothing)
+        , Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initValues.contextPath) (Just "editorTechniques"))
         ]
     )
 
@@ -447,10 +447,10 @@ update msg model =
                         ( { model | mode = Introduction }, initInputs "" )
 
                     else
-                        ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) Nothing) )
+                        ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) (Just "editorTechniques")) )
 
                 _ ->
-                    ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) Nothing) )
+                    ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) (Just "editorTechniques")) )
 
         SelectDraft id ->
             let


### PR DESCRIPTION
https://issues.rudder.io/issues/29516

This PR aims to use a new `POST eventlog/editorTechniques` endpoint in the techniques' recent activity page.
This endpoint is identical to `POST eventlog`, except `POST eventlog/editorTechniques` only returns editor technique-related event logs, which removes the need for the event logs to be filtered by type in the elm app.
in addition, the techniques' recent activity page can now be viewed so long as the user has the `technique_read` authorization, while it could previously only be viewed by `administrator`s