### PR TITLE
Fixes #29539: Handle Scala dependency security checks since Trivy

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,13 +1,14 @@
  # Scala
-CVE-2025-11226 # ch.qos.logback/logback-core: Conditional arbitrary code execution in logback-core
-CVE-2025-58369 # FS2 half-shutdown of socket during TLS handshake may result in spin loop
-CVE-2025-48976 # apache-commons-fileupload: Apache Commons FileUpload DoS via part headers
-CVE-2025-48924 # commons-lang/commons-lang: Uncontrolled Recursion vulnerability in Apache Commons Lang
-CVE-2026-41720 # Spring LDAP has Authentication Bypass with Empty Password
+
 
 # npm
-CVE-2024-1899 # Showdown vulnerable to Regular Expression Denial of Service (ReDoS) in link/anchor parsing, no release patch
-CVE-2025-9910 # jsondiffpatch is vulnerable to Cross-site Scripting (XSS) via HtmlFormatter::nodeBegin
-CVE-2026-59710 # showdown: Showdown: Stored Cross-Site Scripting via unescaped table header ID attributes, no release patch
-CVE-2026-59711 # showdown: Showdown: Cross-site scripting via unescaped metadata title, no release patch
+
+# DoS in markdown to html, OK because display is for authenticated user only (Showdown vulnerable to Regular Expression Denial of Service (ReDoS) in link/anchor parsing, no release patch)
+CVE-2024-1899
+# XSS, OK because pages have strict CSP (showdown: Showdown: Stored Cross-Site Scripting via unescaped table header ID attributes, no release patch)
+CVE-2026-59710
+# XSS, OK because pages have strict CSP (showdown: Showdown: Cross-site scripting via unescaped metadata title, no release patch)
+CVE-2026-59711
+# XSS in change logs, OK because page has strict CSP (jsondiffpatch is vulnerable to Cross-site Scripting (XSS) via HtmlFormatter::nodeBegin)
+CVE-2025-9910
 

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -380,12 +380,12 @@ limitations under the License.
     <scala-xml-version>1.3.0</scala-xml-version>
     <lift-version>4.0.0-M1</lift-version>
     <slf4j-version>2.0.17</slf4j-version>
-    <logback-version>1.5.18</logback-version>
+    <logback-version>1.5.38</logback-version>
     <janino-version>3.1.12</janino-version>
     <jodatime-version>2.14.0</jodatime-version>
     <jodaconvert-version>3.0.1</jodaconvert-version>
     <commons-io-version>2.19.0</commons-io-version>
-    <commons-lang-version>3.17.0</commons-lang-version>
+    <commons-lang-version>3.20.0</commons-lang-version>
     <commons-text-version>1.13.1</commons-text-version>
     <commons-codec-version>1.18.0</commons-codec-version>
     <commons-fileupload>2.0.0-M4</commons-fileupload>
@@ -433,11 +433,11 @@ limitations under the License.
     <junit-version>4.13.2</junit-version>
     <cats-version>2.13.0</cats-version>
     <ip4s-version>3.7.0</ip4s-version>
-    <doobie-version>1.0.0-RC9</doobie-version>
-    <fs2-version>3.10.2</fs2-version>
+    <doobie-version>1.0.0-RC12</doobie-version>
+    <fs2-version>3.12.2</fs2-version>
     <cats-effect-version>3.6.1</cats-effect-version>
     <dev-zio-version>2.1.19</dev-zio-version>
-    <zio-cats-version>23.1.0.5</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->
+    <zio-cats-version>23.1.0.13</zio-cats-version> <!-- gives fs2 3.12.2, doobie 1.0.0-RC12 is in 3.12.2 -->
     <zio-json-version>0.7.43</zio-json-version>
     <izumi-version>3.0.5</izumi-version>
     <magnolia-version>1.3.18</magnolia-version>
@@ -612,8 +612,8 @@ limitations under the License.
         <version>${lift-version}</version>
         <exclusions>
           <exclusion>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
           </exclusion>
 	        <exclusion>
             <groupId>org.slf4j</groupId>

--- a/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FillTemplatesService.scala
+++ b/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FillTemplatesService.scala
@@ -47,7 +47,7 @@ import com.normation.errors.*
 import com.normation.stringtemplate.language.NormationAmpersandTemplateLexer
 import com.normation.zio.*
 import org.antlr.stringtemplate.StringTemplate
-import org.apache.commons.lang3.StringUtils
+import org.apache.commons.lang3.Strings
 import scala.collection.immutable.ArraySeq
 import zio.*
 import zio.syntax.*
@@ -258,9 +258,9 @@ object FillTemplateThreadUnsafe {
                     case None             => (policy, templateName)
                     case Some((from, to)) =>
                       // this is done quite heavely on big instances, with string rather big, and the performance of
-                      // StringUtils.replace ix x4 the one of String.replace (no regex), see:
+                      // Strings.CS.replace (old StringUtils.replace) is x4 the one of String.replace (no regex), see:
                       // https://stackoverflow.com/questions/16228992/commons-lang-stringutils-replace-performance-vs-string-replace/19163566
-                      (policy, StringUtils.replace(templateName, from, to))
+                      (policy, Strings.CS.replace(templateName, from, to))
                   }
       t2       <- currentTimeNanos
       delta     = t2 - t1


### PR DESCRIPTION
https://issues.rudder.io/issues/29539

* fs2 and doobie are tightly linked, just update doobie and zio-cats-interop together so that they both pull latest `fs2:3.12.2` (it's already the case in 9.1). doobie could be `1.0.0-RC11` as in 9.1 branch, to satisfy that constraint, but I kept `1.0.0-RC12` which is n-1 of latest (RC13 is a huge change due to namespace change) 
* apache `commons-lang3` has a deprecation in the patched version (the fix is the same as in 9.1: String.CS.replace)
* a vulnerable version of apache `commons-fileupload2` is pulled by lift-webkit: 2.0.0-M2, the transitive dependency was supposed to be ignored, but it had the wrong name: just exclude the transitive one, the actual one being used is the version in the commons-fileupload variable (and the dependency itself is declared in rudder-rest/pom.xml) i.e. 2.0.0-M4
* others: just a bump of the `logback` version