### PR TITLE
Fixes #29625: error 500 when deleting a campaign

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/MainCampaignService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/MainCampaignService.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.campaigns.CampaignEventStateType.*
 import com.normation.utils.StringUuidGenerator
 import org.joda.time.{Duration as JTDuration, *}
 import zio.*
+import zio.syntax.*
 
 /*
  * Method used by API of the campaign service, implemented by the top level
@@ -142,6 +143,10 @@ class MainCampaignService(
     handlersRef.update(h :: _)
   }
 
+  private val noopDelete: PartialFunction[Campaign, IOResult[EventOrchestration]] = {
+    case _ => EventOrchestration.IgnoreAndStop.succeed
+  }
+
   // entry point for API
   override def deleteCampaign(id: CampaignId): IOResult[Unit] = {
     for {
@@ -150,7 +155,7 @@ class MainCampaignService(
       _        <- ZIO.foreachDiscard(events) { event =>
                     handlersRef.get.flatMap(services => {
                       ZIO
-                        .foreachDiscard(services)(s => s.delete(event)(campaign).unit)
+                        .foreachDiscard(services)(s => s.delete(event).orElse(noopDelete)(campaign).unit)
                         .catchAll { _ =>
                           CampaignLogger.warn(
                             s"An error occurred while cleaning campaign event ${event.id.value} during deletion of campaign ${id.value}"
@@ -180,15 +185,15 @@ class MainCampaignService(
                     for {
                       campaign <- campaignRepo.get(event.campaignId).notOptional(s"Campaign with id ${id.value} not found")
                       _        <-
-                        handlersRef.get.flatMap(services => {
+                        handlersRef.get.flatMap { services =>
                           ZIO
-                            .foreachDiscard(services)(s => s.delete(event)(campaign).unit)
-                            .catchAll(_ => {
+                            .foreachDiscard(services)(s => s.delete(event).orElse(noopDelete)(campaign).unit)
+                            .catchAll { _ =>
                               CampaignLogger.warn(
                                 s"An error occurred while cleaning campaign event ${event.id.value} during deletion of campaign ${id.value}"
                               )
-                            })
-                        })
+                            }
+                        }
                     } yield ()
                   }
       _        <- repo.deleteEvent(Some(id))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -83,10 +83,14 @@ object ApiLogger extends Logger {
 }
 
 object ApiLoggerPure extends NamedZioLogger {
-  def loggerName = "api-processing"
+  override def loggerName = "api-processing"
 
-  object Metrics extends NamedZioLogger {
-    def loggerName = "api-processing.metrics"
+  object Metrics       extends NamedZioLogger {
+    override def loggerName = "api-processing.metrics"
+  }
+  // a logger used to log API errors (when they return an error message) in webapp log
+  object ResponseError extends NamedZioLogger {
+    override def loggerName = "api-processing.response-error"
   }
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.rest
 import com.normation.errors.*
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.domain.logger.ApiLogger
+import com.normation.rudder.domain.logger.ApiLoggerPure
 import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.utils.Csv
 import com.normation.zio.*
@@ -316,7 +317,18 @@ object RudderJsonResponse {
             },
             a => process(a)
           )
-          .catchAllDefect(err => zio.ZIO.succeed(internalError(id.error, ResponseSchema.fromSchema(schema), err.getMessage)))
+          .catchAllDefect { throwable =>
+            // here, we had an error that isn't caught by standard process, so we really need a debug message, and
+            // something understandable for the API
+            ApiLoggerPure.ResponseError.warn(SystemError("An internal error occurred", throwable).fullMsg) *>
+            zio.ZIO.succeed(
+              internalError(
+                id.error,
+                ResponseSchema.fromSchema(schema),
+                "An internal error occurred. Please contact your service administrator."
+              )
+            )
+          }
           .runNow
       }
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -104,16 +104,10 @@ class CampaignApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      val res = {
-        for {
-          campaign <- mainCampaignService.deleteCampaign(CampaignId(resources))
-        } yield {
-          resources
-        }
-      }
-
-      res.toLiftResponseOne(params, schema, _ => Some(resources))
-
+      mainCampaignService
+        .deleteCampaign(CampaignId(resources))
+        .as(resources)
+        .toLiftResponseOne(params, schema, _ => Some(resources))
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29625

So, we were doing partial function without handling the cases when param is out of domain, which leads to a `MatchError` by construction. 
We didn't see the `MatchError`, because our API error handling function was refactored in 9.2 and doesn't display it correctly in logs. 

So, that PR addresses both - in 9.2, because before 9.2, we didn't had cases out of PF domain (only kind of campaign was update campaigns). 

# Correct the API error log case

When we reach the `catchAllDefect` in `toLiftResponseGeneric`, that means that's an error out of `IOResult`, so most likely a code error. Only dev can do something, but they need to get the info. 
So now, we: 
- display a message in JS console telling people to ask for the admin assistance, because they can't do anything, 
- add a warning log so that the bug (which is a bug at that point, or something strange enought that it needs a ticket) with the stack trace

<img width="1717" height="830" alt="image" src="https://github.com/user-attachments/assets/17f24c90-6794-4a27-b555-da704e767dd9" />

<img width="909" height="171" alt="image" src="https://github.com/user-attachments/assets/2334eba5-1d08-4910-9776-4975d6b98453" />


# MatchError in partial function

We missed the `orElse(defaultCase)` in the handler chain, so I added on in every place where `delete` was called. 
The default case is `IgnoreAndStop`, ie don't do anything more. 