### PR TITLE
Fixes #29517: Use dedicated event log endpoint in groups recent activity tab

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -279,6 +279,13 @@ object EventLogApi extends Enum[EventLogApi] with ApiModuleProvider[EventLogApi]
     val authz: List[AuthorizationType] = AuthorizationType.Directive.Read :: Nil
   }
 
+  case object GetGroupEventLogs extends EventLogApi with InternalApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get group-related event logs based on filters"
+    val (action, path) = POST / "eventlog" / "groups"
+    val authz: List[AuthorizationType] = AuthorizationType.Group.Read :: Nil
+  }
+
   def endpoints: List[EventLogApi] = values.toList.sortBy(_.z)
 
   def values = findValues

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -80,6 +80,7 @@ class EventLogAPI(
       case EventLogApi.RollbackEventLog      => RollbackEventLog
       case EventLogApi.GetRuleEventLogs      => GetRuleEventLogs
       case EventLogApi.GetDirectiveEventLogs => GetDirectiveEventLogs
+      case EventLogApi.GetGroupEventLogs     => GetGroupEventLogs
     }
   }
 
@@ -258,6 +259,26 @@ class EventLogAPI(
         req,
         params,
         NonEmptyChunk(AddRuleEventType, DeleteRuleEventType, ModifyRuleEventType)
+      )
+    }
+  }
+
+  object GetGroupEventLogs extends LiftApiModule0 {
+    val schema: EventLogApi.GetGroupEventLogs.type = EventLogApi.GetGroupEventLogs
+
+    def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      getEventLogsOfGivenTypes(
+        req,
+        params,
+        NonEmptyChunk(AddNodeGroupEventType, DeleteNodeGroupEventType, ModifyNodeGroupEventType)
       )
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
@@ -106,7 +106,7 @@ init flags =
             }
 
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath Nothing) ]
+            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath (Just "groups")) ]
     in
     ( initModel, Cmd.batch initActions )
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29517

This PR aims to use a new `POST eventlog/groups` endpoint in the groups' recent activity page.
This endpoint is identical to `POST eventlog`, except `POST eventlog/groups` only returns group-related event logs, which removes the need for the event logs to be filtered by type in the elm app.
in addition, the groups' recent activity page can now be viewed so long as the user has the `group_read` authorization, while it could previously only be viewed by `administrator`s