### PR TITLE
Fixes #29519: exotic passwords fails vulnerability management

### DIFF
--- a/relay/sources/rudder-package/src/config.rs
+++ b/relay/sources/rudder-package/src/config.rs
@@ -129,6 +129,7 @@ mod tests {
     use std::path::Path;
 
     use pretty_assertions::assert_eq;
+    use secrecy::ExposeSecret;
 
     use crate::config::{Configuration, Credentials, ProxyConfiguration};
 
@@ -173,5 +174,87 @@ mod tests {
         };
         let conf = Configuration::read(Path::new("./tests/config/rudder-pkg.proxy.conf")).unwrap();
         assert_eq!(reference, conf);
+    }
+
+    // `rudder-pkg.conf` is read both in Rust here and in Scala the webapp part.
+    // We must ensure that the parsing (and esp. escaping rules) are the same between the two
+    // parsers, so we use the `rudder-pkg.tricky.conf` file.
+    // A change here or in the data file needs to be mirrored in
+    // `webapp/sources/utils/src/test/scala/com/normation/utils/IniTest.scala`.
+
+    // no escape for backslash and `#`, `;` and `=` are ordinary characters inside a value
+    #[test]
+    fn it_reads_values_verbatim_without_unescaping() {
+        let conf = Configuration::read(Path::new("./tests/config/rudder-pkg.tricky.conf")).unwrap();
+
+        let credentials = conf.credentials.expect("credentials must be parsed");
+        assert_eq!(credentials.username, "user-é-ü");
+        assert_eq!(
+            credentials.password.expose_secret(),
+            r#"p@ss\w0rd\\next#hash;semi=equals "quoted" spaced"#
+        );
+
+        let proxy = conf.proxy.expect("proxy must be parsed");
+        let proxy_credentials = proxy.credentials.expect("proxy credentials must be parsed");
+        assert_eq!(proxy_credentials.username, "mario");
+        assert_eq!(proxy_credentials.password.expose_secret(), "mot-de-passe-é");
+    }
+
+    // Only keys and values are trimmed. A section name is taken verbatim between the
+    // brackets, and the line itself is not trimmed before being looked at, so an
+    // indented header or comment is not a valid section.
+    #[test]
+    fn it_does_not_trim_section_names() {
+        // `[ Rudder ]` declares a section named " Rudder ", which is not the `Rudder` field,
+        // so the credentials are ignored
+        let conf =
+            Configuration::parse("[ Rudder ]\nusername = user\npassword = s3cret\n").unwrap();
+        assert_eq!(conf.credentials, None);
+        assert_eq!(conf.url, "https://repository.rudder.io/plugins");
+    }
+
+    #[test]
+    fn it_rejects_an_indented_section_header() {
+        assert!(Configuration::parse("  [Rudder]\nusername = user\n").is_err());
+    }
+
+    #[test]
+    fn it_rejects_an_indented_comment() {
+        assert!(Configuration::parse("[Rudder]\n  # a comment\n").is_err());
+    }
+
+    #[test]
+    fn it_rejects_a_blank_but_not_empty_line() {
+        assert!(Configuration::parse("[Rudder]\n \nusername = user\n").is_err());
+        // an actually empty line is fine
+        assert!(Configuration::parse("[Rudder]\n\nusername = user\n").is_ok());
+    }
+
+    #[test]
+    fn it_rejects_a_section_name_holding_a_closing_bracket() {
+        assert!(Configuration::parse("[Rud]der]\n").is_err());
+    }
+
+    // password are trimmed of all whitespace chars
+    #[test]
+    fn it_trims_whitespace_around_keys_and_values() {
+        let conf = Configuration::parse("[Rudder]\n  username\t=\tuser  \n\tpassword =  s3cret \n")
+            .unwrap();
+
+        let credentials = conf.credentials.expect("credentials must be parsed");
+        assert_eq!(credentials.username, "user");
+        assert_eq!(credentials.password.expose_secret(), "s3cret");
+    }
+
+    #[test]
+    fn it_trims_the_unicode_definition_of_whitespace() {
+        // `str::trim` follows the Unicode White_Space property, which includes the
+        // non-breaking spaces that Java's `Character.isWhitespace` deliberately excludes
+        let conf =
+            Configuration::parse("[Rudder]\nusername = user\npassword =\u{00A0}s3cret\u{202F}\n")
+                .unwrap();
+
+        let credentials = conf.credentials.expect("credentials must be parsed");
+        assert_eq!(credentials.password.expose_secret(), "s3cret");
     }
 }

--- a/relay/sources/rudder-package/tests/config/rudder-pkg.tricky.conf
+++ b/relay/sources/rudder-package/tests/config/rudder-pkg.tricky.conf
@@ -1,0 +1,15 @@
+# Test file shared with the Scala INI reader at webapp/sources/utils/src/test/scala/com/normation/utils/IniTest.scala
+#
+# `rudder-pkg.conf` is written by the webapp (Rudder Setup page) and read back by
+# both `rudder package` (Rust) and the webapp itself (CVE plugin in particular).
+# The two parsers must agree on parsing/escaping rules to stay consistent.
+#
+# If you change this file, change both tests; and same if you change the parsing rules.
+#
+[Rudder]
+url = https://download.rudder.io/plugins
+username = user-é-ü
+password = p@ss\w0rd\\next#hash;semi=equals "quoted" spaced
+proxy_url = http://proxy.example.org:3128
+proxy_user = mario
+proxy_password = mot-de-passe-é

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/settings/PluginSettings.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/settings/PluginSettings.scala
@@ -59,6 +59,23 @@ case class PluginSettings(
   }
 
   private def isEmpty = this == empty
+
+  /*
+   * The settings as they are laid out in `rudder-pkg.conf`, in file order. `None` and
+   * the empty string are the same thing for that file: both mean "not set".
+   *
+   * This is the single place where the mapping between the domain object and the file
+   * keys lives: `FilePluginSettingsService` writes it, and the REST API validates it
+   * (with `Ini.checkEntries`) before accepting an update.
+   */
+  def entries: List[(String, String)] = List(
+    "url"            -> url.getOrElse(""),
+    "username"       -> username.getOrElse(""),
+    "password"       -> password.getOrElse(""),
+    "proxy_url"      -> proxyUrl.getOrElse(""),
+    "proxy_user"     -> proxyUser.getOrElse(""),
+    "proxy_password" -> proxyPassword.getOrElse("")
+  )
 }
 
 object PluginSettings {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/settings/PluginSettingsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/settings/PluginSettingsService.scala
@@ -40,7 +40,8 @@ package com.normation.plugins.settings
 import better.files.File
 import com.normation.errors.*
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
-import java.util.Properties
+import com.normation.utils.Ini
+import java.nio.charset.StandardCharsets
 import zio.syntax.*
 
 /**
@@ -53,12 +54,23 @@ trait PluginSettingsService {
   def writePluginSettings(settings: PluginSettings): IOResult[Unit]
 }
 
+object FilePluginSettingsService {
+
+  /*
+   * `rudder-pkg.conf` is an INI file which is also read by `rudder package` with `serde_ini` (see `RawConfiguration`
+   * in `relay/sources/rudder-package/src/config.rs`).
+   * Keys living outside of that section are ignored by both implementations.
+   */
+  val RUDDER_SECTION = "Rudder"
+}
+
 /**
-  * Implementation that manages settings value in a properties file,
+  * Implementation that manages settings value in an INI file,
   * and syncs the setup state
   */
 class FilePluginSettingsService(pluginConfFile: File, readSetupDone: IOResult[Boolean], writeSetupDone: Boolean => IOResult[Unit])
     extends PluginSettingsService {
+  import FilePluginSettingsService.RUDDER_SECTION
 
   /**
     * Watch the rudder_setup_done setting to see if the plugin settings has been setup.
@@ -90,63 +102,47 @@ class FilePluginSettingsService(pluginConfFile: File, readSetupDone: IOResult[Bo
   }
 
   def readPluginSettings(): IOResult[PluginSettings] = {
-
-    val p = new Properties()
     for {
-      _ <- IOResult.attempt(s"Reading properties from ${pluginConfFile.pathAsString}")(p.load(pluginConfFile.newInputStream))
-
-      url            <- IOResult.attempt(s"Getting plugin repository url in ${pluginConfFile.pathAsString}") {
-                          val res = p.getProperty("url", "")
-                          if (res == "") None else Some(res)
-                        }
-      userName       <-
-        IOResult.attempt(s"Getting user name for plugin download in ${pluginConfFile.pathAsString}") {
-          val res = p.getProperty("username", "")
-          if (res == "") None else Some(res)
-        }
-      pass           <-
-        IOResult.attempt(s"Getting password for plugin download in ${pluginConfFile.pathAsString}") {
-          val res = p.getProperty("password", "")
-          if (res == "") None else Some(res)
-        }
-      proxy          <- IOResult.attempt(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
-                          val res = p.getProperty("proxy_url", "")
-                          if (res == "") None else Some(res)
-                        }
-      proxy_user     <- IOResult.attempt(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
-                          val res = p.getProperty("proxy_user", "")
-                          if (res == "") None else Some(res)
-                        }
-      proxy_password <- IOResult.attempt(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
-                          val res = p.getProperty("proxy_password", "")
-                          if (res == "") None else Some(res)
-                        }
+      content <- IOResult.attempt(s"Reading plugin settings from ${pluginConfFile.pathAsString}") {
+                   pluginConfFile.contentAsString(using StandardCharsets.UTF_8)
+                 }
+      ini     <- Ini
+                   .parse(content)
+                   .chainError(s"Error in plugin settings file ${pluginConfFile.pathAsString}")
+                   .toIO
     } yield {
-      PluginSettings(url, userName, pass, proxy, proxy_user, proxy_password)
+      def get(key: String) = ini.getNonEmpty(RUDDER_SECTION, key)
+
+      PluginSettings(
+        get("url"),
+        get("username"),
+        get("password"),
+        get("proxy_url"),
+        get("proxy_user"),
+        get("proxy_password")
+      )
     }
   }
 
   def writePluginSettings(update: PluginSettings): IOResult[Unit] = {
     for {
-      base <- readPluginSettings()
-      _    <- IOResult.attempt({
-                val settings = base.copy(
-                  url = update.url orElse base.url,
-                  username = update.username orElse base.username,
-                  password = update.password orElse base.password,
-                  proxyUrl = update.proxyUrl orElse base.proxyUrl,
-                  proxyUser = update.proxyUser orElse base.proxyUser,
-                  proxyPassword = update.proxyPassword orElse base.proxyPassword
-                )
-                pluginConfFile.write(s"""[Rudder]
-                                     |url = ${settings.url.getOrElse("")}
-                                     |username = ${settings.username.getOrElse("")}
-                                     |password = ${settings.password.getOrElse("")}
-                                     |proxy_url = ${settings.proxyUrl.getOrElse("")}
-                                     |proxy_user = ${settings.proxyUser.getOrElse("")}
-                                     |proxy_password = ${settings.proxyPassword.getOrElse("")}
-                                     |""".stripMargin)
-              })
+      base    <- readPluginSettings()
+      settings = PluginSettings(
+                   url = update.url orElse base.url,
+                   username = update.username orElse base.username,
+                   password = update.password orElse base.password,
+                   proxyUrl = update.proxyUrl orElse base.proxyUrl,
+                   proxyUser = update.proxyUser orElse base.proxyUser,
+                   proxyPassword = update.proxyPassword orElse base.proxyPassword
+                 )
+      // `Ini.render` refuses values it would not read back identically to avoid breaking persisted file content
+      content <- Ini
+                   .render(RUDDER_SECTION, settings.entries)
+                   .chainError(s"Can not write plugin settings in ${pluginConfFile.pathAsString}")
+                   .toIO
+      _       <- IOResult.attempt(s"Writing plugin settings in ${pluginConfFile.pathAsString}") {
+                   pluginConfFile.writeText(content)(using File.OpenOptions.default, StandardCharsets.UTF_8)
+                 }
     } yield {}
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/PluginApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/PluginApi.scala
@@ -47,12 +47,16 @@ import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.PluginApi as API
 import com.normation.rudder.rest.RudderJsonRequest.ReqToJson
+import com.normation.rudder.rest.RudderJsonResponse.BadRequestError
+import com.normation.rudder.rest.RudderJsonResponse.ResponseError
 import com.normation.rudder.rest.data.JsonPluginsDetails
 import com.normation.rudder.rest.data.JsonPluginSettings
 import com.normation.rudder.rest.implicits.*
+import com.normation.utils.Ini
 import io.scalaland.chimney.syntax.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
+import zio.ZIO
 
 class PluginApi(
     pluginSettingsService: PluginSettingsService,
@@ -93,16 +97,25 @@ class PluginApi(
     val schema:                                                                                                API.UpdatePluginsSettings.type = API.UpdatePluginsSettings
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse                   = {
       import com.normation.errors.*
+      type Result = Either[ResponseError, JsonPluginSettings]
+
       ({
         for {
-          json <- req.fromJson[JsonPluginSettings].toIO
-          _    <- pluginSettingsService.writePluginSettings(json.transformInto[PluginSettings])
-          _    <- pluginService.updateIndex()
+          json    <- req.fromJson[JsonPluginSettings].toIO
+          settings = json.transformInto[PluginSettings]
+          // We only accept values that will be read-back identically. When it's not the case, it's a result error.
+          res     <- Ini.checkEntries(settings.entries) match {
+                       case Left(err) => ZIO.succeed[Result](Left(BadRequestError(Some(err.fullMsg))))
+                       case Right(_)  =>
+                         for {
+                           _ <- pluginSettingsService.writePluginSettings(settings)
+                           _ <- pluginService.updateIndex()
+                         } yield (Right(json): Result)
+                     }
         } yield {
-          json
-
+          res
         }
-      }).toLiftResponseOne(params, schema, None)
+      }).toLiftResponseOneEither[JsonPluginSettings](params, schema, None)
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
@@ -296,4 +296,34 @@ class TestRestPluginInfo extends Specification with JsonSpecMatcher {
     })
 
   }
+
+  /*
+   * `rudder-pkg.conf` is an INI file with no escaping mechanism: a line break in a value
+   * would not be stored, it would inject arbitrary keys - a password of
+   * `x\nurl = http://evil.example` used to silently repoint the plugin repository. Since
+   * the value can not be represented, this is a client error, not a server one.
+   */
+  "Updating plugin settings with a value that can not be stored should" >> {
+    val mockReq = new MockHttpServletRequest("http://localhost:8080")
+    mockReq.method = "POST"
+    mockReq.path = "/api/latest/plugins/settings"
+    mockReq.body = """{
+      "url": "http://localhost:8888",
+      "username": "testuser",
+      "password": "x\nurl = http://evil.example"
+    }""".getBytes
+    mockReq.headers = Map()
+    mockReq.contentType = "application/json"
+
+    test.execRequestResponse(mockReq)(response => {
+      response.map { r =>
+        val rr = r.toResponse.asInstanceOf[InMemoryResponse]
+        (rr.code, new String(rr.data, "UTF-8"))
+      } match {
+        case Full((400, json)) => json must contain("line break")
+        case e                 => ko(s"Not the expected response : ${e}")
+      }
+    })
+
+  }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1178,6 +1178,12 @@ object RudderParsedProperties {
     }
   }
 
+  /*
+   * The INI file holding the plugin repository account, shared with `rudder package`.
+   * Exposed because plugins need it too (at least the CVE plugin)
+   */
+  val RUDDER_PLUGIN_SETTINGS_FILE: better.files.File = root / "opt" / "rudder" / "etc" / "rudder-pkg" / "rudder-pkg.conf"
+
   // Comes with the rudder-server packages
   val GENERIC_METHODS_SYSTEM_LIB: String = {
     try {
@@ -1316,6 +1322,7 @@ object RudderConfig extends Loggable {
   def RUDDER_BCRYPT_COST                           = RudderParsedProperties.RUDDER_BCRYPT_COST
   def RUDDER_ARGON2_PARAMS                         = RudderParsedProperties.RUDDER_ARGON2_PARAMS
   def RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL = RudderParsedProperties.RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL
+  def RUDDER_PLUGIN_SETTINGS_FILE                  = RudderParsedProperties.RUDDER_PLUGIN_SETTINGS_FILE
 
   //
   // Theses services can be called from the outer world
@@ -1671,7 +1678,7 @@ object RudderConfigInit {
     )
 
     lazy val pluginSettingsService = new FilePluginSettingsService(
-      root / "opt" / "rudder" / "etc" / "rudder-pkg" / "rudder-pkg.conf",
+      RUDDER_PLUGIN_SETTINGS_FILE,
       configService.rudder_setup_done().chainError("Could not get 'setup done' property"),
       (done: Boolean) => configService.set_rudder_setup_done(value = done).chainError("Could not get 'setup done' property")
     )

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/Ini.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/Ini.scala
@@ -1,0 +1,225 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.utils
+
+import com.normation.errors.*
+import scala.annotation.tailrec
+
+/*
+ * A minimal reader/writer for the INI files shared with Rust, in particular
+ * `/opt/rudder/etc/rudder-pkg/rudder-pkg.conf`.
+ * That file is written by the webapp (Rudder Setup page) and read back by both the webapp and
+ * `rudder package`.
+ *
+ * The reference implementation is the Rust one in `relay/sources/rudder-package/src/config.rs`.
+ *
+ * We didn't use a dependency because the obvious ones are unmaintained (ini4j), the other big and with
+ * significantly different escaping rules than serde/Rust side (commonconfig2).
+ *
+ * The following rules apply:
+ *
+ * - the file is UTF-8 as everything in Rudder
+ * - there is no escaping mechanism whatsoever, especially of backslash (see https://issues.rudder.io/issues/29519)
+ * - `#` and `;` start a comment only at the beginning of a line, never inside a value
+ * - a value is everything after the first `=`; only keys and values are trimmed, with
+ *   Rust's Unicode definition of whitespace (see `rustTrim`);
+ * - `[section]` headers are significant and a section name is
+ *   taken verbatim between the brackets (`[ Rudder ]` isn't the `Rudder` section).
+ * - indented section or comment is an error (no trim on line)
+ *
+ * In addition, we fail on following cases:
+ *
+ * - a duplicated key inside a section or a duplicated section;
+ * - on `render` if a read-render-read cycles are not idempotent by `
+ */
+final case class Ini(sections: Map[String, Map[String, String]]) {
+
+  def section(name: String): Map[String, String] = sections.getOrElse(name, Map.empty)
+
+  def get(section: String, key: String): Option[String] = sections.get(section).flatMap(_.get(key))
+
+  /*
+   * `key =` and a missing key are the same thing for us: the default `rudder-pkg.conf`
+   * ships with empty `proxy_url`/`proxy_user`/`proxy_password` lines meaning "unset",
+   * and the Rust side maps them to `None` too.
+   */
+  def getNonEmpty(section: String, key: String): Option[String] = get(section, key).filter(_.nonEmpty)
+}
+
+object Ini {
+
+  /*
+   * Keys appearing before any `[section]` header. The Rust side ignores them (they
+   * deserialize to unknown fields of the top-level struct), we just keep them apart.
+   */
+  val GlobalSection: String = ""
+
+  private val CommentMarkers = Set('#', ';')
+
+  /*
+   * Rust's `char::is_whitespace` follows the Unicode `White_Space` property, whereas
+   * Java's `Character.isWhitespace` excludes three non-breaking spaces, so we must align.
+   */
+  private val NonBreakingSpaces = Set(0x00a0, 0x2007, 0x202f) // NBSP, FIGURE SPACE, NARROW NBSP
+
+  private def isRustWhitespace(c: Char): Boolean = {
+    Character.isWhitespace(c) || NonBreakingSpaces.contains(c.toInt)
+  }
+
+  private def rustTrim(s: String): String = {
+    val from = s.indexWhere(c => !isRustWhitespace(c))
+    if (from < 0) "" // only whitespace
+    else s.substring(from, s.lastIndexWhere(c => !isRustWhitespace(c)) + 1)
+  }
+
+  def parse(content: String): PureResult[Ini] = {
+    // `-1` keeps trailing empty strings so that line numbers in errors match the file
+    val lines = content.split("\\R", -1).toList.zipWithIndex.map { case (l, i) => (l, i + 1) }
+
+    @tailrec
+    def loop(remaining: List[(String, Int)], current: String, acc: Map[String, Map[String, String]]): PureResult[Ini] = {
+      remaining match {
+        case Nil                        => Right(Ini(acc))
+        case (line, lineNumber) :: tail =>
+          // we don't trim line to match `serde_ini` behavior
+          if (line.startsWith("[")) {
+            if (!line.endsWith("]")) {
+              Left(Inconsistency(s"Error at line ${lineNumber}: section missing ']'"))
+            } else {
+              val name = line.substring(1, line.length - 1)
+              if (name.contains("]")) {
+                Left(Inconsistency(s"Error at line ${lineNumber}: section name contains ']'"))
+              } else if (acc.contains(name)) {
+                Left(Inconsistency(s"Error at line ${lineNumber}: section '${name}' is declared twice"))
+              } else {
+                loop(tail, name, acc + (name -> Map.empty))
+              }
+            }
+          } else if (CommentMarkers.exists(c => line.startsWith(c.toString))) {
+            loop(tail, current, acc)
+          } else {
+            // `indexOf` and not `split('=')` because it drops trailing empty string like
+            // `"proxy_url ="` in the default `rudder-pkg.conf`
+            line.indexOf('=') match {
+              case -1  =>
+                if (line.isEmpty) loop(tail, current, acc)
+                // a non-key-value non-empty line is an error in `serde_ini`
+                else Left(Inconsistency(s"Error at line ${lineNumber}: variable assignment missing '=', got '${line}'"))
+              case pos =>
+                val key   = rustTrim(line.substring(0, pos))
+                val value = rustTrim(line.substring(pos + 1))
+                if (acc.get(current).exists(_.contains(key))) {
+                  Left(
+                    Inconsistency(
+                      s"Error at line ${lineNumber}: key '${key}' is defined twice in section '${current}', " +
+                      s"which implementation wins is not specified for that file format"
+                    )
+                  )
+                } else {
+                  loop(tail, current, acc.updatedWith(current)(s => Some(s.getOrElse(Map.empty) + (key -> value))))
+                }
+            }
+          }
+      }
+    }
+
+    loop(lines, GlobalSection, Map.empty)
+  }
+
+  /*
+   * Check that every entry can be written and read back identically.
+   * All the entries are checked, so that the user gets every problem at once.
+   */
+  def checkEntries(values: List[(String, String)]): PureResult[Unit] = {
+    values.accumulatePure { case (k, v) => checkKey(k).flatMap(_ => checkValue(k, v)) }.map(_ => ())
+  }
+
+  /*
+   * Serialize one section. Values are kept ordered as they were provided.
+   */
+  def render(section: String, values: List[(String, String)]): PureResult[String] = {
+    for {
+      _ <- checkSection(section)
+      _ <- checkEntries(values)
+    } yield {
+      values.map {
+        case (k, v) =>
+          if (v.isEmpty) s"${k} ="
+          else s"${k} = ${v}"
+      }.mkString(s"[${section}]\n", "\n", "\n")
+    }
+  }
+
+  private def checkSection(section: String): PureResult[Unit] = {
+    if (section.isEmpty) Left(Inconsistency("An INI section name can not be empty"))
+    else if (section.exists(c => c == '[' || c == ']' || c == '\n' || c == '\r')) {
+      Left(Inconsistency(s"Invalid INI section name '${section}': it can not contain '[', ']' or a line break"))
+    } else Right(())
+  }
+
+  private def checkKey(key: String): PureResult[Unit] = {
+    if (key.isEmpty) Left(Inconsistency("An INI key can not be empty"))
+    else if (key.exists(c => c == '=' || c == '\n' || c == '\r')) {
+      Left(Inconsistency(s"Invalid INI key '${key}': it can not contain '=' or a line break"))
+    } else if (CommentMarkers.contains(key.charAt(0))) {
+      Left(Inconsistency(s"Invalid INI key '${key}': it can not start with '#' or ';', it would be read back as a comment"))
+    } else if (key.exists(isRustWhitespace)) {
+      Left(Inconsistency(s"Invalid INI key '${key}': it can not contain whitespace"))
+    } else Right(())
+  }
+
+  /*
+   * The format has no escaping, so anything we can not write verbatim must be refused.
+   *
+   * Two cases:
+   * - a line break could inject arbitrary keys into the file, for ex `x\nurl = http://evil.example`
+   * - leading/trailing whitespace is trimmed by every reader of that format
+   */
+  private def checkValue(key: String, value: String): PureResult[Unit] = {
+    if (value.exists(c => c == '\n' || c == '\r')) {
+      Left(Inconsistency(s"Value for '${key}' can not contain a line break: that file format has no escaping mechanism"))
+    } else if (value.nonEmpty && (isRustWhitespace(value.charAt(0)) || isRustWhitespace(value.charAt(value.length - 1)))) {
+      Left(
+        Inconsistency(
+          s"Value for '${key}' can not start or end with a whitespace character: " +
+          s"it would be trimmed when the file is read back"
+        )
+      )
+    } else Right(())
+  }
+}

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/IniTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/IniTest.scala
@@ -1,0 +1,237 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.utils
+
+import better.files.File
+import com.normation.errors.*
+import java.nio.charset.StandardCharsets
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+/*
+ * The first two examples are the Scala half of a cross-language conformance suite: they
+ * assert, value for value, the same things as `it_reads_values_verbatim_without_unescaping`
+ * and `it_trims_whitespace_around_keys_and_values` in
+ * `relay/sources/rudder-package/src/config.rs`, over the same fixture file.
+ *
+ * They exist because `/opt/rudder/etc/rudder-pkg/rudder-pkg.conf` is written by the webapp
+ * and read by both the webapp and `rudder package` (Rust). When the two readers disagree -
+ * which they did, the webapp used `java.util.Properties`, i.e. ISO-8859-1 plus backslash
+ * escape processing - credentials are corrupted on one side only and the failure surfaces
+ * as an authentication error far away from its cause.
+ *
+ * If you change one side, change the other.
+ */
+@RunWith(classOf[JUnitRunner])
+class IniTest extends Specification {
+
+  // surefire runs with the module directory as CWD; `basedir` is the fallback for IDEs
+  private val repositoryRoot = File(System.getProperty("basedir", ".")) / ".." / ".." / ".."
+  private val fixtures       = repositoryRoot / "relay" / "sources" / "rudder-package" / "tests" / "config"
+
+  private def readFixture(name: String): String = {
+    val f = fixtures / name
+    if (!f.exists) {
+      failure(s"Missing shared fixture '${f.pathAsString}'. It is the one shared with the Rust reader's tests.")
+    }
+    f.contentAsString(using StandardCharsets.UTF_8)
+  }
+
+  private def parsed(content: String): Ini = {
+    Ini.parse(content) match {
+      case Right(ini) => ini
+      case Left(err)  => throw new AssertionError(s"Could not parse: ${err.fullMsg}")
+    }
+  }
+
+  "The INI reader" should {
+
+    "read values verbatim, without unescaping" in {
+      val ini = parsed(readFixture("rudder-pkg.tricky.conf"))
+
+      ini.get("Rudder", "username") must beSome("user-é-ü")
+      // a backslash is a backslash: no escape sequence, no line continuation, no \uXXXX
+      // decoding, and `#`, `;` and `=` are ordinary characters inside a value
+      ini.get("Rudder", "password") must beSome("""p@ss\w0rd\\next#hash;semi=equals "quoted" spaced""")
+      ini.get("Rudder", "proxy_user") must beSome("mario")
+      ini.get("Rudder", "proxy_password") must beSome("mot-de-passe-é")
+    }
+
+    "trim whitespace around keys and values" in {
+      val ini = parsed("[Rudder]\n  username\t=\tuser  \n\tpassword =  s3cret \n")
+
+      ini.get("Rudder", "username") must beSome("user")
+      // consequence: a password with leading or trailing whitespace can not be
+      // represented in this format, which is why `render` refuses to write one
+      ini.get("Rudder", "password") must beSome("s3cret")
+    }
+
+    "read the default shipped configuration, empty values meaning 'unset'" in {
+      val ini = parsed(readFixture("rudder-pkg.conf"))
+
+      ini.get("Rudder", "username") must beSome("user")
+      // `proxy_url =`: present but empty. `split('=')` would have dropped it entirely.
+      ini.get("Rudder", "proxy_url") must beSome("")
+      ini.getNonEmpty("Rudder", "proxy_url") must beNone
+    }
+
+    "keep sections apart" in {
+      val ini = parsed("[Rudder]\npassword = good\n[Other]\npassword = bad\n")
+
+      ini.get("Rudder", "password") must beSome("good")
+      ini.get("Other", "password") must beSome("bad")
+    }
+
+    "only treat '#' and ';' as comments at the beginning of a line" in {
+      val ini = parsed("# a comment\n; another one\n[Rudder]\npassword = a#b;c\n")
+
+      ini.get("Rudder", "password") must beSome("a#b;c")
+    }
+
+    /*
+     * The cases below are where a reader written "the obvious way" silently disagrees
+     * with `serde_ini`: it looks at the very first character of the line, and it never
+     * trims a section name. Each one is mirrored in `config.rs`.
+     */
+    "not trim section names" in {
+      val ini = parsed("[ Rudder ]\nusername = user\n")
+
+      // for `rudder package` this means the settings are ignored, not read
+      ini.get("Rudder", "username") must beNone
+      ini.get(" Rudder ", "username") must beSome("user")
+    }
+
+    "refuse an indented section header" in {
+      Ini.parse("  [Rudder]\nusername = user\n") must beLeft
+    }
+
+    "refuse an indented comment" in {
+      Ini.parse("[Rudder]\n  # a comment\n") must beLeft
+    }
+
+    "refuse a blank but not empty line, and accept an empty one" in {
+      Ini.parse("[Rudder]\n \nusername = user\n") must beLeft
+      Ini.parse("[Rudder]\n\nusername = user\n") must beRight
+    }
+
+    "refuse a section name holding a closing bracket" in {
+      Ini.parse("[Rud]der]\n") must beLeft
+    }
+
+    "trim the Unicode definition of whitespace, not Java's" in {
+      // Java's `strip` keeps the non-breaking spaces that Rust's `trim` removes, so a
+      // plain `strip` here would read a different password than `rudder package` does
+      val ini = parsed("[Rudder]\npassword =" + 0x00a0.toChar + "s3cret" + 0x202f.toChar + "\n")
+
+      ini.get("Rudder", "password") must beSome("s3cret")
+    }
+
+    "refuse a line that is neither a section, a comment nor a key/value pair" in {
+      Ini.parse("[Rudder]\nnot a pair\n") must beLeft[RudderError].like { case err => err.fullMsg must contain("line 2") }
+    }
+
+    "refuse a key defined twice in the same section, rather than pick a winner" in {
+      Ini.parse("[Rudder]\npassword = one\npassword = two\n") must beLeft[RudderError].like {
+        case err => err.fullMsg must contain("defined twice")
+      }
+    }
+  }
+
+  "The INI writer" should {
+
+    val settings = List(
+      "url"            -> "https://download.rudder.io/plugins",
+      "username"       -> "user",
+      "password"       -> """p@ss\w0rd""",
+      "proxy_url"      -> "",
+      "proxy_user"     -> "",
+      "proxy_password" -> ""
+    )
+
+    "keep the layout of the file we ship" in {
+      Ini.render("Rudder", settings) must beRight(
+        """|[Rudder]
+           |url = https://download.rudder.io/plugins
+           |username = user
+           |password = p@ss\w0rd
+           |proxy_url =
+           |proxy_user =
+           |proxy_password =
+           |""".stripMargin
+      )
+    }
+
+    "round-trip every value it accepts" in {
+      val rendered = Ini.render("Rudder", settings) match {
+        case Right(s)  => s
+        case Left(err) => throw new AssertionError(err.fullMsg)
+      }
+      parsed(rendered).section("Rudder") must beEqualTo(settings.toMap)
+    }
+
+    /*
+     * The format has no escaping, so a newline in a value would not be lost, it would
+     * inject arbitrary keys: this is what used to let a password silently repoint the
+     * plugin repository URL.
+     */
+    "refuse a value containing a line break" in {
+      val injection = List("password" -> "x\nurl = http://evil.example")
+
+      Ini.render("Rudder", injection) must beLeft[RudderError].like { case err => err.fullMsg must contain("line break") }
+    }
+
+    "refuse a value that would be trimmed when read back" in {
+      Ini.render("Rudder", List("password" -> " leading")) must beLeft
+      Ini.render("Rudder", List("password" -> "trailing ")) must beLeft
+    }
+
+    /*
+     * Java's `Character.isWhitespace` excludes the non-breaking spaces, Rust's
+     * `char::is_whitespace` does not. `rudder package` would therefore trim a password
+     * bounded by one of them while we would keep it, and the two would disagree about
+     * the very same file - so we refuse to write it.
+     */
+    "refuse a value bounded by a non-breaking space, which Rust trims and Java does not" in {
+      val nbsp = "secret" + 0x00a0.toChar
+
+      nbsp.strip must beEqualTo(nbsp) // Java keeps it...
+      Ini.render("Rudder", List("password" -> nbsp)) must beLeft // ...so we must refuse it
+    }
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/29519

So, that was far less trivial than initially though, the main reason being that there isn't really a good, small INI parser in JVM that is maintained and matches `serde_ini` parsing/escaping even a bit. 

So it was easier (and more tedious) to just do our own. 

The main points: 
- we have a new INI reader/writer in scala in `util` packages following `serde_ini` semantic in the tiny subset that we use
    - and there is a lot of details about trim (serde doesn't do that), white spaces (they are not the same in java and rust), split (doesn't do what we want), etc. 
    - the general rule is that our file format is very strict (because of `serde_ini`), which is certainly good because it lets very few space for client file having diverged: they don't have the lattitude for that, not even a space in EOL. 
- we have a common test file and common test rules between rust and scala (the test file lives in the rust part), 
- we have a common `PluginSettingService` used everywhere in Rudder, including in CVE (see https://github.com/Normation/rudder-plugins-private/pull/1479)
- `rudder-pkg.conf` file is now a global property exposed in `RudderConfig` and used elsewhere (in plugins),
- we have an explicit list of known keys, in a specific order for `PluginSettings`, other are ignored. 


Most of the code is simple, just... I really would have prefered to not have to write here.
