### PR TITLE
Fixes #29667: Define global vars for group/rule root categories to avoid misnaming

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/Constants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/Constants.scala
@@ -38,6 +38,8 @@
 package com.normation.rudder.domain
 
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.rule.category.RuleCategoryId
 
 object Constants {
 
@@ -114,4 +116,8 @@ object Constants {
 
   // for secret variable
   val XML_TAG_SECRET = "secret"
+
+  // root of things
+  val ROOT_GROUP_CATEGORY = NodeGroupCategoryId("GroupRoot")
+  val ROOT_RULE_CATEGORY  = RuleCategoryId("rootRuleCategory")
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
@@ -50,6 +50,7 @@ import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.xmlparsers.TechniqueParser
 import com.normation.errors.*
 import com.normation.rudder.configuration.GroupAndCat
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.logger.ConfigurationLoggerPure
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupUid
@@ -282,7 +283,7 @@ class GitParseGroupLibrary(
 
   // the root category is stored in the group library directory itself, so contrary to the other
   // categories, its ID can not be read back from the path of the files it holds
-  private val rootCategoryId = NodeGroupCategoryId("GroupRoot")
+  private val rootCategoryId = Constants.ROOT_GROUP_CATEGORY
 
   val groupsDirectory: GitRootCategory = getGitDirectoryPath(libRootDirectory)
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -80,7 +80,6 @@ import com.normation.rudder.domain.queries.QueryReturnType.NodeAndRootServerRetu
 import com.normation.rudder.domain.queries.ResultTransformation
 import com.normation.rudder.domain.queries.StringComparator
 import com.normation.rudder.repository.EventLogRepository
-import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.servers.json.*
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
@@ -678,7 +677,7 @@ object PolicyServerConfigurationObjects {
     Rule(
       RuleId(RuleUid(s"hasPolicyServer-${nodeId.value}")),
       s"Rudder system policy: basic setup (common) - ${nodeId.value}",
-      RuleCategoryId("rootRuleCategory"),
+      Constants.ROOT_RULE_CATEGORY,
       Set(GroupTarget(idGroupHasPolicyServer(nodeId))),
       Set(DirectiveId(DirectiveUid(s"common-hasPolicyServer-${nodeId.value}"))),
       "Common - Technical",
@@ -693,7 +692,7 @@ object PolicyServerConfigurationObjects {
     Rule(
       RuleId(RuleUid(s"policy-server-${nodeId.value}")),
       s"Rule for policy server ${nodeId.value}",
-      RuleCategoryId("rootRuleCategory"),
+      Constants.ROOT_RULE_CATEGORY,
       Set(PolicyServerTarget(nodeId)),
       techniques.map(t => DirectiveId(DirectiveUid(s"${t}-${nodeId.value}"))).toSet,
       "Server components configuration - Technical",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -65,6 +65,7 @@ import com.normation.rudder.configuration.DirectiveRevisionRepository
 import com.normation.rudder.configuration.GroupRevisionRepository
 import com.normation.rudder.configuration.RuleRevisionRepository
 import com.normation.rudder.db.DB
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.NodeDit
 import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.archives.ParameterArchiveId
@@ -1315,7 +1316,7 @@ class MockRules(mockTenants: MockTenants) {
   val t1: Long = System.currentTimeMillis()
 
   val rootRuleCategory: RuleCategory = RuleCategory(
-    RuleCategoryId("rootRuleCategory"),
+    Constants.ROOT_RULE_CATEGORY,
     "Rules",
     "This is the main category of Rules",
     RuleCategory(RuleCategoryId("category1"), "Category 1", "description of category 1", Nil, security = None) :: Nil,
@@ -2752,7 +2753,7 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam, moc
     val categories: Ref.Synchronized[FullNodeGroupCategory] = Ref.Synchronized
       .make(
         FullNodeGroupCategory(
-          NodeGroupCategoryId("GroupRoot"),
+          Constants.ROOT_GROUP_CATEGORY,
           name = "GroupRoot",
           description = "root of group categories",
           subCategories = Nil,
@@ -3249,7 +3250,7 @@ class MockNodeGroups(mockNodes: MockNodes, mockGlobalParam: MockGlobalParam, moc
   }
 
   val groupLib: FullNodeGroupCategory = FullNodeGroupCategory(
-    NodeGroupCategoryId("GroupRoot"),
+    Constants.ROOT_GROUP_CATEGORY,
     "GroupRoot",
     "root of group categories",
     List(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/BasicLdapPersistenceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/BasicLdapPersistenceTest.scala
@@ -40,10 +40,10 @@ package com.normation.rudder.repository.ldap
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.queries.*
-import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.tenants.*
 import com.normation.zio.*
 import java.time.Instant
@@ -156,7 +156,7 @@ class BasicLdapPersistenceTest extends Specification with SetupLdapRepositories 
     val expected = Rule(
       ruleId,
       "User rule",
-      RuleCategoryId("rootRuleCategory"),
+      Constants.ROOT_RULE_CATEGORY,
       Set(TargetExclusion(TargetUnion(Set(AllTarget)), TargetUnion(Set()))),
       Set(did),
       "",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LdapRepositoryTenantTest.scala
@@ -39,8 +39,8 @@ package com.normation.rudder.repository.ldap
 
 import com.normation.GitVersion
 import com.normation.eventlog.EventActor
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.nodes.NodeGroup
-import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.ActiveTechniqueCategory
@@ -51,7 +51,6 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.Visibility
-import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
@@ -93,7 +92,7 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
 
   val groupWithTenantId = NodeGroupId(NodeGroupUid("test-group-node1"))
 
-  val rootCat = NodeGroupCategoryId("GroupRoot")
+  val rootCat = Constants.ROOT_GROUP_CATEGORY
 
   sequential
 
@@ -499,7 +498,7 @@ class LdapRepositoryTenantTest extends Specification with SetupLdapRepositories 
   }
 
   def newRule(id: String, tenant: Option[SecurityTag]): Rule =
-    Rule(RuleId(RuleUid(id)), id, RuleCategoryId("rootRuleCategory"), security = tenant)
+    Rule(RuleId(RuleUid(id)), id, Constants.ROOT_RULE_CATEGORY, security = tenant)
 
   "[Rules] Creating a rule" should {
     "lead to an error if the user has a tenant and the plugin is disabled" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/ItemRollbackRepositoryImplTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/ItemRollbackRepositoryImplTest.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.MockRules
 import com.normation.rudder.MockTechniques
 import com.normation.rudder.MockTenants
 import com.normation.rudder.configuration.GroupAndCat
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.eventlog.*
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
@@ -327,7 +328,7 @@ private object ItemRollbackRepositoryImplTest {
   val directiveActiveTechniqueId: ActiveTechniqueId   =
     ActiveTechniqueId(mockDirectives.directives.archiveTechnique.id.name.value)
   val groupId:                    NodeGroupId         = mockGroups.g1.id
-  val groupCategoryId:            NodeGroupCategoryId = NodeGroupCategoryId("GroupRoot")
+  val groupCategoryId:            NodeGroupCategoryId = Constants.ROOT_GROUP_CATEGORY
   val parameterName:              String              = mockParams.stringParam.name
   val ruleId:                     RuleId              = mockRules.rules.defaultRule.id
 
@@ -435,7 +436,7 @@ private object ItemRollbackRepositoryImplTest {
   }
 
   private def emptyNodeGroupCategory =
-    NodeGroupCategory(NodeGroupCategoryId("GroupRoot"), "GroupRoot", "", Nil, Nil, isSystem = false, security = None)
+    NodeGroupCategory(Constants.ROOT_GROUP_CATEGORY, "GroupRoot", "", Nil, Nil, isSystem = false, security = None)
 
   //////////////////////////// event logs ////////////////////////////
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitParseRudderObjects.scala
@@ -99,7 +99,7 @@ class TestGitParseRudderObjects extends Specification with Loggable with AfterAl
   val rootCatGroupId: NodeGroupUid        = NodeGroupUid("5aa4e2ba-4e6c-4d5e-a5d4-1cbc9a1ef2d1")
   val subCatGroupId:  NodeGroupUid        = NodeGroupUid("87e3d2cb-6f43-4b7a-9c8d-2f1a0e6b3c74")
   val subCatId:       NodeGroupCategoryId = NodeGroupCategoryId("2f37b1c4-4a2e-4ff0-9e46-0a2dcd7e07a1")
-  val rootCatId:      NodeGroupCategoryId = NodeGroupCategoryId("GroupRoot")
+  val rootCatId:      NodeGroupCategoryId = Constants.ROOT_GROUP_CATEGORY
 
   lazy val groupLibRoot: File = File.newTemporaryDirectory("rudder-test-group-lib-")
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/ChangeRequestTenantTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/tenants/ChangeRequestTenantTest.scala
@@ -38,6 +38,7 @@ package com.normation.rudder.tenants
 
 import com.normation.GitVersion
 import com.normation.eventlog.EventActor
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.policies.ModifyToRuleDiff
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
@@ -48,7 +49,6 @@ import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.ModifyToGlobalParameterDiff
 import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.workflows.*
-import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.zio.*
 import org.joda.time.DateTime
 import org.junit.runner.*
@@ -78,7 +78,7 @@ class ChangeRequestTenantTest extends Specification {
   val zoneAro = grant(TenantAccess(TenantId("zoneA"), TenantPermission.Read))
 
   private def rule(id: String, security: Option[SecurityTag]): Rule =
-    Rule(RuleId(RuleUid(id)), id, RuleCategoryId("rootRuleCategory"), security = security)
+    Rule(RuleId(RuleUid(id)), id, Constants.ROOT_RULE_CATEGORY, security = security)
 
   private def ruleChanges(r: Rule): RuleChanges =
     RuleChanges(RuleChange(Some(r), RuleChangeItem(EventActor("u"), DateTime.now(), None, ModifyToRuleDiff(r)), Seq()), Seq())

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.configuration.ActiveDirective
 import com.normation.rudder.configuration.ConfigurationRepository
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategory
@@ -1533,7 +1534,7 @@ class SaveArchiveServicebyRepo(
     uuidGen:             StringUuidGenerator
 ) extends SaveArchiveService {
 
-  val GroupRootId = NodeGroupCategoryId("GroupRoot")
+  val GroupRootId = Constants.ROOT_GROUP_CATEGORY
 
   def saveTechniqueCat(eventMetadata: EventMetadata, a: TechniqueCategoryArchive): IOResult[Unit] = {
     val catPath = a.category.toList

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.config.ReasonBehavior
 import com.normation.rudder.config.UserPropertyService
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.properties.FailedNodePropertyHierarchy
 import com.normation.rudder.domain.properties.SuccessNodePropertyHierarchy
@@ -998,7 +999,7 @@ class GroupApiService14(
     for {
       update  <- restData.create(defaultId).toIO
       category = update.toNodeGroupCategory
-      parent   = restData.parent.getOrElse(NodeGroupCategoryId("GroupRoot"))
+      parent   = restData.parent.getOrElse(Constants.ROOT_GROUP_CATEGORY)
       _       <- writeGroup.addGroupCategoryToCategory(category, parent)
     } yield {
       JRMinimalGroupCategory.fromCategory(update, parent)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -196,7 +196,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
 
     override def getFullGroupLibrary()(implicit qc: QueryContext): IOResult[FullNodeGroupCategory] = {
       FullNodeGroupCategory(
-        NodeGroupCategoryId("GroupRoot"),
+        Constants.ROOT_GROUP_CATEGORY,
         name = "GroupRoot",
         description = "root of group categories",
         subCategories = Nil,

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/RuleTests.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/RuleTests.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder
 
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
@@ -90,7 +91,7 @@ class RuleTest extends Specification with Loggable {
   }
 
   val root: RuleCategory = RuleCategory(
-    RuleCategoryId("rootRuleCategory"),
+    Constants.ROOT_RULE_CATEGORY,
     name = "Root category",
     description = "base root category",
     childs = subCat,
@@ -101,7 +102,7 @@ class RuleTest extends Specification with Loggable {
   "Testing rule utility tools" should {
     "List all categories and subcategories" in {
       val listCatIds = Set(
-        RuleCategoryId("rootRuleCategory"),
+        Constants.ROOT_RULE_CATEGORY,
         RuleCategoryId("cat1"),
         RuleCategoryId("cat2"),
         RuleCategoryId("cat3"),
@@ -122,7 +123,7 @@ class RuleTest extends Specification with Loggable {
     }
 
     "List only root category" in {
-      val listCatIds = Set(RuleCategoryId("rootRuleCategory"))
+      val listCatIds = Set(Constants.ROOT_RULE_CATEGORY)
       restTestSetUp.ruleApiService14.listCategoriesId(root.copy(childs = List.empty)) shouldEqual (listCatIds)
     }
 
@@ -155,7 +156,7 @@ class RuleTest extends Specification with Loggable {
 
     "Find no missing categories" in {
       val rules = List(
-        Rule(RuleId(RuleUid("rule1")), "", RuleCategoryId("rootRuleCategory"), security = None),
+        Rule(RuleId(RuleUid("rule1")), "", Constants.ROOT_RULE_CATEGORY, security = None),
         Rule(RuleId(RuleUid("rule2")), "", RuleCategoryId("cat1"), security = None),
         Rule(RuleId(RuleUid("rule3")), "", RuleCategoryId("cat3"), security = None),
         Rule(RuleId(RuleUid("rule4")), "", RuleCategoryId("cat4"), security = None),

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
@@ -49,6 +49,7 @@ import com.normation.rudder.MockDirectives
 import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockTechniques
 import com.normation.rudder.MockTenants
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
@@ -157,7 +158,7 @@ class SetUpCompliance(numNodes: Int, numRules: Int) {
 
     override def getFullGroupLibrary()(implicit qc: QueryContext): IOResult[FullNodeGroupCategory] = {
       FullNodeGroupCategory(
-        NodeGroupCategoryId("GroupRoot"),
+        Constants.ROOT_GROUP_CATEGORY,
         name = "GroupRoot",
         description = "root of group categories",
         subCategories = Nil,

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestTenantFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestTenantFromFileDef.scala
@@ -41,8 +41,8 @@ import better.files.*
 import com.normation.GitVersion
 import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.nodes.NodeGroup
-import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.ActiveTechniqueId
@@ -58,7 +58,6 @@ import com.normation.rudder.domain.properties.GenericProperty.*
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.repository.FullActiveTechniqueCategory
-import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.tenants.SecurityTag
@@ -93,7 +92,7 @@ class TestRestTenantFromFileDef extends ZIOSpecDefault {
   val tenantRule: Rule = Rule(
     RuleId(RuleUid("tenant-rule-1")),
     "Tenant test rule",
-    RuleCategoryId("rootRuleCategory"),
+    Constants.ROOT_RULE_CATEGORY,
     Set(AllTarget),
     Set(DirectiveId(DirectiveUid("directive1"))),
     "A rule for tenant testing",
@@ -183,7 +182,7 @@ class TestRestTenantFromFileDef extends ZIOSpecDefault {
         _      <-
           ZIO.unless(exists)(
             restTestSetUp.mockNodeGroups.groupsRepoImpl
-              .create(tenantGroup, NodeGroupCategoryId("GroupRoot"))(using ChangeContext.newForRudder(Some("seed tenant group")))
+              .create(tenantGroup, Constants.ROOT_GROUP_CATEGORY)(using ChangeContext.newForRudder(Some("seed tenant group")))
           )
         // restore directive2 if a previous evaluation deleted it, then (re)apply the tenant tags
         dirOk  <- restTestSetUp.mockDirectives.directiveRepoImpl


### PR DESCRIPTION
https://issues.rudder.io/issues/29667

Introduce `Constants.ROOT_GROUP_CATEGORY` and `Constants.ROOT_RULE_CATEGORY` and use them everywhere in place of the hard-coded string. 