### PR TITLE
Fixes #29544: Put rule's node compliance and directive compliance tabs in a parent Compliance tab

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -18,10 +18,15 @@ import Ui.Datatable exposing (Category, SortOrder, TableFilters, getAllCats, get
 --
 
 
+type ComplianceSortBy
+    = ByDirective
+    | ByNode
+
+
 type TabMenu
     = Information
+    | ComplianceTab ComplianceSortBy
     | Directives
-    | Nodes
     | Groups
     | TechnicalLogs
     | Rules

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
@@ -296,31 +296,6 @@ editionTemplate model details =
                             ]
                         ]
                     ]
-                , if isNewRule then
-                    text ""
-
-                  else
-                    li [ class "nav-item" ]
-                        [ button
-                            [ attribute "role" "tab"
-                            , type_ "button"
-                            , class
-                                ("nav-link"
-                                    ++ (if details.tab == Nodes then
-                                            " active"
-
-                                        else
-                                            ""
-                                       )
-                                )
-                            , onClick (UpdateRuleForm { details | tab = Nodes })
-                            ]
-                            [ text "Nodes"
-                            , span [ class "badge badge-secondary badge-resources" ]
-                                [ getNbResourcesBadge (Maybe.withDefault 0 (getRuleNbNodes details)) "This rule is not applied on any node"
-                                ]
-                            ]
-                        ]
                 , li [ class "nav-item" ]
                     [ button
                         [ attribute "role" "tab"
@@ -352,6 +327,28 @@ editionTemplate model details =
                             ]
                         ]
                     ]
+                , if isNewRule then
+                    text ""
+
+                  else
+                    li [ class "nav-item" ]
+                        [ button
+                            [ attribute "role" "tab"
+                            , type_ "button"
+                            , class
+                                ("nav-link"
+                                    ++ (if (details.tab == ComplianceTab ByDirective) || (details.tab == ComplianceTab ByNode) then
+                                            " active"
+
+                                        else
+                                            ""
+                                       )
+                                )
+                            , onClick (UpdateRuleForm { details | tab = ComplianceTab ByDirective })
+                            ]
+                            [ text "Compliance"
+                            ]
+                        ]
                 , if isNewRule then
                     text ""
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
@@ -1,9 +1,12 @@
 module Rules.ViewTabContent exposing (..)
 
 import Html exposing (..)
+import Html.Attributes exposing (attribute, class, type_)
+import Html.Events exposing (onClick)
+import Html.Lazy
 import Rules.DataTypes exposing (..)
 import Rules.ViewRepairedReports exposing (technicalLogsTab)
-import Rules.ViewTabDirectives exposing (directivesTab)
+import Rules.ViewTabDirectives exposing (directivesComplianceTab, selectDirectivesTab)
 import Rules.ViewTabGroups exposing (groupsTab)
 import Rules.ViewTabInformation exposing (informationTab)
 import Rules.ViewTabNodes exposing (nodesTab)
@@ -22,11 +25,11 @@ tabContent model details =
         Information ->
             informationTab model details
 
-        Directives ->
-            directivesTab model details
+        ComplianceTab sortBy ->
+            viewComplianceTab model details sortBy
 
-        Nodes ->
-            nodesTab model details
+        Directives ->
+            selectDirectivesTab details model
 
         Groups ->
             groupsTab model details
@@ -39,3 +42,54 @@ tabContent model details =
 
         RecentActivity ->
             recentActivityTab model.activityTable
+
+
+viewComplianceTab : Model -> RuleDetails -> ComplianceSortBy -> Html Msg
+viewComplianceTab model details sortBy =
+    div [ class "tab-table-content" ]
+        (List.append
+            [ ul [ class "nav nav-underline" ]
+                [ li [ class "nav-item" ]
+                    [ button
+                        [ attribute "role" "tab"
+                        , type_ "button"
+                        , class
+                            ("nav-link "
+                                ++ (if sortBy == ByDirective then
+                                        " active"
+
+                                    else
+                                        ""
+                                   )
+                            )
+                        , onClick (UpdateRuleForm { details | tab = ComplianceTab ByDirective })
+                        ]
+                        [ text "By directive" ]
+                    ]
+                , li [ class "nav-item" ]
+                    [ button
+                        [ attribute "role" "tab"
+                        , type_ "button"
+                        , class
+                            ("nav-link "
+                                ++ (if sortBy == ByNode then
+                                        " active"
+
+                                    else
+                                        ""
+                                   )
+                            )
+                        , onClick (UpdateRuleForm { details | tab = ComplianceTab ByNode })
+                        ]
+                        [ text "By node" ]
+                    ]
+                ]
+            ]
+            [ case sortBy of
+                ByDirective ->
+                    Html.Lazy.lazy (directivesComplianceTab details) model
+
+                ByNode ->
+                    Html.Lazy.lazy (nodesTab details) model
+            ]
+        )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabDirectives.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabDirectives.elm
@@ -23,17 +23,11 @@ import Utils.CsvExportUtils exposing (exportToCsvButton)
 import Utils.TooltipUtils exposing (buildTooltipContent)
 
 
-directivesTab : Model -> RuleDetails -> Html Msg
-directivesTab model details =
+directivesComplianceTab : RuleDetails -> Model -> Html Msg
+directivesComplianceTab details model =
     let
-        isNewRule =
-            Maybe.Extra.isNothing details.originRule
-
         rule =
             details.rule
-
-        originRule =
-            details.originRule
 
         ui =
             details.ui
@@ -43,9 +37,6 @@ directivesTab model details =
 
         tableFilters =
             directiveFilters.tableFilters
-
-        treeFilters =
-            directiveFilters.treeFilters
 
         complianceFilters =
             model.ui.complianceFilters
@@ -68,45 +59,6 @@ directivesTab model details =
                     |> List.filter (\id -> not (List.member id knonwIds))
                     |> List.map (\id -> Directive id ("Missing directive with ID " ++ id.value) "" "" "" False False "" [])
                 )
-
-        buildListRow : List (Html Msg)
-        buildListRow =
-            let
-                rowDirective : Directive -> Html Msg
-                rowDirective directive =
-                    let
-                        newClass =
-                            case originRule of
-                                Nothing ->
-                                    "new"
-
-                                Just oR ->
-                                    if List.member directive.id oR.directives then
-                                        ""
-
-                                    else
-                                        "new"
-
-                        ( disabledClass, disabledLabel ) =
-                            if directive.enabled then
-                                ( "", text "" )
-
-                            else
-                                ( " is-disabled ", span [ class "badge-disabled" ] [] )
-                    in
-                    li [ class (newClass ++ disabledClass) ]
-                        [ a [ href (getDirectiveLink model.contextPath directive.id) ]
-                            [ badgePolicyMode model.policyMode directive.policyMode
-                            , span [ class "target-name" ] [ text directive.displayName ]
-                            , disabledLabel
-                            , buildTagsList directive.tags
-                            , goToIcon
-                            ]
-                        , span [ class "target-remove", onClick (UpdateRuleForm { details | rule = { rule | directives = List.Extra.remove directive.id rule.directives } }) ] [ i [ class "fa fa-times" ] [] ]
-                        , span [ class "border" ] []
-                        ]
-            in
-            List.map rowDirective directives
 
         ruleDirectivesId =
             case details.originRule of
@@ -376,302 +328,371 @@ directivesTab model details =
                     ]
                 ]
     in
-    if not details.ui.editDirectives then
-        div [ class "tab-table-content" ]
-            (List.append
-                [ div [ class "table-title mb-3" ]
-                    [ h4 [ class "mb-0" ] [ text "Compliance by directive" ]
-                    , if model.ui.hasWriteRights then
-                        button [ class "btn btn-default btn-icon", onClick (UpdateRuleForm { details | ui = { ui | editDirectives = True } }) ] [ text "Select ", i [ class "fa fa-plus-circle" ] [] ]
+    div [ class "tab-table-content" ]
+        (List.append
+            [ if List.isEmpty disabledRuleDirectives && rule.enabled then
+                text ""
 
-                      else
-                        text ""
-                    ]
-                , if List.isEmpty disabledRuleDirectives && rule.enabled then
-                    text ""
-
-                  else
-                    let
-                        warningMessage =
-                            case ( rule.enabled, List.isEmpty disabledRuleDirectives ) of
-                                ( True, False ) ->
-                                    span []
-                                        [ text "This rule has"
-                                        , b [ class "badge" ] [ text (String.fromInt (List.length disabledRuleDirectives)) ]
-                                        , text
-                                            ("disabled directive"
-                                                ++ (if List.length disabledRuleDirectives > 1 then
-                                                        "s"
-
-                                                    else
-                                                        ""
-                                                   )
-                                                ++ " that will not be applied. "
-                                            )
-                                        ]
-
-                                ( False, False ) ->
-                                    span []
-                                        [ text "This rule is "
-                                        , b [] [ text "disabled" ]
-                                        , text ", none of its directives will be applied. Plus, it has"
-                                        , b [ class "badge" ] [ text (String.fromInt (List.length disabledRuleDirectives)) ]
-                                        , text
-                                            ("disabled directive"
-                                                ++ (if List.length disabledRuleDirectives > 1 then
-                                                        "s"
-
-                                                    else
-                                                        ""
-                                                   )
-                                                ++ ". "
-                                            )
-                                        ]
-
-                                ( False, True ) ->
-                                    span [] [ text "This rule is ", b [] [ text "disabled" ], text ", none of its directives will be applied" ]
-
-                                _ ->
-                                    text ""
-
-                        ( checkbox, caret, list ) =
-                            if List.isEmpty disabledRuleDirectives then
-                                ( text ""
-                                , text ""
-                                , text ""
-                                )
-
-                            else
-                                ( input [ type_ "checkbox", id "disabled-directives", class "toggle-checkbox" ] []
-                                , i [ class "fa fa-caret-down" ] []
-                                , ul []
-                                    (List.map
-                                        (\d ->
-                                            li []
-                                                [ a [ href (getDirectiveLink model.contextPath d.id) ]
-                                                    [ badgePolicyMode model.policyMode d.policyMode
-                                                    , text d.displayName
-                                                    , goToIcon
-                                                    ]
-                                                ]
-                                        )
-                                        disabledRuleDirectives
-                                    )
-                                )
-                    in
-                    div [ class "toggle-checkbox-container" ]
-                        [ checkbox
-                        , div [ class "callout-fade callout-warning" ]
-                            [ label [ for "disabled-directives" ]
-                                [ i [ class "fa fa-warning" ] []
-                                , warningMessage
-                                , caret
-                                ]
-                            , list
-                            ]
-                        ]
-                , noComplianceMsg
-                ]
-                directiveComplianceTable
-            )
-
-    else
-        let
-            addDirectives : DirectiveId -> Msg
-            addDirectives id =
+              else
                 let
-                    newDirectives =
-                        if List.Extra.notMember id rule.directives then
-                            id :: rule.directives
+                    warningMessage =
+                        case ( rule.enabled, List.isEmpty disabledRuleDirectives ) of
+                            ( True, False ) ->
+                                span []
+                                    [ text "This rule has"
+                                    , b [ class "badge" ] [ text (String.fromInt (List.length disabledRuleDirectives)) ]
+                                    , text
+                                        ("disabled directive"
+                                            ++ (if List.length disabledRuleDirectives > 1 then
+                                                    "s"
+
+                                                else
+                                                    ""
+                                               )
+                                            ++ " that will not be applied. "
+                                        )
+                                    ]
+
+                            ( False, False ) ->
+                                span []
+                                    [ text "This rule is "
+                                    , b [] [ text "disabled" ]
+                                    , text ", none of its directives will be applied. Plus, it has"
+                                    , b [ class "badge" ] [ text (String.fromInt (List.length disabledRuleDirectives)) ]
+                                    , text
+                                        ("disabled directive"
+                                            ++ (if List.length disabledRuleDirectives > 1 then
+                                                    "s"
+
+                                                else
+                                                    ""
+                                               )
+                                            ++ ". "
+                                        )
+                                    ]
+
+                            ( False, True ) ->
+                                span [] [ text "This rule is ", b [] [ text "disabled" ], text ", none of its directives will be applied" ]
+
+                            _ ->
+                                text ""
+
+                    ( checkbox, caret, list ) =
+                        if List.isEmpty disabledRuleDirectives then
+                            ( text ""
+                            , text ""
+                            , text ""
+                            )
 
                         else
-                            List.Extra.remove id rule.directives
-                in
-                UpdateRuleForm { details | rule = { rule | directives = newDirectives } }
-
-            directiveTreeElem : Technique -> Maybe (Html Msg)
-            directiveTreeElem item =
-                let
-                    directivesList =
-                        item.directives
-                            |> List.filter (\d -> filterSearch model.ui.directiveFilters.treeFilters.filter (searchFieldDirectives d))
-                            |> List.sortWith (\d1 d2 -> N.compare d1.displayName d2.displayName)
-                            |> List.map
-                                (\d ->
-                                    let
-                                        selectedClass =
-                                            if List.member d.id rule.directives then
-                                                " item-selected"
-
-                                            else
-                                                ""
-
-                                        ( disabledClass, disabledLabel ) =
-                                            if d.enabled then
-                                                ( "", text "" )
-
-                                            else
-                                                ( " is-disabled", span [ class "badge-disabled" ] [] )
-
-                                        isUsed =
-                                            getAllElems model.rulesTree
-                                                |> List.concatMap (\r -> r.directives)
-                                                |> List.member d.id
-
-                                        unusedWarning =
-                                            if isUsed then
-                                                text ""
-
-                                            else
-                                                span
-                                                    [ class "fa fa-warning text-warning-rudder"
-                                                    , attribute "data-bs-toggle" "tooltip"
-                                                    , attribute "data-bs-placement" "bottom"
-                                                    , title (buildTooltipContent "Unused directive" "This directive is not used in any rule")
-                                                    ]
-                                                    []
-                                    in
-                                    li [ class ("jstree-node jstree-leaf directiveNode" ++ disabledClass) ]
-                                        [ i [ class "jstree-icon jstree-ocl" ] []
-                                        , a [ class ("jstree-anchor" ++ selectedClass), onClickPreventDefault (addDirectives d.id) ]
-                                            [ badgePolicyMode model.policyMode d.policyMode
-                                            , unusedWarning
-                                            , span [ class "item-name" ] [ text d.displayName ]
-                                            , disabledLabel
-                                            , buildTagsTree d.tags
-                                            , div [ class "treeActions-container" ]
-                                                [ span [ class "treeActions" ] [ span [ class "fa action-icon ms-1 accept" ] [] ]
+                            ( input [ type_ "checkbox", id "disabled-directives", class "toggle-checkbox" ] []
+                            , i [ class "fa fa-caret-down" ] []
+                            , ul []
+                                (List.map
+                                    (\d ->
+                                        li []
+                                            [ a [ href (getDirectiveLink model.contextPath d.id) ]
+                                                [ badgePolicyMode model.policyMode d.policyMode
+                                                , text d.displayName
+                                                , goToIcon
                                                 ]
-                                            , goToBtn (getDirectiveLink model.contextPath d.id)
                                             ]
-                                        ]
+                                    )
+                                    disabledRuleDirectives
                                 )
+                            )
                 in
-                if not (List.isEmpty directivesList) then
-                    Just
-                        (li [ class ("jstree-node" ++ foldedClass model.ui.directiveFilters.treeFilters item.name) ]
-                            [ i [ class "jstree-icon jstree-ocl", onClick (UpdateDirectiveFilters (foldUnfoldCategory model.ui.directiveFilters item.name)) ] []
-                            , a [ class "jstree-anchor" ]
-                                [ i [ class "jstree-icon jstree-themeicon fa fa-gear jstree-themeicon-custom" ] []
-                                , span [ class "item-name" ] [ text item.name ]
-                                ]
-                            , ul [ class "jstree-children" ] directivesList
+                div [ class "toggle-checkbox-container" ]
+                    [ checkbox
+                    , div [ class "callout-fade callout-warning" ]
+                        [ label [ for "disabled-directives" ]
+                            [ i [ class "fa fa-warning" ] []
+                            , warningMessage
+                            , caret
                             ]
-                        )
-
-                else
-                    Nothing
-
-            directiveTreeCategory : Category Technique -> Maybe (Html Msg)
-            directiveTreeCategory item =
-                let
-                    categories =
-                        getSubElems item
-                            |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
-                            |> List.filterMap directiveTreeCategory
-
-                    techniques =
-                        item.elems
-                            |> List.filterMap directiveTreeElem
-
-                    children =
-                        techniques ++ categories
-                in
-                if not (List.isEmpty children) then
-                    Just
-                        (li [ class ("jstree-node" ++ foldedClass model.ui.directiveFilters.treeFilters item.id) ]
-                            [ i [ class "jstree-icon jstree-ocl", onClick (UpdateDirectiveFilters (foldUnfoldCategory model.ui.directiveFilters item.name)) ] []
-                            , a [ class "jstree-anchor" ]
-                                [ i [ class "jstree-icon jstree-themeicon fa fa-folder jstree-themeicon-custom" ] []
-                                , span [ class "treeGroupCategoryName" ] [ text item.name ]
-                                ]
-                            , ul [ class "jstree-children" ] children
-                            ]
-                        )
-
-                else
-                    Nothing
-
-            cancelDirectives =
-                case details.originRule of
-                    Just oR ->
-                        oR.directives
-
-                    Nothing ->
-                        []
-
-            ( cancelUi, confirmBtn ) =
-                if isNewRule then
-                    ( ui
-                    , text ""
-                    )
-
-                else
-                    ( { ui | editDirectives = False }
-                    , button [ class "btn btn-default btn-icon", onClick (UpdateRuleForm { details | ui = { ui | editDirectives = False } }) ] [ text "Confirm", i [ class "fa fa-check" ] [] ]
-                    )
-        in
-        div [ class "row flex-container" ]
-            [ div [ class "list-edit d-flex flex-column col-sm-12 col-md-6 col-xl-7" ]
-                [ div [ class "list-container" ]
-                    [ div [ class "list-heading align-items-center" ]
-                        [ h4 [ class "mb-0" ] [ text "Apply these directives" ]
-                        , div [ class "btn-actions" ]
-                            [ button [ class "btn btn-default btn-icon", onClick (UpdateRuleForm { details | rule = { rule | directives = cancelDirectives }, ui = cancelUi }) ]
-                                [ text "Cancel", i [ class "fa fa-undo-alt" ] [] ]
-                            , confirmBtn
-                            ]
+                        , list
                         ]
-                    , ul [ class "directives applied-list" ]
-                        (if List.length rule.directives > 0 then
-                            buildListRow
-
-                         else
-                            [ li [ class "empty" ]
-                                [ span [] [ text "There is no directive applied." ]
-                                , span [ class "warning-sign" ] [ i [ class "fa fa-info-circle" ] [] ]
-                                ]
-                            ]
-                        )
                     ]
-                ]
-            , div [ class "tree-edit col-sm-12 col-md-6 col-xl-5" ]
-                [ div [ class "tree-container" ]
-                    [ div [ class "tree-heading" ]
-                        [ h4 [] [ text "Select directives" ]
-                        , i [ class "fa fa-bars" ] []
-                        ]
-                    , div [ class "header-filter" ]
-                        [ div [ class "input-group" ]
-                            [ button [ class "btn btn-default", type_ "button" ] [ span [ class "fa fa-folder fa-folder-open" ] [] ]
-                            , input
-                                [ type_ "text"
-                                , placeholder "Filter"
-                                , class "form-control"
-                                , onInput (\s -> UpdateDirectiveFilters { directiveFilters | treeFilters = { treeFilters | filter = s } })
-                                ]
-                                []
-                            , button
-                                [ class "btn btn-default"
-                                , type_ "button"
-                                , onClick (UpdateDirectiveFilters { directiveFilters | treeFilters = { treeFilters | filter = "" } })
-                                ]
-                                [ span [ class "fa fa-times" ] [] ]
-                            ]
-                        ]
-                    , div [ class "jstree jstree-default" ]
-                        [ ul [ class "jstree-container-ul jstree-children" ]
-                            [ case directiveTreeCategory model.techniquesTree of
-                                Just html ->
-                                    html
+            , noComplianceMsg
+            ]
+            directiveComplianceTable
+        )
 
+
+selectDirectivesTab : RuleDetails -> Model -> Html Msg
+selectDirectivesTab details model =
+    let
+        isNewRule =
+            Maybe.Extra.isNothing details.originRule
+
+        rule =
+            details.rule
+
+        originRule =
+            details.originRule
+
+        ui =
+            details.ui
+
+        directiveFilters =
+            model.ui.directiveFilters
+
+        treeFilters =
+            directiveFilters.treeFilters
+
+        --Get more information about directives, to correctly sort them by displayName
+        directives =
+            let
+                knownDirectives =
+                    Dict.Extra.keepOnly (Set.fromList (List.map .value rule.directives)) model.directives
+                        |> Dict.values
+                        |> List.sortWith (compareOn .displayName)
+
+                -- add missing directives
+                knonwIds =
+                    List.map .id knownDirectives
+            in
+            List.append
+                knownDirectives
+                (rule.directives
+                    |> List.filter (\id -> not (List.member id knonwIds))
+                    |> List.map (\id -> Directive id ("Missing directive with ID " ++ id.value) "" "" "" False False "" [])
+                )
+
+        buildListRow : List (Html Msg)
+        buildListRow =
+            let
+                rowDirective : Directive -> Html Msg
+                rowDirective directive =
+                    let
+                        newClass =
+                            case originRule of
                                 Nothing ->
-                                    div [ class "alert alert-warning" ]
-                                        [ i [ class "fa fa-exclamation-triangle" ] []
-                                        , text "No directives match your filters."
-                                        ]
+                                    "new"
+
+                                Just oR ->
+                                    if List.member directive.id oR.directives then
+                                        ""
+
+                                    else
+                                        "new"
+
+                        ( disabledClass, disabledLabel ) =
+                            if directive.enabled then
+                                ( "", text "" )
+
+                            else
+                                ( " is-disabled ", span [ class "badge-disabled" ] [] )
+                    in
+                    li [ class (newClass ++ disabledClass) ]
+                        [ a [ href (getDirectiveLink model.contextPath directive.id) ]
+                            [ badgePolicyMode model.policyMode directive.policyMode
+                            , span [ class "target-name" ] [ text directive.displayName ]
+                            , disabledLabel
+                            , buildTagsList directive.tags
+                            , goToIcon
                             ]
+                        , span [ class "target-remove", onClick (UpdateRuleForm { details | rule = { rule | directives = List.Extra.remove directive.id rule.directives } }) ] [ i [ class "fa fa-times" ] [] ]
+                        , span [ class "border" ] []
+                        ]
+            in
+            List.map rowDirective directives
+
+        addDirectives : DirectiveId -> Msg
+        addDirectives id =
+            let
+                newDirectives =
+                    if List.Extra.notMember id rule.directives then
+                        id :: rule.directives
+
+                    else
+                        List.Extra.remove id rule.directives
+            in
+            UpdateRuleForm { details | rule = { rule | directives = newDirectives } }
+
+        directiveTreeElem : Technique -> Maybe (Html Msg)
+        directiveTreeElem item =
+            let
+                directivesList =
+                    item.directives
+                        |> List.filter (\d -> filterSearch model.ui.directiveFilters.treeFilters.filter (searchFieldDirectives d))
+                        |> List.sortWith (\d1 d2 -> N.compare d1.displayName d2.displayName)
+                        |> List.map
+                            (\d ->
+                                let
+                                    selectedClass =
+                                        if List.member d.id rule.directives then
+                                            " item-selected"
+
+                                        else
+                                            ""
+
+                                    ( disabledClass, disabledLabel ) =
+                                        if d.enabled then
+                                            ( "", text "" )
+
+                                        else
+                                            ( " is-disabled", span [ class "badge-disabled" ] [] )
+
+                                    isUsed =
+                                        getAllElems model.rulesTree
+                                            |> List.concatMap (\r -> r.directives)
+                                            |> List.member d.id
+
+                                    unusedWarning =
+                                        if isUsed then
+                                            text ""
+
+                                        else
+                                            span
+                                                [ class "fa fa-warning text-warning-rudder"
+                                                , attribute "data-bs-toggle" "tooltip"
+                                                , attribute "data-bs-placement" "bottom"
+                                                , title (buildTooltipContent "Unused directive" "This directive is not used in any rule")
+                                                ]
+                                                []
+                                in
+                                li [ class ("jstree-node jstree-leaf directiveNode" ++ disabledClass) ]
+                                    [ i [ class "jstree-icon jstree-ocl" ] []
+                                    , a [ class ("jstree-anchor" ++ selectedClass), onClickPreventDefault (addDirectives d.id) ]
+                                        [ badgePolicyMode model.policyMode d.policyMode
+                                        , unusedWarning
+                                        , span [ class "item-name" ] [ text d.displayName ]
+                                        , disabledLabel
+                                        , buildTagsTree d.tags
+                                        , div [ class "treeActions-container" ]
+                                            [ span [ class "treeActions" ] [ span [ class "fa action-icon ms-1 accept" ] [] ]
+                                            ]
+                                        , goToBtn (getDirectiveLink model.contextPath d.id)
+                                        ]
+                                    ]
+                            )
+            in
+            if not (List.isEmpty directivesList) then
+                Just
+                    (li [ class ("jstree-node" ++ foldedClass model.ui.directiveFilters.treeFilters item.name) ]
+                        [ i [ class "jstree-icon jstree-ocl", onClick (UpdateDirectiveFilters (foldUnfoldCategory model.ui.directiveFilters item.name)) ] []
+                        , a [ class "jstree-anchor" ]
+                            [ i [ class "jstree-icon jstree-themeicon fa fa-gear jstree-themeicon-custom" ] []
+                            , span [ class "item-name" ] [ text item.name ]
+                            ]
+                        , ul [ class "jstree-children" ] directivesList
+                        ]
+                    )
+
+            else
+                Nothing
+
+        directiveTreeCategory : Category Technique -> Maybe (Html Msg)
+        directiveTreeCategory item =
+            let
+                categories =
+                    getSubElems item
+                        |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
+                        |> List.filterMap directiveTreeCategory
+
+                techniques =
+                    item.elems
+                        |> List.filterMap directiveTreeElem
+
+                children =
+                    techniques ++ categories
+            in
+            if not (List.isEmpty children) then
+                Just
+                    (li [ class ("jstree-node" ++ foldedClass model.ui.directiveFilters.treeFilters item.id) ]
+                        [ i [ class "jstree-icon jstree-ocl", onClick (UpdateDirectiveFilters (foldUnfoldCategory model.ui.directiveFilters item.name)) ] []
+                        , a [ class "jstree-anchor" ]
+                            [ i [ class "jstree-icon jstree-themeicon fa fa-folder jstree-themeicon-custom" ] []
+                            , span [ class "treeGroupCategoryName" ] [ text item.name ]
+                            ]
+                        , ul [ class "jstree-children" ] children
+                        ]
+                    )
+
+            else
+                Nothing
+
+        cancelDirectives =
+            case details.originRule of
+                Just oR ->
+                    oR.directives
+
+                Nothing ->
+                    []
+
+        ( cancelUi, confirmBtn ) =
+            if isNewRule then
+                ( ui
+                , text ""
+                )
+
+            else
+                ( { ui | editDirectives = False }
+                , button [ class "btn btn-default btn-icon", onClick (UpdateRuleForm { details | ui = { ui | editDirectives = False } }) ] [ text "Confirm", i [ class "fa fa-check" ] [] ]
+                )
+    in
+    div [ class "row flex-container" ]
+        [ div [ class "list-edit d-flex flex-column col-sm-12 col-md-6 col-xl-7" ]
+            [ div [ class "list-container" ]
+                [ div [ class "list-heading align-items-center" ]
+                    [ h4 [ class "mb-0" ] [ text "Apply these directives" ]
+                    , div [ class "btn-actions" ]
+                        [ button [ class "btn btn-default btn-icon", onClick (UpdateRuleForm { details | rule = { rule | directives = cancelDirectives }, ui = cancelUi }) ]
+                            [ text "Cancel", i [ class "fa fa-undo-alt" ] [] ]
+                        , confirmBtn
+                        ]
+                    ]
+                , ul [ class "directives applied-list" ]
+                    (if List.length rule.directives > 0 then
+                        buildListRow
+
+                     else
+                        [ li [ class "empty" ]
+                            [ span [] [ text "There is no directive applied." ]
+                            , span [ class "warning-sign" ] [ i [ class "fa fa-info-circle" ] [] ]
+                            ]
+                        ]
+                    )
+                ]
+            ]
+        , div [ class "tree-edit col-sm-12 col-md-6 col-xl-5" ]
+            [ div [ class "tree-container" ]
+                [ div [ class "tree-heading" ]
+                    [ h4 [] [ text "Select directives" ]
+                    , i [ class "fa fa-bars" ] []
+                    ]
+                , div [ class "header-filter" ]
+                    [ div [ class "input-group" ]
+                        [ button [ class "btn btn-default", type_ "button" ] [ span [ class "fa fa-folder fa-folder-open" ] [] ]
+                        , input
+                            [ type_ "text"
+                            , placeholder "Filter"
+                            , class "form-control"
+                            , onInput (\s -> UpdateDirectiveFilters { directiveFilters | treeFilters = { treeFilters | filter = s } })
+                            ]
+                            []
+                        , button
+                            [ class "btn btn-default"
+                            , type_ "button"
+                            , onClick (UpdateDirectiveFilters { directiveFilters | treeFilters = { treeFilters | filter = "" } })
+                            ]
+                            [ span [ class "fa fa-times" ] [] ]
+                        ]
+                    ]
+                , div [ class "jstree jstree-default" ]
+                    [ ul [ class "jstree-container-ul jstree-children" ]
+                        [ case directiveTreeCategory model.techniquesTree of
+                            Just html ->
+                                html
+
+                            Nothing ->
+                                div [ class "alert alert-warning" ]
+                                    [ i [ class "fa fa-exclamation-triangle" ] []
+                                    , text "No directives match your filters."
+                                    ]
                         ]
                     ]
                 ]
             ]
+        ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabNodes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabNodes.elm
@@ -18,8 +18,8 @@ import Ui.Datatable exposing (Category, SortOrder(..), generateLoadingTable, get
 import Utils.CsvExportUtils exposing (exportToCsvButton)
 
 
-nodesTab : Model -> RuleDetails -> Html Msg
-nodesTab model details =
+nodesTab : RuleDetails -> Model -> Html Msg
+nodesTab details model =
     let
         ui =
             details.ui
@@ -213,16 +213,7 @@ nodesTab model details =
     in
     div [ class "tab-table-content" ]
         (List.append
-            [ div [ class "table-title mb-3" ]
-                [ h4 [ class "mb-0" ] [ text "Compliance by node" ]
-                , if model.ui.hasWriteRights then
-                    button [ class "btn btn-default btn-icon", onClick (UpdateRuleForm { details | ui = { ui | editGroups = True }, tab = Groups }) ]
-                        [ text "Select groups", i [ class "fa fa-plus-circle" ] [] ]
-
-                  else
-                    text ""
-                ]
-            , if details.rule.enabled then
+            [ if details.rule.enabled then
                 text ""
 
               else


### PR DESCRIPTION
https://issues.rudder.io/issues/29544

This PR involves : 
- Putting the "Nodes" (i.e. Node compliance) and "Directives" (i.e. Directive compliance) tabs as sub-tabs of a common "Compliance" tab
- Creating a standalone "Directives" tab that allows the user to select the directives on which to apply the rules
- Removing the "Select groups" and "Select directives" buttons from the Node compliance and Directive compliance tabs

in short, the page's structure went from
```
- Information
- Directives (directive compliance, and directive selection when clicking on the select button)
- Nodes (node compliance, and group selection when clicking on the select groups button)
- Groups (group selection)
- Recent changes
- Recent activity
```

to 

```
- Information
- Directives (directive selection)
- Groups (group selection)
- Compliance
|-- By directive
|-- By node
- Recent changes 
- Recent activity 
```

### before

<img width="1131" height="385" alt="image" src="https://github.com/user-attachments/assets/09de4bd8-86cf-409f-9e2c-9e398c4b3f27" />

<img width="1131" height="385" alt="image" src="https://github.com/user-attachments/assets/9aba6ce0-be1c-45c4-9f68-d28db8250055" />

<img width="1131" height="385" alt="image" src="https://github.com/user-attachments/assets/b52c0d77-b55f-480d-a8cc-471d2cac466b" />

<img width="1131" height="385" alt="image" src="https://github.com/user-attachments/assets/63c3c561-7c6d-47a0-ac4b-db089210cd48" />


### after

<img width="1131" height="372" alt="image" src="https://github.com/user-attachments/assets/5b2b29b1-1b12-46b6-b5db-8cfce3a288b1" />

<img width="1131" height="372" alt="image" src="https://github.com/user-attachments/assets/fc8bce67-da69-4499-944b-332443cac746" />

<img width="1131" height="372" alt="image" src="https://github.com/user-attachments/assets/7b2de679-d564-45b2-b1b1-ba6ea3d8b702" />

<img width="1131" height="412" alt="image" src="https://github.com/user-attachments/assets/d42653e9-41bb-4a3e-9395-9a74d820166e" />
