### PR TITLE
Fixes #29518: Use dedicated event log endpoint in global parameter recent activity tab

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -294,6 +294,13 @@ object EventLogApi extends Enum[EventLogApi] with ApiModuleProvider[EventLogApi]
     val authz: List[AuthorizationType] = AuthorizationType.Technique.Read :: Nil
   }
 
+  case object GetParameterEventLogs extends EventLogApi with InternalApi with ZeroParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get parameter-related event logs based on filters"
+    val (action, path) = POST / "eventlog" / "parameters"
+    val authz: List[AuthorizationType] = AuthorizationType.Parameter.Read :: Nil
+  }
+
   def endpoints: List[EventLogApi] = values.toList.sortBy(_.z)
 
   def values = findValues

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -82,6 +82,7 @@ class EventLogAPI(
       case EventLogApi.GetDirectiveEventLogs       => GetDirectiveEventLogs
       case EventLogApi.GetGroupEventLogs           => GetGroupEventLogs
       case EventLogApi.GetEditorTechniqueEventLogs => GetEditorTechniqueEventLogs
+      case EventLogApi.GetParameterEventLogs       => GetParameterEventLogs
     }
   }
 
@@ -300,6 +301,26 @@ class EventLogAPI(
         req,
         params,
         NonEmptyChunk(AddEditorTechniqueEventType, DeleteEditorTechniqueEventType, ModifyEditorTechniqueEventType)
+      )
+    }
+  }
+
+  object GetParameterEventLogs extends LiftApiModule0 {
+    val schema: EventLogApi.GetParameterEventLogs.type = EventLogApi.GetParameterEventLogs
+
+    def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      getEventLogsOfGivenTypes(
+        req,
+        params,
+        NonEmptyChunk(AddGlobalParameterEventType, DeleteGlobalParameterEventType, ModifyGlobalParameterEventType)
       )
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ApiCalls.elm
@@ -1,6 +1,6 @@
 module Activity.ApiCalls exposing (..)
 
-import Activity.DataTypes exposing (ActivityMsg(..), BodyParameters, ContextPath(..), Search)
+import Activity.DataTypes exposing (ActivityMsg(..), ContextPath(..), Search)
 import Activity.JsonDecoder exposing (decodeErrorDetails, decodeGetActivities)
 import Activity.JsonEncoder exposing (encodeRestEventLogFilter)
 import Http exposing (header, jsonBody, request)
@@ -8,8 +8,8 @@ import Http.Detailed as Detailed
 import Url.Builder exposing (QueryParameter)
 
 
-getActivities : BodyParameters -> ContextPath -> Maybe String -> Cmd ActivityMsg
-getActivities bodyParameters (ContextPath contextPath) resourceTypeOpt =
+getActivities : Search -> ContextPath -> Maybe String -> Cmd ActivityMsg
+getActivities search (ContextPath contextPath) resourceTypeOpt =
     let
         url =
             case resourceTypeOpt of
@@ -24,7 +24,7 @@ getActivities bodyParameters (ContextPath contextPath) resourceTypeOpt =
                 { method = "POST"
                 , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
                 , url = Url.Builder.relative url []
-                , body = encodeRestEventLogFilter bodyParameters |> jsonBody
+                , body = encodeRestEventLogFilter search |> jsonBody
                 , expect = Detailed.expectJson GetActivities decodeGetActivities
                 , timeout = Nothing
                 , tracker = Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/DataTypes.elm
@@ -1,4 +1,4 @@
-module Activity.DataTypes exposing (Activity, ActivityMsg(..), BodyParameters, ContextPath(..), EventLogFilterOrder, FilterTypes, Search, listString2FilterTypes, search2String, string2Search)
+module Activity.DataTypes exposing (Activity, ActivityMsg(..), ContextPath(..), EventLogFilterOrder, FilterTypes, Search, listString2FilterTypes, search2String, string2Search)
 
 import Html.Parser exposing (Node)
 import Http exposing (Error)
@@ -37,12 +37,6 @@ type alias FilterTypes =
 listString2FilterTypes : List String -> FilterTypes
 listString2FilterTypes lstring =
     lstring
-
-
-type alias BodyParameters =
-    { search : Search
-    , filterTypes : FilterTypes
-    }
 
 
 type alias Activity =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/JsonEncoder.elm
@@ -4,14 +4,11 @@ import Activity.DataTypes exposing (..)
 import Json.Encode exposing (Value, int, list, object, string)
 
 
-encodeRestEventLogFilter : BodyParameters -> Value
-encodeRestEventLogFilter bodyParameters =
+encodeRestEventLogFilter : Search -> Value
+encodeRestEventLogFilter search =
     let
         isSearchEmpty =
-            search2String bodyParameters.search == ""
-
-        isFilterTypesEmpty =
-            List.isEmpty bodyParameters.filterTypes
+            search2String search == ""
     in
     object
         (List.filterMap identity
@@ -23,12 +20,7 @@ encodeRestEventLogFilter bodyParameters =
                 Nothing
 
               else
-                Just ( "search", object [ ( "value", string (search2String bodyParameters.search) ) ] )
-            , if isFilterTypesEmpty then
-                Nothing
-
-              else
-                Just ( "typeFilter", object [ ( "include", list string bodyParameters.filterTypes ) ] )
+                Just ( "search", object [ ( "value", string (search2String search) ) ] )
             ]
         )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard.elm
@@ -77,14 +77,9 @@ init flags =
             , zone = initTimeZone ()
             }
 
-        bodyParameters =
-            { search = Nothing
-            , filterTypes = []
-            }
-
         initActions : List (Cmd Msg)
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initModel.contextPath) Nothing)
+            [ Cmd.map ActivityMessage (getActivities Nothing (ContextPath initModel.contextPath) Nothing)
             , initTooltips ""
             , Task.perform Tick Time.now
             ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveRecentActivity.elm
@@ -2,7 +2,7 @@ port module DirectiveRecentActivity exposing (..)
 
 import Activity.ActivityTable exposing (initTable)
 import Activity.ApiCalls exposing (getActivities, processActivityApiError)
-import Activity.DataTypes exposing (Activity, ActivityMsg(..), BodyParameters, ContextPath(..), Search, string2Search)
+import Activity.DataTypes exposing (Activity, ActivityMsg(..), ContextPath(..), Search, string2Search)
 import Browser
 import Dict
 import Html exposing (Html, div)
@@ -63,16 +63,8 @@ init flags =
         search =
             string2Search flags.directiveId
 
-        bodyParameters : BodyParameters
-        bodyParameters =
-            { search = search
-
-            -- Keep only directive activity filtering on event log types
-            , filterTypes = [ "DirectiveAdded", "DirectiveDeleted", "DirectiveModified" ]
-            }
-
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath (Just "directives")) ]
+            [ Cmd.map ActivityMessage (getActivities search initModel.contextPath (Just "directives")) ]
     in
     ( initModel, Cmd.batch initActions )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -2,7 +2,7 @@ port module Editor exposing (..)
 
 import Activity.ActivityTable exposing (initTable)
 import Activity.ApiCalls exposing (getActivities, processActivityApiError)
-import Activity.DataTypes exposing (Activity, ActivityMsg(..), BodyParameters, ContextPath(..), Search, string2Search)
+import Activity.DataTypes exposing (Activity, ActivityMsg(..), ContextPath(..), Search, string2Search)
 import Browser
 import Dict exposing (Dict)
 import Dict.Extra
@@ -157,11 +157,6 @@ mainInit :
     -> ( Model, Cmd Msg )
 mainInit initValues =
     let
-        bodyParameters =
-            { search = Nothing
-            , filterTypes = filterTypes
-            }
-
         initTimeZone =
             Dict.get initValues.timeZone TimeZone.zones
                 |> Maybe.withDefault (\() -> Time.utc)
@@ -199,7 +194,7 @@ mainInit initValues =
         , getTechniquesCategories model
         , getDirectives model
         , getPolicyMode model
-        , Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath initValues.contextPath) (Just "editorTechniques"))
+        , Cmd.map ActivityMessage (getActivities Nothing (ContextPath initValues.contextPath) (Just "editorTechniques"))
         ]
     )
 
@@ -435,11 +430,9 @@ update msg model =
                         _ ->
                             ( model, Cmd.none )
 
-                bodyParameters : BodyParameters
-                bodyParameters =
-                    { search = string2Search id.value
-                    , filterTypes = filterTypes
-                    }
+                search : Search
+                search =
+                    string2Search id.value
             in
             case model.mode of
                 TechniqueDetails t _ _ editInfo ->
@@ -447,10 +440,10 @@ update msg model =
                         ( { model | mode = Introduction }, initInputs "" )
 
                     else
-                        ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) (Just "editorTechniques")) )
+                        ( newModel, Cmd.map ActivityMessage (getActivities search (ContextPath model.contextPath) (Just "editorTechniques")) )
 
                 _ ->
-                    ( newModel, Cmd.map ActivityMessage (getActivities bodyParameters (ContextPath model.contextPath) (Just "editorTechniques")) )
+                    ( newModel, Cmd.map ActivityMessage (getActivities search (ContextPath model.contextPath) (Just "editorTechniques")) )
 
         SelectDraft id ->
             let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GlobalPropertiesRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GlobalPropertiesRecentActivity.elm
@@ -2,7 +2,7 @@ port module GlobalPropertiesRecentActivity exposing (..)
 
 import Activity.ActivityTable exposing (initTable)
 import Activity.ApiCalls exposing (getActivities, processActivityApiError)
-import Activity.DataTypes exposing (Activity, ActivityMsg(..), BodyParameters, ContextPath(..), string2Search)
+import Activity.DataTypes exposing (Activity, ActivityMsg(..), ContextPath(..), string2Search)
 import Browser
 import Dict
 import Html exposing (Html, div, i, table, tbody, td, text, th, thead, tr)
@@ -66,16 +66,8 @@ init flags =
         search =
             string2Search flags.globalPropertyId
 
-        bodyParameters : BodyParameters
-        bodyParameters =
-            { search = search
-
-            -- Keep only directive activity filtering on event log types
-            , filterTypes = [ "GlobalParameterAdded", "GlobalParameterDeleted", "GlobalParameterModified" ]
-            }
-
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath Nothing) ]
+            [ Cmd.map ActivityMessage (getActivities search initModel.contextPath (Just "parameters")) ]
     in
     ( initModel, Cmd.batch initActions )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRecentActivity.elm
@@ -2,7 +2,7 @@ port module GroupRecentActivity exposing (..)
 
 import Activity.ActivityTable exposing (initTable)
 import Activity.ApiCalls exposing (getActivities, processActivityApiError)
-import Activity.DataTypes exposing (Activity, ActivityMsg(..), BodyParameters, ContextPath(..), Search, string2Search)
+import Activity.DataTypes exposing (Activity, ActivityMsg(..), ContextPath(..), Search, string2Search)
 import Browser
 import Dict
 import Html exposing (Html, div)
@@ -97,16 +97,12 @@ init flags =
             , zone = zone
             }
 
-        bodyParameters : BodyParameters
-        bodyParameters =
-            { search = string2Search flags.groupId
-
-            -- Keep only groups activity filtering on event log types
-            , filterTypes = [ "NodeGroupAdded", "NodeGroupDeleted", "NodeGroupModified" ]
-            }
+        search : Search
+        search =
+            string2Search flags.groupId
 
         initActions =
-            [ Cmd.map ActivityMessage (getActivities bodyParameters initModel.contextPath (Just "groups")) ]
+            [ Cmd.map ActivityMessage (getActivities search initModel.contextPath (Just "groups")) ]
     in
     ( initModel, Cmd.batch initActions )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -19,7 +19,7 @@ import Rudder.Table exposing (OutMsg(..), updateData)
 import Rules.ApiCalls exposing (..)
 import Rules.ChangeRequest exposing (ChangeRequestSettings, initCrSettings)
 import Rules.DataTypes exposing (..)
-import Rules.Init exposing (bodyParameters, init)
+import Rules.Init exposing (init)
 import Rules.View exposing (view)
 import Rules.ViewUtils exposing (..)
 import Task
@@ -521,7 +521,7 @@ update msg model =
                             ContextPath model.contextPath
 
                         callGetActivities =
-                            getActivities (bodyParameters (Just details.rule.id.value)) contextPath (Just "rules")
+                            getActivities (Just details.rule.id.value) contextPath (Just "rules")
                     in
                     ( { model | mode = RuleForm details }
                     , Cmd.batch

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
@@ -1,7 +1,7 @@
 module Rules.Init exposing (..)
 
 import Activity.ActivityTable exposing (initTable)
-import Activity.DataTypes exposing (Activity, BodyParameters, ContextPath(..), Search)
+import Activity.DataTypes exposing (Activity, ContextPath(..), Search)
 import Compliance.Html exposing (buildComplianceBar)
 import Compliance.Utils exposing (defaultComplianceFilter)
 import Dict
@@ -20,13 +20,6 @@ import Time exposing (Zone)
 import TimeZone
 import Ui.Datatable exposing (Category, SubCategories(..), defaultTableFilters)
 import Utils.TooltipUtils exposing (buildTooltipContent)
-
-
-bodyParameters : Search -> BodyParameters
-bodyParameters search =
-    { search = search
-    , filterTypes = [ "RuleAdded", "RuleDeleted", "RuleModified" ]
-    }
 
 
 init : { contextPath : String, hasWriteRights : Bool, canReadChanqeRequest : Bool, timeZone : String } -> ( Model, Cmd Msg )


### PR DESCRIPTION
https://issues.rudder.io/issues/29518

This PR aims to use a new `POST eventlog/parameters` endpoint in the parameters' recent activity page.
This endpoint is identical to `POST eventlog`, except `POST eventlog/parameters` only returns parameter-related event logs, which removes the need for the event logs to be filtered by type in the elm app.
in addition, the parameters' recent activity page can now be viewed so long as the user has the `parameter_read` authorization, while it could previously only be viewed by `administrator`s

:warning: This PR also removes the `BodyParameters` datatype in the `Activity` Elm app since its `filterTypes` field is no longer used; we only need its `search` field