### PR TITLE
Fixes #29500: Technique modification event log rollback causes sql error

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitItemRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitItemRepository.scala
@@ -267,6 +267,41 @@ trait GitConfigItemRepository extends GitItemRepository {
 }
 
 /**
+ * A `GitConfigItemRepository` that commits without linking the commit to the modification id.
+ *
+ * Sometimes, modId are linked to several operation that each have a linked commit entry (to keep the whole change traceable).
+ * But we don't always want to link the commits to that modId, typically for callback-like changes.
+ *
+ * So, use this mixin to enforce that a modification is not linked to a commit (e.g. for a secondary commit of a user change).
+ *
+ * See https://issues.rudder.io/issues/29500, for the case of technique callbacks
+ */
+trait GitConfigItemRepositoryWithoutModId extends GitConfigItemRepository {
+
+  override def commitAddFileWithModId(
+      modId:         ModificationId,
+      commiter:      PersonIdent,
+      gitPath:       String,
+      commitMessage: String
+  ): IOResult[GitCommitId] = commitAddFile(commiter, gitPath, commitMessage)
+
+  override def commitRmFileWithModId(
+      modId:         ModificationId,
+      commiter:      PersonIdent,
+      gitPath:       String,
+      commitMessage: String
+  ): IOResult[GitCommitId] = commitRmFile(commiter, gitPath, commitMessage)
+
+  override def commitMvDirectoryWithModId(
+      modId:         ModificationId,
+      commiter:      PersonIdent,
+      oldGitPath:    String,
+      newGitPath:    String,
+      commitMessage: String
+  ): IOResult[GitCommitId] = commitMvDirectory(commiter, oldGitPath, newGitPath, commitMessage)
+}
+
+/**
  * Utility trait that factor global commit and tags.
  */
 trait GitArchiverFullCommitUtils extends NamedZioLogger {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -38,11 +38,8 @@
 package com.normation.rudder.repository.xml
 
 import com.normation.NamedZioLogger
-import com.normation.cfclerk.domain.RootTechniqueCategoryId
 import com.normation.cfclerk.domain.SectionSpec
-import com.normation.cfclerk.domain.SubTechniqueCategoryId
 import com.normation.cfclerk.domain.Technique
-import com.normation.cfclerk.domain.TechniqueCategoryId
 import com.normation.cfclerk.domain.TechniqueCategoryMetadata
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
@@ -65,7 +62,9 @@ import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitArchiverFullCommitUtils
+import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitConfigItemRepository
+import com.normation.rudder.git.GitConfigItemRepositoryWithoutModId
 import com.normation.rudder.git.GitPath
 import com.normation.rudder.git.GitRepositoryProvider
 import com.normation.rudder.ncf.ResourceFile
@@ -245,17 +244,6 @@ trait TechniqueArchiver {
       msg:         String
   ): IOResult[Unit]
 
-  /*
-   * Delete a category with all files and techniques it contains.
-   * WARNING: you should probably not do that.
-   */
-  def deleteCategoryRecursively(
-      categoryId: TechniqueCategoryId,
-      modId:      ModificationId,
-      committer:  EventActor,
-      msg:        String
-  ): IOResult[Unit]
-
   def saveTechnique(
       techniqueId:     TechniqueId,
       categories:      Seq[String],
@@ -271,19 +259,6 @@ trait TechniqueArchiver {
       modId:      ModificationId,
       committer:  EventActor,
       msg:        String
-  ): IOResult[Unit]
-
-  /*
-   * Add or update a technique category with all its content, recursively.
-   * In intent, it's a:
-   * `git -a categoryPath; git -u categoryPath; git commit`
-   * If the category path doesn't exists, it's a no-op.
-   */
-  def updateTechniqueCategoryRecursively(
-      category:  TechniqueCategoryId,
-      modId:     ModificationId,
-      committer: EventActor,
-      msg:       String
   ): IOResult[Unit]
 
   /*
@@ -370,30 +345,18 @@ class TechniqueArchiverImpl(
       ident        <- personIdentservice.getPersonIdentOrDefault(committer.name)
       // construct the path to the technique. Root category is "/", so we filter out all / to be sure
       categoryPath <- categories.filter(_ != "/").mkString("/").succeed
-      rm           <- IOResult.attempt(gitRepo.git.rm.addFilepattern(s"${relativePath}/${categoryPath}/${techniqueId.serialize}").call())
 
-      commit <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+      commit <-
+        gitRepo.semaphore.withPermit(for {
+          rm     <-
+            IOResult.attempt(gitRepo.git.rm.addFilepattern(s"${relativePath}/${categoryPath}/${techniqueId.serialize}").call())
+          rev    <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+          commit <- IOResult.attempt(GitCommitId(rev.getName))
+        } yield commit)
+      _      <- gitModificationRepository.addCommit(commit, modId)
     } yield {
       s"${relativePath}/${categoryPath}/${techniqueId.serialize}"
     }).chainError(s"error when deleting and committing Technique '${techniqueId.serialize}").unit
-  }
-
-  def deleteCategoryRecursively(
-      categoryId: TechniqueCategoryId,
-      modId:      ModificationId,
-      committer:  EventActor,
-      msg:        String
-  ): IOResult[Unit] = {
-    (for {
-      ident        <- personIdentservice.getPersonIdentOrDefault(committer.name)
-      // construct the path to the technique. Root category is "/", so we filter out all / to be sure
-      categoryPath <- categoryId match {
-                        case RootTechniqueCategoryId => Inconsistency("You can't delete root technique category").fail
-                        case s: SubTechniqueCategoryId => s.getPathFromRoot.tail.map(_.value).mkString("/").succeed
-                      }
-      _            <- IOResult.attempt(gitRepo.git.rm.addFilepattern(s"${relativePath}/${categoryPath}").call())
-      _            <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
-    } yield ()).chainError(s"error when deleting and committing category '${categoryId.toString}").unit
   }
 
   /*
@@ -486,10 +449,15 @@ class TechniqueArchiverImpl(
       tech       <- techniqueParser.parseXml(metadata, techniqueId).toIO
       files       = getFilesToCommit(tech, techniqueGitPath, fileStates)
       ident      <- personIdentservice.getPersonIdentOrDefault(committer.name)
-      _          <- ZIO.foreach(files.add)(f => IOResult.attempt(gitRepo.git.add.addFilepattern(f).call()))
-      _          <- ZIO.foreach(files.delete)(f => IOResult.attempt(gitRepo.git.rm.addFilepattern(f).call()))
-      _          <- ZIO.foreach(files.stage)(f => IOResult.attempt(gitRepo.git.add.setUpdate(true).addFilepattern(f).call()))
-      _          <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+
+      commit <- gitRepo.semaphore.withPermit(for {
+                  _      <- ZIO.foreach(files.add)(f => IOResult.attempt(gitRepo.git.add.addFilepattern(f).call()))
+                  _      <- ZIO.foreach(files.delete)(f => IOResult.attempt(gitRepo.git.rm.addFilepattern(f).call()))
+                  _      <- ZIO.foreach(files.stage)(f => IOResult.attempt(gitRepo.git.add.setUpdate(true).addFilepattern(f).call()))
+                  rev    <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+                  commit <- IOResult.attempt(GitCommitId(rev.getName))
+                } yield commit)
+      _      <- gitModificationRepository.addCommit(commit, modId)
     } yield ()).chainError(s"error when committing Technique '${techniqueId.serialize}'").unit
   }
 
@@ -503,9 +471,9 @@ class TechniqueArchiverImpl(
   }
 
   def saveTechniqueCategory(
-      categories: Seq[String], // path (inclusive) to the category
+      categories: Seq[String],    // path (inclusive) to the category
       metadata:   TechniqueCategoryMetadata,
-      modId:      ModificationId,
+      modId:      ModificationId, // unused: no gitcommit for technique category save, which has no rollback commit
       committer:  EventActor,
       msg:        String
   ): IOResult[Unit] = {
@@ -530,32 +498,14 @@ class TechniqueArchiverImpl(
                           ident <- personIdentservice.getPersonIdentOrDefault(committer.name)
                           parent = categoryFile.parent
                           _     <- writeXml(categoryFile.toJava, xml, s"Archived technique category: ${catGitPath}")
-                          _     <- IOResult.attempt(gitRepo.git.add.addFilepattern(catGitPath).call())
-                          _     <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+                          _     <- gitRepo.semaphore.withPermit(IOResult.attempt {
+                                     gitRepo.git.add.addFilepattern(catGitPath).call()
+                                     gitRepo.git.commit.setCommitter(ident).setMessage(msg).call()
+                                   })
                         } yield ()
                       }
         } yield ()).chainError(s"error when committing technique category '${catGitPath}'").unit
     }
-  }
-
-  override def updateTechniqueCategoryRecursively(
-      categoryId: TechniqueCategoryId,
-      modId:      ModificationId,
-      committer:  EventActor,
-      msg:        String
-  ): IOResult[Unit] = {
-    (for {
-      ident       <- personIdentservice.getPersonIdentOrDefault(committer.name)
-      // construct the path to the technique. Root category is "/", so we filter out all / to be sure
-      categoryPath = categoryId match {
-                       case RootTechniqueCategoryId => ""
-                       case s: SubTechniqueCategoryId => s.getPathFromRoot.tail.map(_.value).mkString("/")
-                     }
-      filePattern  = s"${relativePath}/${categoryPath}"
-      _           <- IOResult.attempt(gitRepo.git.add.addFilepattern(filePattern).call())
-      _           <- IOResult.attempt(gitRepo.git.add.setUpdate(true).addFilepattern(filePattern).call())
-      _           <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
-    } yield ()).chainError(s"error when adding/updating and committing category '${categoryId.toString}").unit
   }
 }
 
@@ -569,6 +519,9 @@ class TechniqueArchiverImpl(
  * Basically, we directly map the category tree to file-system directories,
  * with the root category being the file denoted by "techniqueLibraryRootDir"
  *
+ * It archives without linking its commits to the modification ([[GitConfigItemRepositoryWithoutModId]]).
+ * An active technique category has even no event log, so there is no need to link modification to commit.
+ * Similarly to [[GitActiveTechniqueArchiverImpl]], its is triggered from changes in the technique library.
  */
 class GitActiveTechniqueCategoryArchiverImpl(
     override val gitRepo:                 GitRepositoryProvider,
@@ -580,7 +533,7 @@ class GitActiveTechniqueCategoryArchiverImpl(
     override val encoding:                  String,
     serializedCategoryName:                 String,
     override val groupOwner:                String
-) extends GitActiveTechniqueCategoryArchiver with Loggable with GitConfigItemRepository with XmlArchiverUtils
+) extends GitActiveTechniqueCategoryArchiver with Loggable with GitConfigItemRepositoryWithoutModId with XmlArchiverUtils
     with BuildCategoryPathName[ActiveTechniqueCategoryId] with GitArchiverFullCommitUtils {
 
   override def loggerName: String = this.getClass.getName
@@ -758,7 +711,6 @@ class UpdatePiOnActiveTechniqueEvent(
   override val uptModificationCallbackName = "Update PI on UPT events"
 
   override def loggerName: String = this.getClass.getName
-  // TODO: why gitCommit is not used here ?
   override def onArchive(
       activeTechnique: ActiveTechnique,
       parents:         List[ActiveTechniqueCategoryId],
@@ -820,6 +772,14 @@ class UpdatePiOnActiveTechniqueEvent(
 
 /**
  * A specific trait to create archive of an active technique.
+ * It archives without linking its commits to the modification ([[GitConfigItemRepositoryWithoutModId]]).
+ *
+ * The event logs of an active technique change (`ModifyTechnique`, `DeleteTechnique`) are simply not rollback-able.
+ *
+ * So we don't want to commit anything in this archiver since modifications is triggered from changes in
+ * the technique library (a modification is linked to the technique library commit, prior to reaching active techniques).
+ *
+ * See https://issues.rudder.io/issues/29500
  */
 class GitActiveTechniqueArchiverImpl(
     override val gitRepo:         GitRepositoryProvider,
@@ -832,7 +792,7 @@ class GitActiveTechniqueArchiverImpl(
     override val encoding:                  String,
     val activeTechniqueFileName:            String,
     override val groupOwner:                String
-) extends GitActiveTechniqueArchiver with NamedZioLogger with GitConfigItemRepository with XmlArchiverUtils
+) extends GitActiveTechniqueArchiver with NamedZioLogger with GitConfigItemRepositoryWithoutModId with XmlArchiverUtils
     with BuildCategoryPathName[ActiveTechniqueCategoryId] {
 
   override def loggerName: String = this.getClass.getName

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
@@ -612,15 +612,17 @@ object PartialArchive {
   val ruleArchive:      PartialArchive = PartialArchive("rules/")
   val directiveArchive: PartialArchive = PartialArchive("directives/")
   val ncfArchive:       PartialArchive = PartialArchive("ncf/")
+  val techniqueArchive: PartialArchive = PartialArchive("techniques/")
   val parameterArchive: PartialArchive = PartialArchive("parameters/")
 }
 
 import com.normation.rudder.repository.xml.PartialArchive.*
 
 case object TechniqueLibraryArchive extends ArchiveMode {
-  def configureRm(rmCmd: RmCommand): RmCommand = directiveArchive.configureRm(ncfArchive.configureRm(rmCmd))
+  def configureRm(rmCmd: RmCommand):             RmCommand       =
+    directiveArchive.configureRm(ncfArchive.configureRm(techniqueArchive.configureRm(rmCmd)))
   def configureCheckout(coCmd: CheckoutCommand): CheckoutCommand =
-    directiveArchive.configureCheckout(ncfArchive.configureCheckout(coCmd))
+    directiveArchive.configureCheckout(ncfArchive.configureCheckout(techniqueArchive.configureCheckout(coCmd)))
 }
 case object FullArchive             extends ArchiveMode {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/SecurityContext.scala
@@ -214,8 +214,8 @@ final case class QueryContext(
   /*
    * Create a fresh new ChangeContext, with a new modification ID, from that QueryContext
    */
-  def newCC(message: Option[String] = None): ChangeContext = {
-    ChangeContext.newFor(actor, accessGrant, message, actorIp)
+  def newCC(message: Option[String] = None, modId: Option[ModificationId] = None): ChangeContext = {
+    ChangeContext.newFor(actor, accessGrant, message, modId, actorIp)
   }
 }
 
@@ -269,12 +269,13 @@ object ChangeContext {
       actor:       EventActor,
       accessGrant: TenantAccessGrant,
       message:     Option[String] = None,
+      modId:       Option[ModificationId] = None,
       actorIp:     Option[String] = None
   ): ChangeContext = {
     ChangeContext(
       actor,
       accessGrant,
-      ModificationId(java.util.UUID.randomUUID.toString),
+      modId.getOrElse(ModificationId(java.util.UUID.randomUUID.toString)),
       Instant.now(),
       message,
       actorIp
@@ -282,7 +283,11 @@ object ChangeContext {
 
   }
 
-  def newForRudder(message: Option[String] = None, actorIp: Option[String] = None): ChangeContext = {
-    newFor(eventlog.RudderEventActor, TenantAccessGrant.All, message, actorIp)
+  def newForRudder(
+      message: Option[String] = None,
+      modId:   Option[ModificationId] = None,
+      actorIp: Option[String] = None
+  ): ChangeContext = {
+    newFor(eventlog.RudderEventActor, TenantAccessGrant.All, message, modId, actorIp)
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -257,10 +257,25 @@ class MockGitConfigRepo(prefixTestResources: String = "", configRepoDirName: Str
     }
   }
 
-  val gitModificationRepository: GitModificationRepository = new GitModificationRepository {
-    override def getCommits(modificationId: ModificationId): IOResult[Option[GitCommitId]] = None.succeed
-    override def addCommit(commit: GitCommitId, modId: ModificationId): IOResult[DB.GitCommitJoin] =
-      DB.GitCommitJoin(commit, modId).succeed
+  val gitModificationRepository: MockGitModificationRepository = new MockGitModificationRepository()
+}
+
+class MockGitModificationRepository extends GitModificationRepository {
+
+  private val commits: Ref[Map[ModificationId, Chunk[GitCommitId]]] =
+    Ref.make(Map.empty[ModificationId, Chunk[GitCommitId]]).runNow
+
+  // get all the commits recorded for that modId, in insertion order
+  def getAllCommits(modificationId: ModificationId): IOResult[Chunk[GitCommitId]] = {
+    commits.get.map(_.getOrElse(modificationId, Chunk.empty))
+  }
+
+  override def getCommits(modificationId: ModificationId): IOResult[Option[GitCommitId]] = {
+    getAllCommits(modificationId).map(_.headOption)
+  }
+
+  override def addCommit(commit: GitCommitId, modId: ModificationId): IOResult[DB.GitCommitJoin] = {
+    commits.update(m => m + (modId -> (m.getOrElse(modId, Chunk.empty) :+ commit))).as(DB.GitCommitJoin(commit, modId))
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -134,15 +134,6 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         msg:         String
     ): IOResult[Unit] = ZIO.unit
 
-    override def deleteCategoryRecursively(
-        categoryId: TechniqueCategoryId,
-        modId:      ModificationId,
-        committer:  EventActor,
-        msg:        String
-    ): IOResult[Unit] = {
-      ZIO.unit
-    }
-
     override def saveTechnique(
         techniqueId:     TechniqueId,
         categories:      Seq[String],
@@ -159,15 +150,6 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         committer:  EventActor,
         msg:        String
     ): IOResult[Unit] = ZIO.unit
-
-    override def updateTechniqueCategoryRecursively(
-        category:  TechniqueCategoryId,
-        modId:     ModificationId,
-        committer: EventActor,
-        msg:       String
-    ): IOResult[Unit] = {
-      ZIO.unit
-    }
 
     override def parseTechnique(techniqueId: TechniqueId, techniquePath: File): IOResult[Technique] = {
       Unexpected("parseTechnique is not implemented").fail

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -52,6 +52,7 @@ import com.normation.cfclerk.services.UpdateTechniqueLibrary
 import com.normation.cfclerk.xmlparsers.TechniqueParser
 import com.normation.errors.*
 import com.normation.eventlog.EventMetadata
+import com.normation.eventlog.ModificationId
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonResponseObjects.JRDirective
 import com.normation.rudder.apidata.JsonResponseObjects.JRGroup
@@ -1768,7 +1769,8 @@ class SaveArchiveServicebyRepo(
    * Starts with techniques then other things.
    */
   override def save(archive: PolicyArchive, mergePolicy: MergePolicy)(implicit qc: QueryContext): IOResult[Unit] = {
-    implicit val cc: ChangeContext = qc.newCC(Some(s"Importing archive '${archive.metadata.filename}'"))
+    implicit val cc: ChangeContext =
+      qc.newCC(Some(s"Importing archive '${archive.metadata.filename}'"), Some(ModificationId(uuidGen.newUuid)))
     val eventMetadata = cc.transformInto[EventMetadata]
     for {
       _ <- ZIO.foreach(archive.techniqueCats)(saveTechniqueCat(eventMetadata, _))

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SaveArchiveServiceTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SaveArchiveServiceTest.scala
@@ -40,24 +40,32 @@ import com.normation.cfclerk.domain.RootTechniqueCategory
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueResourceId
-import com.normation.cfclerk.services.TechniqueReader
-import com.normation.cfclerk.services.TechniquesInfo
-import com.normation.cfclerk.services.TechniquesLibraryUpdateType
+import com.normation.cfclerk.domain.TechniqueVersion
+import com.normation.cfclerk.services.*
 import com.normation.errors.IOResult
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockRules
+import com.normation.rudder.MockTechniques
 import com.normation.rudder.rest.lift.JRuleCategories
 import com.normation.rudder.rest.lift.MergePolicy
 import com.normation.rudder.rest.lift.PolicyArchive
 import com.normation.rudder.rest.lift.RuleCategoryArchive
 import com.normation.rudder.rest.lift.SaveArchiveService
 import com.normation.rudder.rest.lift.SaveArchiveServicebyRepo
+import com.normation.rudder.rest.lift.TechniqueArchive
+import com.normation.rudder.rest.lift.TechniqueInfo
+import com.normation.rudder.rest.lift.TechniqueType
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.utils.StringUuidGenerator
 import io.scalaland.chimney.syntax.*
 import java.io.InputStream
 import net.liftweb.actor.MockLiftActor
+import net.liftweb.common.Box
+import net.liftweb.common.Full
 import org.junit.runner.RunWith
 import scala.collection.SortedSet
 import zio.Chunk
@@ -71,7 +79,9 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
 
   implicit val qc: QueryContext = QueryContext.testQC
 
-  val mockRules = new MockRules()
+  val mockRules         = MockRules()
+  val mockGitConfigRepo = MockGitConfigRepo()
+  val mockTechniques    = MockTechniques(mockGitConfigRepo)
 
   val rootRuleCategory            = mockRules.rootRuleCategory
   val ruleCategory2               = RuleCategory(RuleCategoryId("category2"), "Category 2", "", Nil, security = None)
@@ -94,30 +104,35 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
 
   override def spec: Spec[TestEnvironment & Scope, Any] = {
     suite("SaveArchiveService")(
-      testSaveRuleCategories("save initial root rule category idempotently")(
-        policyArchiveRuleCategory(rootRuleCategory),
-        rootRuleCategory
-      ) @@ TestAspect.repeats(2),
-      testSaveRuleCategories("keep old rule category when tree is empty")(
-        policyArchiveRuleCategory(rootRuleCategory.copy(childs = Nil)),
-        rootRuleCategory
-      ),
-      testSaveRuleCategories("save new rule category2")(
-        policyArchiveRuleCategory(rootRuleCategoryWithCat2),
-        rootRuleCategoryWithCat12
-      ),
-      test("move nested rule category2")(
-        // the expected value is wrong : the test Repo does something unexpected, it leads to multiple categories with same ID, and the root is moved.
-        // for now, check that the "rootRuleCategory" effectively contains the expected format
-        withCtx(_.save(policyArchiveRuleCategory(rootRuleCategoryWithSubcat2), MergePolicy.KeepRuleTargets))(
-          root =>
-            root
-              .find(rootRuleCategory.id)
-              .map(_._1)
-              .getOrElse(rootRuleCategory)
-              .transformInto[JRuleCategories],
-          Assertion.equalTo(rootRuleCategoryWithSubcat2.transformInto[JRuleCategories])
+      suite("save ruleCategory")(
+        testSaveRuleCategories("save initial root rule category idempotently")(
+          policyArchiveRuleCategory(rootRuleCategory),
+          rootRuleCategory
+        ) @@ TestAspect.repeats(2),
+        testSaveRuleCategories("keep old rule category when tree is empty")(
+          policyArchiveRuleCategory(rootRuleCategory.copy(childs = Nil)),
+          rootRuleCategory
+        ),
+        testSaveRuleCategories("save new rule category2")(
+          policyArchiveRuleCategory(rootRuleCategoryWithCat2),
+          rootRuleCategoryWithCat12
+        ),
+        test("move nested rule category2")(
+          // the expected value is wrong : the test Repo does something unexpected, it leads to multiple categories with same ID, and the root is moved.
+          // for now, check that the "rootRuleCategory" effectively contains the expected format
+          withRuleCtx(_.save(policyArchiveRuleCategory(rootRuleCategoryWithSubcat2), MergePolicy.KeepRuleTargets))(
+            root =>
+              root
+                .find(rootRuleCategory.id)
+                .map(_._1)
+                .getOrElse(rootRuleCategory)
+                .transformInto[JRuleCategories],
+            Assertion.equalTo(rootRuleCategoryWithSubcat2.transformInto[JRuleCategories])
+          )
         )
+      ),
+      suite("save technique")(
+        testSaveTechnique("save gitcommit")(policyArchiveTechnique)
       )
     ) @@ TestAspect.sequential
   }
@@ -126,17 +141,67 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
     PolicyArchive.empty("test archive").copy(ruleCats = Chunk.single(rootCategory.transformInto[RuleCategoryArchive]))
   }
 
+  private def policyArchiveTechnique = {
+    val techniqueCategory = Chunk("ncf_techniques")
+    val techniqueId       = TechniqueId(
+      TechniqueName("technique_with_blocks"),
+      TechniqueVersion.parse("1.0").getOrElse(throw new IllegalArgumentException("test technique version must be parsable"))
+    )
+
+    val techniqueDir =
+      mockGitConfigRepo.configurationRepositoryRoot / "techniques" / techniqueCategory.mkString("/") / techniqueId.serialize
+    val files        = Chunk.fromIterable(
+      techniqueDir.collectChildren(!_.isDirectory).map(f => (techniqueDir.relativize(f).toString, f.byteArray)).toList
+    )
+
+    PolicyArchive
+      .empty("test archive")
+      .copy(techniques = {
+        Chunk.single(
+          TechniqueArchive(
+            TechniqueInfo(
+              TechniqueId(
+                TechniqueName("technique_with_blocks"),
+                TechniqueVersion.parse("1.0").getOrElse(throw new IllegalArgumentException("test"))
+              ),
+              "technique with blocks",
+              TechniqueType.Yaml
+            ),
+            techniqueCategory,
+            files
+          )
+        )
+      })
+  }
+
   /**
    * Test the result using JRuleCategories, which sorts children by id
    */
   private def testSaveRuleCategories(label: String)(policyArchive: PolicyArchive, expectedRoot: RuleCategory) = test(label) {
-    withCtx(_.save(policyArchive, MergePolicy.KeepRuleTargets))(
+    withRuleCtx(_.save(policyArchive, MergePolicy.KeepRuleTargets))(
       _.transformInto[JRuleCategories],
       Assertion.equalTo(expectedRoot.transformInto[JRuleCategories])
     )
   }
 
-  private def withCtx[A](save: SaveArchiveService => IOResult[Unit])(transform: RuleCategory => A, assertion: Assertion[A]) = {
+  /**
+   * Test that saving a technique generates a commit that is traced in gitModificationRepository
+   * (https://issues.rudder.io/issues/29500)
+   */
+  private def testSaveTechnique(label: String)(policyArchive: PolicyArchive) = test(label) {
+    withTechniqueCtx(s => {
+      for {
+        _       <- s.save(policyArchive, MergePolicy.KeepRuleTargets)
+        commits <- mockGitConfigRepo.gitModificationRepository.getAllCommits(ModificationId(stubUuidGen.newUuid))
+      } yield {
+        assertTrue(commits.size == 1)
+      }
+    })
+  }
+
+  private def withRuleCtx[A](
+      save: SaveArchiveService => IOResult[Unit]
+  )(transform: RuleCategory => A, assertion: Assertion[A]) = {
     val ruleCategoryRepo = mockRules.ruleCategoryRepo
     val archiveSaver     = new SaveArchiveServicebyRepo(
       null,
@@ -151,7 +216,7 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
       ruleCategoryRepo,
       null,
       mockActor,
-      dummyUuidGen
+      stubUuidGen
     )
     for {
       _    <- save(archiveSaver)
@@ -160,12 +225,36 @@ class SaveArchiveServiceTest extends ZIOSpecDefault {
       assert(transform(root))(assertion)
     }
   }
+
+  private def withTechniqueCtx[R](save: SaveArchiveService => R): R = {
+    val archiveSaver = new SaveArchiveServicebyRepo(
+      mockTechniques.techniqueArchiver,
+      mockTechniques.techniqueReader,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      dummyTechLibUpdate,
+      mockActor,
+      stubUuidGen
+    )
+    save(archiveSaver)
+  }
 }
 
 private object SaveArchiveServiceTest {
-  private val mockActor    = new MockLiftActor
-  private val dummyUuidGen = new StringUuidGenerator { override def newUuid: String = "not used" }
+  private val mockActor   = new MockLiftActor
+  private val stubUuidGen = new StringUuidGenerator { override def newUuid: String = "11111111-1111-1111-1111-111111111111" }
 
+  private val dummyTechLibUpdate   = new UpdateTechniqueLibrary {
+    override def update()(implicit cc: ChangeContext): Box[Map[TechniqueName, TechniquesLibraryUpdateType]] = Full(Map.empty)
+
+    override def registerCallback(callback: TechniquesLibraryUpdateNotification): Unit = ()
+  }
   private val dummyTechniqueReader = new TechniqueReader {
     override def readTechniques: TechniquesInfo = TechniquesInfo(
       RootTechniqueCategory("name", "description", Set.empty, SortedSet.empty, isSystem = false, security = None),

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -76,6 +76,7 @@ import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.queries.*
 import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.facts.nodes.*
+import com.normation.rudder.git.GitConfigItemRepositoryWithoutModId
 import com.normation.rudder.git.GitItemRepository
 import com.normation.rudder.git.GitRepositoryProvider
 import com.normation.rudder.git.GitRepositoryProviderImpl
@@ -2911,6 +2912,16 @@ object RudderConfigInit {
       RUDDER_CHARSET.name,
       RUDDER_GROUP_OWNER_CONFIG_REPO
     )
+    // only for `UpdatePiOnActiveTechniqueEvent`, see where it is registered
+    lazy val gitDirectiveArchiverWithoutModId:   GitDirectiveArchiver               = new GitDirectiveArchiverImpl(
+      gitConfigRepo,
+      directiveSerialisation,
+      userLibraryDirectoryName,
+      prettyPrinter,
+      gitModificationRepository,
+      RUDDER_CHARSET.name,
+      RUDDER_GROUP_OWNER_CONFIG_REPO
+    ) with GitConfigItemRepositoryWithoutModId
     lazy val gitNodeGroupArchiver:               GitNodeGroupArchiver               = new GitNodeGroupArchiverImpl(
       gitConfigRepo,
       nodeGroupSerialisation,
@@ -2956,8 +2967,12 @@ object RudderConfigInit {
         RUDDER_AUTOARCHIVEITEMS
       )
 
+      // re-archiving the directives is only a consequence of archiving their active technique, which does not
+      // link its commits to the modification: those directives must not link theirs either, else a change on
+      // the reference technique library would link a second commit to its modification, see
+      // https://issues.rudder.io/issues/29500
       gitActiveTechniqueArchiver.uptModificationCallback += new UpdatePiOnActiveTechniqueEvent(
-        gitDirectiveArchiver,
+        gitDirectiveArchiverWithoutModId,
         techniqueRepositoryImpl,
         roLdapDirectiveRepository
       )


### PR DESCRIPTION
https://issues.rudder.io/issues/29500

This one is a crazy combination of bugs, each one needed to be fixed to make it work (see the list below).

It revolves around the `gitcommit` table (which has no constraint, so it allows duplicate pairs): 
```sql
+----------------+------+-----------+
| Column         | Type | Modifiers |
|----------------+------+-----------|
| gitcommit      | text |  not null |
| modificationid | text |           |
+----------------+------+-----------+
Indexes:
    "gitcommit_pkey" PRIMARY KEY, btree (gitcommit)

+------------------------------------------+--------------------------------------+
| gitcommit                                | modificationid                       |
|------------------------------------------+--------------------------------------|
| 4607c5a8d94b7a7ec3351a2285aec89aded6d3fa | 7a714ee5-cd69-4122-971d-1ed5a517501e |
| 9dbc4a0dd759e3068eaad982a90417270337d5e2 | 7a714ee5-cd69-4122-971d-1ed5a517501e |
+------------------------------------------+--------------------------------------+
```

Upon reading the `gitcommit` table with doobie, we assume that we have one single match:
  * I left it untouched, it's a bigger architectural issues on eventlogs that need to be addressed in upper branches   
  * the proposed solution is to ensure we write something that we can read back: write a unique (gitcommit, modificationid) pair 

---
### The bugs that were fixed

1. appending the commit of the technique modifications in `configuration-repository/techniques` to the table was simply forgotten (upon save and deletion, in `TechniqueArchiverImpl`)
    * but simply adding the commit will conflict with number 2:
2. rollback of the technique commit happened on the wrong modification, there was a `modificationid` bound to the wrong commit which changed `configuration-repository/directives`, the culprit is the _callback_ `TechniqueAcceptationUpdater`:
    * solution is to avoid linking the `modificationid` of callbacks to a commit: use a dedicated implementation that do not commit (see https://github.com/Normation/rudder/pull/7452#issuecomment-5512592436)
3. the same solution needs to be applied to `DeleteEditorTechniqueImpl`, which otherwise would generate multiple commits in the table for the same modification
4. with all that, restoration of `techniques/` was not possible until it's correctly added to `PartialArchive`  
5. (a small one:) the semaphore of git repo was not used: it needs to be 

---
### Other changes
* addition of tests when saving a technique, to ensure that the git commit list in memory is correctly updated
* change of utility `newCC`: add the optional `modId`, it looks fine with 9.2
* cleanup of unused methods in the archiver class