### PR TITLE
Fixes #29631: OTP page input should have focus upon page load

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Otp/View.elm
@@ -2,7 +2,7 @@ module Otp.View exposing (..)
 
 import Browser.Events exposing (onKeyDown)
 import Html exposing (..)
-import Html.Attributes exposing (class, disabled, placeholder, size, type_, value)
+import Html.Attributes exposing (autofocus, class, disabled, placeholder, size, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Html.Events.Extra exposing (onEnter)
 import Maybe.Extra
@@ -95,6 +95,7 @@ viewCode code loading =
             , placeholder "Enter 6-digit code"
             , value code
             , size 12
+            , autofocus True
             , onInput SetCode
             , onEnter (VerifyOtp code)
             ]


### PR DESCRIPTION
https://issues.rudder.io/issues/29631

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autofocus: to avoid additional click/navigation