### PR TITLE
Fixes #29641: Prevent the graph legend from taking up too much vertical space

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-dashboard.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-dashboard.scss
@@ -103,11 +103,17 @@ $doughnut-size : 160px;
   color: rudder.$txt-primary;
   font-weight:700;
 }
-.node-chart h4 {
-  color: rudder.$txt-light;
-  margin-bottom: 15px;
-  font-size: 1.2em;
-  width : $doughnut-size;
+
+.node-chart{
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  h4 {
+    color: rudder.$txt-light;
+    margin-bottom: 15px;
+    font-size: 1.2em;
+    width : $doughnut-size;
+  }
 }
 /* Statistics */
 .stats li {
@@ -185,6 +191,8 @@ $doughnut-size : 160px;
 }
 
 .graph-legend {
+  max-height: $doughnut-size;
+  overflow: auto;
   margin-bottom: 0;
   &  > .legend {
     background-color:transparent;


### PR DESCRIPTION
https://issues.rudder.io/issues/29641

The maximum height of the legends corresponds to the size of the doughnuts, and the doughnuts are now aligned with one another even if there is a difference in height between their titles:

<img width="933" height="310" alt="Capture d’écran du 2026-08-26 17-23-16" src="https://github.com/user-attachments/assets/fb768aef-38df-42b3-a271-d2bb932e65cd" />

