### PR TITLE
Fixes #29552: We embeded useless data in war that bloat it sizes

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/pom.xml
+++ b/webapp/sources/ldap-inventory/inventory-api/pom.xml
@@ -50,6 +50,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>utils</artifactId>
       <version>${rudder-version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -278,6 +278,12 @@ limitations under the License.
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version> <!-- 3.4.x does not work -->
         <configuration>
+          <excludes>
+            <!--
+              semanticdb data are only useful in classes, never in package - quite the opposite.
+            -->
+            <exclude>META-INF/semanticdb/**</exclude>
+          </excludes>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
             <manifestEntries>

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -79,7 +79,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
        </executions>
        <configuration>
          <skip>false</skip>
-         <excludes>
+         <!-- `combine.children` keeps the excludes defined in parent pom (semanticdb), else they are overridden -->
+         <excludes combine.children="append">
            <exclude>**/logback-test.xml</exclude>
          </excludes>
        </configuration>
@@ -124,6 +125,14 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <groupId>com.normation</groupId>
       <artifactId>utils</artifactId>
       <version>${rudder-version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.normation</groupId>
+      <artifactId>utils</artifactId>
+      <version>${rudder-version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -264,10 +273,10 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <scope>test</scope>
     </dependency>
 
-    <!-- new js engine -->
+    <!-- js engine for directive params: we use the polyglot API directly, no more JSR-223 bridge -->
     <dependency>
-      <groupId>org.graalvm.js</groupId>
-      <artifactId>js-scriptengine</artifactId>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>polyglot</artifactId>
       <version>${graalvm-version}</version>
     </dependency>
     <dependency>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
@@ -48,7 +48,6 @@ import com.normation.rudder.services.policies.JsEngine.*
 import enumeratum.*
 import java.security.NoSuchAlgorithmException
 import java.util.concurrent.*
-import javax.script.Bindings
 import javax.script.ScriptException
 import org.apache.commons.codec.digest.Md5Crypt
 import org.apache.commons.codec.digest.Sha2Crypt
@@ -262,31 +261,17 @@ final class JsRudderLibImpl(
 }
 
 sealed trait JsRudderLibBinding {
-  def bindings:    Bindings
   def jsRudderLib: JsRudderLibImpl
 }
 
 object JsRudderLibBinding {
 
-  import java.util.HashMap as JHMap
-  import javax.script.SimpleBindings
-
-  private def toBindings(k: String, v: JsRudderLibImpl): Bindings = {
-    val m = new JHMap[String, Object]()
-    m.put(k, v)
-    new SimpleBindings(m)
-  }
-
   /*
-   * Be careful, as bindings are mutable, we can't have
-   * a val for bindings, else the same context is shared...
-   *
    * We have one for Crypt to specialize the
    * "auto" methods
    */
   object Crypt extends JsRudderLibBinding {
     val jsRudderLib = new JsRudderLibImpl(CryptHash)
-    def bindings: Bindings = toBindings("rudder", jsRudderLib)
   }
 }
 

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -84,7 +84,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
          </execution>
        </executions>
         <configuration>
-          <excludes>
+          <!-- `combine.children` keeps the excludes defined in parent pom (semanticdb), else they are overridden -->
+          <excludes combine.children="append">
             <exclude>**/logback-test.xml</exclude>
           </excludes>
         </configuration>

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -78,6 +78,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <attachClasses>true</attachClasses>
+          <!--
+            source maps are only useful to debug the minified libs, and semanticdb (produced by `-Ysemanticdb`
+            for scalafix, which reads it from `target/classes`) has no use in packages.
+          -->
+          <packagingExcludes>**/*.js.map,**/*.css.map,WEB-INF/classes/META-INF/semanticdb/**</packagingExcludes>
           <webResources>
             <resource>
               <filtering>true</filtering>
@@ -113,7 +118,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
          </execution>
        </executions>
         <configuration>
-          <excludes>
+          <!-- `combine.children` keeps the excludes defined in parent pom (semanticdb), else they are overridden -->
+          <excludes combine.children="append">
             <exclude>**/logback-test.xml</exclude>
             <exclude>**/node_modules</exclude>
           </excludes>


### PR DESCRIPTION
https://issues.rudder.io/issues/29552

Remove dev/test data from war: 

- semanticdb files - only interesting for scalac/scalafix, 
- JS/CSS map - only interesting for debuging - it means we won't have them in prod env
- a test jar that wasn't scoped test :shrug: 

With some maven sorcery I'd have prefered not known. 

We that, we gain 8MB, from 180 to 172 MB