### PR TITLE
Fixes #29606: Dockerfile of policies uses 8.3 instead of 9.0 version in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,8 +365,7 @@ pipeline {
                         dockerfile {
                             label 'generic-docker'
                             filename 'policies/Dockerfile'
-                            // FIXME: replace by Rudder version once 9.0 builds
-                            additionalBuildArgs  "--build-arg RUDDER_VER=8.3-nightly --build-arg PSANALYZER_VER=1.20.0"
+                            additionalBuildArgs  "--build-arg RUDDER_VER=${env.RUDDER_VERSION}-nightly --build-arg PSANALYZER_VER=1.20.0"
                             args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }
                     }
@@ -615,7 +614,7 @@ pipeline {
                         dockerfile {
                             label 'generic-docker'
                             filename 'policies/Dockerfile'
-                            additionalBuildArgs  "--build-arg RUDDER_VER=8.3-nightly"
+                            additionalBuildArgs  "--build-arg RUDDER_VER=${env.RUDDER_VERSION}-nightly"
                             // mount cache
                             args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }


### PR DESCRIPTION
https://issues.rudder.io/issues/29606

Resolves the FIXME in https://github.com/Normation/rudder/pull/6270 and reverts it