### PR TITLE
Fixes #29583: Remove scalaj-http dependance in rudder core

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -406,7 +406,6 @@ limitations under the License.
     <postgresql-version>42.7.13</postgresql-version>
     <json-path-version>3.0.0</json-path-version>
     <json-smart-version>2.6.0</json-smart-version>
-    <scalaj-version>2.5.0</scalaj-version>
     <unboundid-version>7.0.4</unboundid-version>
     <fastparse-version>3.1.1</fastparse-version>
     <config-version>1.4.9</config-version>

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -120,13 +120,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
-    <!-- Doing HTTP requests for remote run -->
-    <dependency>
-      <groupId>com.codacy</groupId>
-      <artifactId>scalaj-http_3</artifactId>
-      <version>${scalaj-version}</version>
-    </dependency>
-
     <dependency>
       <groupId>com.lihaoyi</groupId>
       <artifactId>sourcecode_${scala-binary-version}</artifactId>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -119,18 +119,26 @@ import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.net.ConnectException
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpConnectTimeoutException
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
+import java.security.cert.X509Certificate
 import java.util.Arrays
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedTrustManager
 import net.liftweb.common.Box
 import net.liftweb.common.Failure
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.OutputStreamResponse
 import net.liftweb.http.PlainTextResponse
 import net.liftweb.http.Req
+import scala.annotation.tailrec
 import scala.collection.MapView
-import scalaj.http.Http
-import scalaj.http.HttpOptions
-import scalaj.http.HttpRequest
 import zio.{System as _, *}
 import zio.json.JsonEncoder
 import zio.stream.ZSink
@@ -805,6 +813,51 @@ class NodeApiInheritedProperties(
 
 }
 
+/*
+ * We need to declare a "trustEverything" certificate management but just for that internal
+ * connection toward relay, not globaly for all HTTPClient. It's just `X509ExtendedTrustManager`
+ * that does nothing.
+ */
+object RelayApiHttpClient {
+
+  private val trustEverything: SSLContext = {
+    val checkNothing = new X509ExtendedTrustManager {
+      override def checkClientTrusted(chain: Array[X509Certificate], authType: String): Unit = ()
+      override def checkServerTrusted(chain: Array[X509Certificate], authType: String): Unit = ()
+      override def checkClientTrusted(chain: Array[X509Certificate], authType: String, socket: java.net.Socket): Unit = ()
+      override def checkServerTrusted(chain: Array[X509Certificate], authType: String, socket: java.net.Socket): Unit = ()
+      override def checkClientTrusted(chain: Array[X509Certificate], authType: String, engine: SSLEngine):       Unit = ()
+      override def checkServerTrusted(chain: Array[X509Certificate], authType: String, engine: SSLEngine):       Unit = ()
+      override def getAcceptedIssuers(): Array[X509Certificate] = Array.empty
+    }
+    val context      = SSLContext.getInstance("TLS")
+    context.init(null, Array(checkNothing), null)
+    context
+  }
+
+  // the relay is on the same machine: if we can't connect quickly, it's down
+  private val connectionTimeout = java.time.Duration.ofSeconds(1)
+
+  val client: HttpClient = HttpClient.newBuilder().sslContext(trustEverything).connectTimeout(connectionTimeout).build()
+
+  def formUrlEncodedBody(params: List[(String, String)]): String = {
+    def encode(s: String): String = URLEncoder.encode(s, StandardCharsets.UTF_8)
+    params.map { case (name, value) => s"${encode(name)}=${encode(value)}" }.mkString("&")
+  }
+
+  /*
+   * A connection failure can be reported directly or wrapped by the HTTP client, and it's the one
+   * case we want to report with a specific message (the relay API is likely not running).
+   */
+  @tailrec
+  def isConnectionFailure(t: Throwable): Boolean = t match {
+    case null                                                         => false
+    case _: ConnectException | _: HttpConnectTimeoutException         => true
+    case other if (other.getCause != null && other.getCause != other) => isConnectionFailure(other.getCause)
+    case _                                                            => false
+  }
+}
+
 class NodeApiService(
     val nodeFactRepository:     NodeFactRepository,
     propertiesRepo:             PropertiesRepository,
@@ -1290,26 +1343,39 @@ class NodeApiService(
     }
   }
 
-  def remoteRunRequest(nodeId: NodeId, classes: List[String], keepOutput: Boolean, asynchronous: Boolean): HttpRequest = {
-    val url     = s"${relayApiEndpoint}/remote-run/nodes/${nodeId.value}"
-//    val url = s"http://localhost/rudder/relay-api/remote-run/nodes/${nodeId.value}"
-    val params  = {
+  /*
+   * Remote run call is async and may be long.
+   */
+  private val ASYNC_RUN_TIMEOUT = 5.minutes
+
+  /*
+   * Build the form encoded POST to the relay remote-run API.
+   * `responseTimeout` is how long we accept to wait for the relay to answer
+   * When we stream its output, the streaming itself is bounded by the caller (see `runNode`).
+   * Certificate verification is ignored thanks to `RelayApiHttpClient#trustEverything`.
+   */
+  def remoteRunRequest(
+      nodeId:          NodeId,
+      classes:         List[String],
+      keepOutput:      Boolean,
+      asynchronous:    Boolean,
+      responseTimeout: Duration
+  ): HttpRequest = {
+    val url    = s"${relayApiEndpoint}/remote-run/nodes/${nodeId.value}"
+    val params = {
       ("classes", classes.mkString(",")) ::
       ("keep_output", keepOutput.toString) ::
       ("asynchronous", asynchronous.toString) ::
       Nil
     }
-    // We currently bypass verification on certificate
-    // We should add an option to allow the user to define a certificate in configuration file
-    //
-    // We set a 5 minutes timeout (in milliseconds) as remote-runs can be long
-    val options = HttpOptions.allowUnsafeSSL :: HttpOptions.readTimeout(5 * 60 * 1000) :: Nil
 
-    Http(url)
-      .params(params)
-      .options(options)
-      .copy(headers = List(("User-Agent", s"rudder/remote run query for node ${nodeId.value}")))
-      .postForm
+    HttpRequest
+      .newBuilder(URI.create(url))
+      .header("Content-Type", "application/x-www-form-urlencoded")
+      .header("User-Agent", s"rudder/remote run query for node ${nodeId.value}")
+      .timeout(responseTimeout)
+      .POST(HttpRequest.BodyPublishers.ofString(RelayApiHttpClient.formUrlEncodedBody(params)))
+      .build()
   }
 
   /*
@@ -1348,38 +1414,34 @@ class NodeApiService(
 
     val readTimeout = 30.seconds
 
-    val request = {
-      remoteRunRequest(nodeId, classes, keepOutput = true, asynchronous = false)
-        .timeout(connTimeoutMs = 1000, readTimeoutMs = readTimeout.toMillis.toInt)
-    }
+    val request = remoteRunRequest(nodeId, classes, keepOutput = true, asynchronous = false, readTimeout)
 
     // copy will close `os`
     val copy = (os: OutputStream, timeout: Duration) => {
       for {
         _   <- NodeLoggerPure.debug(s"Executing remote run call: ${request.toString}")
         opt <- IOResult.attempt {
-                 request.exec {
-                   case (status, headers, is) =>
-                     NodeLogger.debug(
-                       s"Processing remote-run on ${nodeId.value}: HTTP status ${status}"
-                     ) // this one is written two times - why ??
-                     if (status >= 200 && status < 300) {
-                       copyStreamTo(pipeSize, is)(os)
-                     } else {
-                       val error = errorMessageWithHint(s"(HTTP code ${status})")
-                       NodeLogger.error(error)
-                       os.write(error.getBytes)
-                       os.flush
-                     }
-                     os.close() // os must be closed here, else is never know that the stream is closed and wait forever
+                 val response = RelayApiHttpClient.client.send(request, HttpResponse.BodyHandlers.ofInputStream())
+                 val status   = response.statusCode()
+                 NodeLogger.debug(
+                   s"Processing remote-run on ${nodeId.value}: HTTP status ${status}"
+                 )          // this one is written two times - why ??
+                 if (status >= 200 && status < 300) {
+                   copyStreamTo(pipeSize, response.body())(os)
+                 } else {
+                   val error = errorMessageWithHint(s"(HTTP code ${status})")
+                   NodeLogger.error(error)
+                   os.write(error.getBytes)
+                   os.flush
                  }
+                 os.close() // os must be closed here, else is never know that the stream is closed and wait forever
                }.unit.catchAll {
                  case error @ SystemError(m, ex) =>
                    // special case for "Connection refused": it means that remoteRunRequest is not working
-                   val err = ex match {
-                     case _: ConnectException =>
-                       Unexpected(s"Can not connect to local remote run API (${request.method.toUpperCase}:${request.url})")
-                     case _ => error
+                   val err = if (RelayApiHttpClient.isConnectionFailure(ex)) {
+                     Unexpected(s"Can not connect to local remote run API (${request.method()}:${request.uri()})")
+                   } else {
+                     error
                    }
 
                    NodeLoggerPure.error(errorMessageWithHint(err.fullMsg)) *> IOResult.attempt {
@@ -1424,17 +1486,17 @@ class NodeApiService(
           // remote run only works for CFEngine based agent
           val commandResult = {
             if (node.rudderAgent.agentType == AgentType.CfeCommunity) {
-              val request = remoteRunRequest(node.id, classes, keepOutput = false, asynchronous = true)
+              val request = remoteRunRequest(node.id, classes, keepOutput = false, asynchronous = true, ASYNC_RUN_TIMEOUT)
               try {
-                val result = request.asString
-                if (result.isSuccess) {
+                val response = RelayApiHttpClient.client.send(request, HttpResponse.BodyHandlers.ofString())
+                if (response.statusCode() >= 200 && response.statusCode() < 300) {
                   "Started"
                 } else {
-                  s"An error occurred when applying policy on Node '${node.id.value}', cause is: ${result.body}"
+                  s"An error occurred when applying policy on Node '${node.id.value}', cause is: ${response.body()}"
                 }
               } catch {
-                case ex: ConnectException =>
-                  s"Can not connect to local remote run API (${request.method.toUpperCase}:${request.url})"
+                case ex: Exception if RelayApiHttpClient.isConnectionFailure(ex) =>
+                  s"Can not connect to local remote run API (${request.method()}:${request.uri()})"
               }
             } else {
               s"Node with id '${node.id.value}' has an agent type (${node.rudderAgent.agentType.displayName}) which doesn't support remote run"

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRelayApiHttpClient.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRelayApiHttpClient.scala
@@ -1,0 +1,104 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest
+
+import com.normation.rudder.rest.lift.RelayApiHttpClient
+import java.io.IOException
+import java.net.ConnectException
+import java.net.http.HttpConnectTimeoutException
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+/*
+ * Test the HTTP plumbing used to call the relay API (remote-run). See `RelayApiHttpClient`.
+ */
+@RunWith(classOf[JUnitRunner])
+class TestRelayApiHttpClient extends Specification {
+
+  "form encoding" should {
+
+    "encode the remote-run parameters like a browser form" in {
+      RelayApiHttpClient.formUrlEncodedBody(
+        ("classes", "cls1,cls2") :: ("keep_output", "true") :: ("asynchronous", "false") :: Nil
+      ) === "classes=cls1%2Ccls2&keep_output=true&asynchronous=false"
+    }
+
+    "escape everything that isn't safe in a form body" in {
+      RelayApiHttpClient.formUrlEncodedBody(("classes", "a b&c=d+e/f") :: Nil) === "classes=a+b%26c%3Dd%2Be%2Ff"
+    }
+
+    "give an empty body when there is no parameter" in {
+      RelayApiHttpClient.formUrlEncodedBody(Nil) === ""
+    }
+  }
+
+  /*
+   * "the relay is not answering" must be reported with a dedicated message, and the JDK HTTP client
+   * can report it either directly or wrapped in an IOException.
+   */
+  "connection failure detection" should {
+
+    "recognize a direct connection refused" in {
+      RelayApiHttpClient.isConnectionFailure(new ConnectException("Connection refused")) === true
+    }
+
+    "recognize a connection failure wrapped by the HTTP client" in {
+      RelayApiHttpClient.isConnectionFailure(new IOException("wrapped", new ConnectException("Connection refused"))) === true
+    }
+
+    "recognize a connection timeout" in {
+      RelayApiHttpClient.isConnectionFailure(new HttpConnectTimeoutException("too slow")) === true
+    }
+
+    "not mistake another error for a connection failure" in {
+      RelayApiHttpClient.isConnectionFailure(new IOException("broken pipe")) === false
+    }
+
+    "not loop on a throwable whose cause is itself" in {
+      // `initCause(this)` is forbidden by the JDK, but nothing stops an implementation from
+      // returning itself from `getCause`, and we must not spin on it
+      val loop = new IOException("loop") { override def getCause: Throwable = this }
+      RelayApiHttpClient.isConnectionFailure(loop) === false
+    }
+
+    "not fail on a null throwable" in {
+      RelayApiHttpClient.isConnectionFailure(null) === false
+    }
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/29583

The only big difference is the need to create our own SSL ignored  class, it was provided by  scalaj-http before that. 