### PR TITLE
Fixes #29663: Autovacuuming of nodelastcompliance could be improved

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
@@ -205,6 +205,26 @@ CREATE TABLE NodeLastCompliance (
 , details             jsonb NOT NULL
 );
 
+-- Details of compliance can be very big and occupy TOAST space (depending on directives numbers and size).
+--
+-- Trigger for autovacuum is: autovacuum_vacuum_threshold + autovacuum_vacuum_scale_factor × reltuples
+-- Default is 50 + 0.2 * rows, also applies to TOAST.
+--
+-- We don't want fixed threshold, but scaled factor that would adapt to any number of nodes, behave
+-- the same across different installations.
+--
+-- Finally, we need a factor lower than the default, since by default it leaves quite high number of dead tuples
+-- in the TOAST table without triggering, find it with this query:
+-- SELECT relid::regclass, n_live_tup, n_dead_tup, n_ins_since_vacuum,
+--        last_autovacuum, autovacuum_count,
+--        pg_size_pretty(pg_relation_size(relid)) AS heap,
+--        pg_size_pretty(pg_indexes_size(relid))  AS idx
+-- FROM pg_stat_all_tables
+-- WHERE relid = (SELECT reltoastrelid FROM pg_class WHERE oid='nodelastcompliance'::regclass)
+--
+ALTER TABLE NodeLastCompliance set (toast.autovacuum_vacuum_threshold = 0);
+ALTER TABLE NodeLastCompliance set (toast.autovacuum_vacuum_scale_factor = 0.05);
+
 
 
 /*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableNodeLastCompliance.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableNodeLastCompliance.scala
@@ -38,14 +38,19 @@
 package bootstrap.liftweb.checks.earlyconfig.db
 
 import bootstrap.liftweb.*
+import cats.syntax.apply.*
 import com.normation.errors.IOResult
 import com.normation.rudder.db.Doobie
 import com.normation.zio.*
+import doobie.*
 import doobie.implicits.*
+import doobie.syntax.string.*
 import zio.interop.catz.*
 
 /*
- * During 8.1 cycle, we added a score that is applied to every nodes to give a better understanding
+ * During 8.1 cycle, we added a score that is applied to every nodes to give a better understanding.
+ *
+ * For maintenance purpose we added an autovacuum in 9.0
  */
 class CheckTableNodeLastCompliance(
     doobie: Doobie
@@ -53,7 +58,7 @@ class CheckTableNodeLastCompliance(
 
   import doobie.*
 
-  override def description: String = "Check if table 'NodeLastCompliance' exists"
+  override def description: String = "Check if table 'NodeLastCompliance' exists and has autovacuum settings"
 
   def createTable: IOResult[Unit] = {
 
@@ -66,10 +71,20 @@ class CheckTableNodeLastCompliance(
     transactIOResult(s"Error with 'NodeLastCompliance' table creation")(xa => sql1.update.run.transact(xa)).unit
   }
 
+  def setAutovacuumSettings: IOResult[Unit] = {
+    val sql1 = sql"ALTER TABLE NodeLastCompliance SET (toast.autovacuum_vacuum_threshold = 0)"
+    val sql2 = sql"ALTER TABLE NodeLastCompliance SET (toast.autovacuum_vacuum_scale_factor = 0.05)"
+
+    transactIOResult(s"Error setting autovacuum_vacuum_threshold on 'NodeLastCompliance'")(xa =>
+      (sql1.update.run *> sql2.update.run).transact(xa)
+    ).unit
+  }
+
   override def checks(): Unit = {
     val prog = {
       for {
         _ <- createTable
+        _ <- setAutovacuumSettings
       } yield ()
     }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29663

Found the origin of the issue:
* TOAST table is the culprit (it's the internal PG table that stores the big JSONB compliance with pointers to chunks of binary)
* solution is to adjust toast-specific vacuum options (that will apply only to the toast table, the main table is fine WRT autovacuum)

* ..still tuning the values, I just tried lower ones to prove that it affects the vacuuming with even 2GB, so it should work with higher value...

 