### PR TITLE
Fixes #29565: Trivy skip dir docs/api starting 9.2

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -9,7 +9,7 @@ exit-code: 1
 scan:
   scanners: ["vuln"]
   # ignored for now, only runs on trusted input
-  skip-dirs: ["api-doc"]
+  skip-dirs: ["api-doc", "docs/api"]
   disable-telemetry: true
 pkg:
   # ignored for now

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -9,7 +9,7 @@ exit-code: 1
 scan:
   scanners: ["vuln"]
   # ignored for now, only runs on trusted input
-  skip-dirs: ["api-doc", "docs/api"]
+  skip-dirs: ["docs/api"]
   disable-telemetry: true
 pkg:
   # ignored for now


### PR DESCRIPTION
https://issues.rudder.io/issues/29565

In 9.2 `api-doc` was moved to `docs/api`