### PR TITLE
Fixes #29674: org.eclipse.jgit.errors.MissingObjectException maybe link to Jgit multiPackIndex support

### DIFF
--- a/adr/webapp/29674-disable-jgit-multi-pack-index.md
+++ b/adr/webapp/29674-disable-jgit-multi-pack-index.md
@@ -1,0 +1,23 @@
+# Disable the git multi-pack-index in JGit
+
+* Status: accepted
+* Deciders: FAR
+* Date: 2026-08-29
+
+## Context
+
+Rudder 9.2 upgraded JGit from 7.5 to 7.7, which [integrated multi-pack-index support into `PackDirectory`](https://github.com/eclipse-jgit/jgit/wiki/New-and-Noteworthy-7.7). JGit now reads `.git/objects/pack/multi-pack-index` when `core.multiPackIndex` is true, and [true is its default](https://github.com/eclipse-jgit/jgit/blob/v7.7.0.202606012155-r/org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/PackDirectory.java#L139-L141). JGit never writes that index, but the git CLI does on `git gc` and `git maintenance`, and `/var/rudder/configuration-repository` is an ordinary repository that administrators run git commands on.
+
+When the index is present, JGit [drops from its pack list every pack the index covers and puts the index in their place](https://github.com/eclipse-jgit/jgit/blob/v7.7.0.202606012155-r/org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/PackDirectory.java#L571-L583). The index becomes the only route to those objects: [what it does not resolve is reported as absent](https://github.com/eclipse-jgit/jgit/blob/v7.7.0.202606012155-r/org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/PackMidx.java#L251-L259), with no second chance on the packs themselves. One faulty or discarded index entry therefore hides the content of every pack it covers.
+
+That is how it showed up in 9.2 ([#29674](https://issues.rudder.io/issues/29674)): policy generations failed intermittently with `MissingObjectException: Missing tree <id>`, on objects that `git cat-file` resolved without trouble and that `git fsck` reported as sound, and the next generation succeeded. 9.1 and its JGit 7.5 never showed it, and setting `core.multiPackIndex` to false makes it stop.
+
+## Decision
+
+Set `core.multiPackIndex` to false in the configuration of every git repository that Rudder opens, in `GitRepositoryProviderImpl`. Since the option is read when the object database is built, the repository is reopened once the value has been written.
+
+## Consequences
+
+* Our repositories are small enough that we lose nothing by not using that index. Git keeps the `.idx` files in the pack directory precisely so that it can be ignored ["without any loss of information"](https://git-scm.com/docs/multi-pack-index).
+* The option is written in `.git/config`, so git commands run by an administrator ignore the index too. `git gc` and `git maintenance` may still write the file; it is simply never used.
+* Should a future JGit version keep the covered packs usable when the index fails to answer, this decision can be revisited.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -63,6 +63,7 @@ import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.ObjectStream
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.treewalk.TreeWalk
+import org.eclipse.jgit.treewalk.filter.TreeFilter
 import org.xml.sax.SAXParseException
 import scala.collection.immutable.SortedMap
 import scala.collection.mutable.Map as MutMap
@@ -374,6 +375,64 @@ class GitTechniqueReader(
     }).runNow
   }
 
+  /*
+   * Manage the logic to get a file stream by looking for the file for the exact `revTreeId` and managing
+   * the closing with ZIO `acquireRelease` pattern.
+   * When there is 0 or more than 1 file returned by the filter, error are returned with message from parameters.
+   */
+  private def getMatchingFileStream(
+      revTreeId:   ObjectId,
+      filter:      TreeFilter,
+      notFoundMsg: => String,
+      tooManyMsg:  => String,
+      noFileMsg:   => String
+  ): IOResult[Option[ObjectStream]] = {
+    val managedTw = ZIO.acquireRelease(IOResult.attempt {
+      val tw = new TreeWalk(repo.db)
+      tw.setFilter(filter)
+      tw.setRecursive(true)
+      tw.reset(revTreeId)
+      tw
+    })(tw => effectUioUnit(tw.close()))
+
+    ZIO
+      .scoped(managedTw.flatMap { tw =>
+        IOResult.attempt {
+          var ids = List.empty[ObjectId]
+          while (tw.next) {
+            ids = tw.getObjectId(0) :: ids
+          }
+          ids
+        }.flatMap {
+          case Nil      => TechniqueReaderLoggerPure.error(notFoundMsg) *> Option.empty[ObjectStream].succeed
+          case h :: Nil => IOResult.attempt(Option(repo.db.open(h).openStream))
+          case _        => TechniqueReaderLoggerPure.error(tooManyMsg) *> Option.empty[ObjectStream].succeed
+        }
+      })
+      .catchSome {
+        case SystemError(_, _: FileNotFoundException) =>
+          TechniqueReaderLoggerPure.debug(noFileMsg) *> Option.empty[ObjectStream].succeed
+      }
+  }
+
+  /*
+   * JGit sometimes reports an object as missing while it is actually present in the object
+   * database when some of its cache are corrupted. Such a view heals itself on the next pack list scan,
+   * so one retry is enough and it spares us failing a whole policy generation.
+   * We deliberately retry the same revision to maintain consistency for the generation.
+   * We only retry once so that a real error is still reported without looping.
+   * This is linked to issue: https://issues.rudder.io/issues/29674
+   */
+  private def retryOnceOnMissingObject[A](context: => String)(effect: IOResult[A]): IOResult[A] = {
+    effect.catchSome {
+      case SystemError(_, ex: MissingObjectException) =>
+        TechniqueReaderLoggerPure.warn(
+          s"A git object was not found when reading ${context} although it should be present (${ex.getMessage}). " +
+          s"This is generally a transient inconsistency in the view of the git object database: retrying once"
+        ) *> effect
+    }
+  }
+
   override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] = {
     // build a treewalk with the path, given by metadata.xml
     val path = techniqueId.withDefaultRev.serialize + "/" + techniqueDescriptorName
@@ -381,42 +440,21 @@ class GitTechniqueReader(
     // template only base on the packageId + name.
 
     val managed = ZIO.acquireRelease(
-      for {
-        currentId <- techniqueId.version.rev match {
-                       case GitVersion.DEFAULT_REV => revisionProvider.currentRevTreeId
-                       case r                      => GitFindUtils.findRevTreeFromRevString(repo.db, r.value)
-                     }
-        optStream <- IOResult.attempt {
-                       try {
-                         val tw  = new TreeWalk(repo.db)
-                         tw.setFilter(new ExactFileTreeFilter(canonizedRelativePath, path))
-                         tw.setRecursive(true)
-                         tw.reset(currentId)
-                         var ids = List.empty[ObjectId]
-                         while (tw.next) {
-                           ids = tw.getObjectId(0) :: ids
-                         }
-                         ids match {
-                           case Nil      =>
-                             TechniqueReaderLoggerPure.logEffect.error(
-                               s"Metadata file ${techniqueDescriptorName} was not found for technique with id ${techniqueId.debugString}."
-                             )
-                             Option.empty[ObjectStream]
-                           case h :: Nil =>
-                             Some(repo.db.open(h).openStream)
-                           case _        =>
-                             TechniqueReaderLoggerPure.logEffect.error(
-                               s"There is more than one Technique with ID '${techniqueId.debugString}', what is forbidden. Please check if several categories have that Technique, and rename or delete the clones."
-                             )
-                             Option.empty[ObjectStream]
-                         }
-                       } catch {
-                         case ex: FileNotFoundException =>
-                           TechniqueReaderLoggerPure.logEffect.debug(s"Template '${path}' does not exist")
-                           Option.empty[ObjectStream]
+      retryOnceOnMissingObject(s"the metadata of technique '${techniqueId.debugString}'") {
+        for {
+          currentId <- techniqueId.version.rev match {
+                         case GitVersion.DEFAULT_REV => revisionProvider.currentRevTreeId
+                         case r                      => GitFindUtils.findRevTreeFromRevString(repo.db, r.value)
                        }
-                     }
-      } yield optStream
+          optStream <- getMatchingFileStream(
+                         currentId,
+                         new ExactFileTreeFilter(canonizedRelativePath, path),
+                         s"Metadata file ${techniqueDescriptorName} was not found for technique with id ${techniqueId.debugString}.",
+                         s"There is more than one Technique with ID '${techniqueId.debugString}', what is forbidden. Please check if several categories have that Technique, and rename or delete the clones.",
+                         s"Template '${path}' does not exist"
+                       )
+        } yield optStream
+      }
     )(optStream => effectUioUnit(optStream.map(_.close())))
 
     ZIO.scoped(managed.flatMap(useIt))
@@ -443,42 +481,18 @@ class GitTechniqueReader(
     // template only base on the techniqueId + name.
 
     val managed = ZIO.acquireRelease(
-      for {
-        currentId <- GitFindUtils.findRevTreeFromRevision(repo.db, rev, revisionProvider.currentRevTreeId)
-        optStream <- IOResult.attempt {
-                       try {
-                         // now, the treeWalk
-                         val tw  = new TreeWalk(repo.db)
-                         tw.setFilter(filenameFilter)
-                         tw.setRecursive(true)
-                         tw.reset(currentId)
-                         var ids = List.empty[ObjectId]
-                         while (tw.next) {
-                           ids = tw.getObjectId(0) :: ids
-                         }
-                         ids match {
-                           case Nil      =>
-                             TechniqueReaderLoggerPure.logEffect.error(
-                               s"Template with id ${techniqueResourceId.displayPath} was not found"
-                             )
-                             Option.empty[ObjectStream]
-                           case h :: Nil =>
-                             Some(repo.db.open(h).openStream)
-                           case _        =>
-                             TechniqueReaderLoggerPure.logEffect.error(
-                               s"There is more than one Technique with name '${techniqueResourceId.name}' which is forbidden. Please check if several categories have that Technique and rename or delete the clones"
-                             )
-                             Option.empty[ObjectStream]
-                         }
-                       } catch {
-                         case ex: FileNotFoundException =>
-                           TechniqueReaderLoggerPure.logEffect.debug(
-                             s"Technique Template ${techniqueResourceId.displayPath} does not exist"
-                           )
-                           Option.empty[ObjectStream]
-                       }
-                     }
-      } yield optStream
+      retryOnceOnMissingObject(s"the technique resource '${techniqueResourceId.displayPath}'") {
+        for {
+          currentId <- GitFindUtils.findRevTreeFromRevision(repo.db, rev, revisionProvider.currentRevTreeId)
+          optStream <- getMatchingFileStream(
+                         currentId,
+                         filenameFilter,
+                         s"Template with id ${techniqueResourceId.displayPath} was not found",
+                         s"There is more than one Technique with name '${techniqueResourceId.name}' which is forbidden. Please check if several categories have that Technique and rename or delete the clones",
+                         s"Technique Template ${techniqueResourceId.displayPath} does not exist"
+                       )
+        } yield optStream
+      }
     )(optStream => effectUioUnit(optStream.map(_.close())))
 
     ZIO.scoped(managed.flatMap(useIt))
@@ -585,29 +599,32 @@ class GitTechniqueReader(
     val prop = new java.util.Properties()
 
     // now, for each potential path, look if the cat or policy
-    // is valid
-    while (tw.next) {
-      // we need to filter out directories
-      if (tw.getNameString == directiveDefaultName) {
-        var is: InputStream = null
-        try {
-          is = db.open(tw.getObjectId(0)).openStream
-          prop.load(is)
-        } catch {
-          case ex: Exception =>
-            TechniqueReaderLoggerPure.logEffect.error(
-              s"Error when trying to load directive default name from '${directiveDefaultName}' No specific default naming rules will be available. ",
-              ex
-            )
-            Map()
-        } finally {
+    try {
+      while (tw.next) {
+        // we need to filter out directories
+        if (tw.getNameString == directiveDefaultName) {
+          var is: InputStream = null
           try {
-            if (is != null) { is.close() }
+            is = db.open(tw.getObjectId(0)).openStream
+            prop.load(is)
           } catch {
-            case ioe: IOException => // ignore
+            case ex: Exception =>
+              TechniqueReaderLoggerPure.logEffect.error(
+                s"Error when trying to load directive default name from '${directiveDefaultName}' No specific default naming rules will be available. ",
+                ex
+              )
+              Map()
+          } finally {
+            try {
+              if (is != null) { is.close() }
+            } catch {
+              case ioe: IOException => // ignore
+            }
           }
         }
       }
+    } finally {
+      tw.close()
     }
     import scala.jdk.CollectionConverters.*
     prop.asScala.toMap

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
@@ -94,10 +94,13 @@ object GitFindUtils extends NamedZioLogger {
 
       val paths = scala.collection.mutable.Set[String]()
 
-      while (tw.next) {
-        paths += tw.getPathString
+      try {
+        while (tw.next) {
+          paths += tw.getPathString
+        }
+      } finally {
+        tw.close()
       }
-      tw.close()
 
       paths.toSet
     }
@@ -126,9 +129,18 @@ object GitFindUtils extends NamedZioLogger {
 
       tw.setRecursive(true)
       tw.reset(revTreeId)
-      var ids = List.empty[ObjectId]
-      while (tw.next) {
-        ids = tw.getObjectId(0) :: ids
+      // the TreeWalk owns an ObjectReader, it must be closed whatever happens. The stream we
+      // return below is opened on another reader, so it stays valid once the walk is done.
+      val ids = {
+        try {
+          var acc = List.empty[ObjectId]
+          while (tw.next) {
+            acc = tw.getObjectId(0) :: acc
+          }
+          acc
+        } finally {
+          tw.close()
+        }
       }
       ids match {
         case Nil      =>
@@ -183,8 +195,13 @@ object GitFindUtils extends NamedZioLogger {
         Inconsistency(s"The reference branch '${revString}' is not found in the Active Techniques Library's git repository").fail
       } else {
         val rw = new RevWalk(db)
-        val id = rw.parseTree(tree).getId
-        rw.dispose
+        val id = {
+          try {
+            rw.parseTree(tree).getId
+          } finally {
+            rw.close()
+          }
+        }
         id.succeed
       }
     }
@@ -221,13 +238,17 @@ object GitFindUtils extends NamedZioLogger {
       tw.setRecursive(true)
       tw.reset(revTreeId)
 
-      while (tw.next) {
-        val path   = tw.getPathString
-        val parent = (new File(path)).getParent
-        if (null != parent) {
-          directories += parent
+      try {
+        while (tw.next) {
+          val path   = tw.getPathString
+          val parent = (new File(path)).getParent
+          if (null != parent) {
+            directories += parent
+          }
+          entries += ((path, Some(GitFindUtils.getManagedFileContent(db, revTreeId, path))))
         }
-        entries += ((path, Some(GitFindUtils.getManagedFileContent(db, revTreeId, path))))
+      } finally {
+        tw.close()
       }
 
       // start by listing all directories, then all content

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRepositoryProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRepositoryProvider.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.domain.logger.GitRepositoryLogger
 import com.normation.zio.*
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.internal.storage.file.FileRepository
+import org.eclipse.jgit.lib.ConfigConstants
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import zio.*
@@ -87,6 +88,35 @@ class GitRepositoryProviderImpl(override val db: Repository, override val rootDi
 
 object GitRepositoryProviderImpl {
 
+  private def buildRepository(root: File): FileRepository = {
+    (new FileRepositoryBuilder().setWorkTree(root.toJava).build).asInstanceOf[FileRepository]
+  }
+
+  /*
+   * Since 7.7, JGit reads `.git/objects/pack/multi-pack-index` when `core.multiPackIndex`
+   * is true, which is the default.
+   *
+   * It seems that this option can cause `MissingObjectException` (see https://issues.rudder.io/issues/29674)
+   * so we want to disable it, esp. since our repositories should remain well below the threshold that makes
+   * multipack needed. More information on ADR `29674`.
+   */
+  private def disableMultiPackIndex(root: File, db: FileRepository): FileRepository = {
+    val config = db.getConfig
+    if (!config.getBoolean(ConfigConstants.CONFIG_CORE_SECTION, ConfigConstants.CONFIG_KEY_MULTIPACKINDEX, true)) {
+      db // already disabled, nothing to do
+    } else {
+      config.setBoolean(ConfigConstants.CONFIG_CORE_SECTION, null, ConfigConstants.CONFIG_KEY_MULTIPACKINDEX, false)
+      config.save()
+      GitRepositoryLogger.logEffect.info(
+        s"Disabling git multi-pack-index ('core.multiPackIndex') on '${root.pathAsString}': JGit does not fall back to " +
+        s"the pack index when the multi-pack-index is incomplete, which makes objects that do exist look missing"
+      )
+      // option is read when the repository is opened, so we need to close/reopen it
+      db.close()
+      buildRepository(root)
+    }
+  }
+
   /**
    * Use the provided full path as the root directory for given git provider.
    */
@@ -118,7 +148,7 @@ object GitRepositoryProviderImpl {
      */
     def checkGitRepos(root: File): IOResult[Repository] = {
       IOResult.attempt {
-        val db = (new FileRepositoryBuilder().setWorkTree(root.toJava).build).asInstanceOf[FileRepository]
+        val db = buildRepository(root)
         if (!db.getConfig.getFile.exists) {
           GitRepositoryLogger.logEffect.info(
             s"Git directory was not initialised: create a new git repository into folder '${root.pathAsString}' and add all its content as initial release"
@@ -128,7 +158,7 @@ object GitRepositoryProviderImpl {
           git.add.addFilepattern(".").call
           git.commit.setMessage("initial commit").call
         }
-        db
+        disableMultiPackIndex(root, db)
       }
     }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRevisionProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRevisionProvider.scala
@@ -117,8 +117,13 @@ class SimpleGitRevisionProvider(refPath: String, repo: GitRepositoryProvider) ex
       }
 
       val rw = new RevWalk(repo.db)
-      val id = rw.parseTree(treeId).getId
-      rw.dispose
+      val id = {
+        try {
+          rw.parseTree(treeId).getId
+        } finally {
+          rw.close()
+        }
+      }
       id
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/git/GitRepositoryProviderTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/git/GitRepositoryProviderTest.scala
@@ -1,0 +1,101 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.git
+
+import better.files.File
+import com.normation.zio.*
+import org.apache.commons.io.FileUtils
+import org.eclipse.jgit.lib.ConfigConstants
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+
+/*
+ * Test disabling of multipack option by adding the corresponding git config option.
+ */
+@RunWith(classOf[JUnitRunner])
+class GitRepositoryProviderTest extends Specification with AfterAll {
+
+  sequential
+
+  val testRoot: File = File("/tmp/test-git-repository-provider-" + java.lang.System.currentTimeMillis().toString)
+
+  override def afterAll(): Unit = {
+    if (java.lang.System.getProperty("tests.clean.tmp") != "false") {
+      FileUtils.deleteDirectory(testRoot.toJava)
+    }
+  }
+
+  def isMultiPackIndexEnabled(repo: GitRepositoryProvider): Boolean = {
+    repo.db.getConfig.getBoolean(ConfigConstants.CONFIG_CORE_SECTION, ConfigConstants.CONFIG_KEY_MULTIPACKINDEX, true)
+  }
+
+  def newRepoDir(name: String): File = {
+    val dir = testRoot / name
+    dir.createDirectories()
+    (dir / "some-file.txt").writeText("some content")
+    dir
+  }
+
+  "a git repository created by Rudder" should {
+    "have the multi-pack-index disabled" in {
+      val dir  = newRepoDir("created")
+      val repo = GitRepositoryProviderImpl.make(dir.pathAsString).runNow
+      isMultiPackIndexEnabled(repo) must beFalse
+    }
+  }
+
+  "an existing git repository whose multi-pack-index was (re)enabled" should {
+    "get it disabled again when Rudder opens it, and persist the change" in {
+      val dir = newRepoDir("existing")
+
+      // create the repository, then put the option back to true, as a `git gc` would
+      val created = GitRepositoryProviderImpl.make(dir.pathAsString).runNow
+      created.db.getConfig
+        .setBoolean(ConfigConstants.CONFIG_CORE_SECTION, null, ConfigConstants.CONFIG_KEY_MULTIPACKINDEX, true)
+      created.db.getConfig.save()
+      created.db.close()
+
+      val reopened = GitRepositoryProviderImpl.make(dir.pathAsString).runNow
+
+      (isMultiPackIndexEnabled(reopened) must beFalse) and
+      ((dir / ".git" / "config").contentAsString must contain("multiPackIndex"))
+    }
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/29674

So, this is very strange and I'm not sure I really found the correct culprit after chasing a lot of possibilities. 
It *looks* like setting `core.multiPackIndex` to false made the error stop. But since it was somehow random and non reproducible... Well. We got `org.eclipse.jgit.errors.MissingObjectException` in 9.2 that we didn't before. We switched version of JGit to 7.7, and the big new in 7.7 is the addition of multipack index. A fresh, complex new feature feels like a good culprit. 

So basically, that PR configure our `configuration-repository` with multipack index set to false. 

I made claude find the correct reference in code and check jgit behavior, and it well explains what I was seeing. I used the ref to create an ADR on the choice to disable MPI for us for now. 

That PR also clause others things that could have been the cause (but they are here since ever, so it was unlikely). I let them on 9.2 only, because touching jgit is always a bit scary: 
- close of the open tw that where likely leaking resources at full speed, 
- factor out the logic to find exactly one file and get its content, also closing correctly opened resourced. 