### PR TITLE
Fixes #29648: Wrong change logs result when comming from recent activity id link

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
@@ -231,6 +231,7 @@ case object UnknownEventLogType extends NoRollbackEventLogType {
 case class EventLogRequest(
     start:      Int,
     length:     Int,
+    id:         Option[EventLogRequest.Id],
     search:     Option[EventLogRequest.Search],
     startDate:  Option[Instant],
     endDate:    Option[Instant],
@@ -262,6 +263,7 @@ case class EventLogRequest(
 
 object EventLogRequest {
 
+  final case class Id(value: Int)
   final case class Search(value: String)
   final case class Order(column: Column, dir: Direction)
 
@@ -307,6 +309,7 @@ object EventLogRequest {
     new EventLogRequest(
       start = 0,
       length = 25,
+      id = None,
       search = None,
       startDate = None,
       endDate = None,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
@@ -340,12 +340,14 @@ object EventLogJdbcRepository {
         .flatMap(p => p.exclude.map(nec => fragments.notIn(fr"eventtype", nec.map(_.serialize))))
     }
 
+    val id = filter.flatMap(f => f.id).map(id => fr"id = ${id.value}")
+
     val search = filter.flatMap(f => f.search).flatMap(toFragment)
 
     val tenant = TenantSql.readerScopeFragment(readerScope, "securitytag")
 
     val where =
-      Fragments.whereAndOpt(interval, includePrincipals, excludePrincipals, includeTypes, excludeTypes, search, tenant)
+      Fragments.whereAndOpt(interval, includePrincipals, excludePrincipals, includeTypes, excludeTypes, search, tenant, id)
 
     val fromWithSearchFragment = {
       fr"""

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepositoryTest.scala
@@ -142,6 +142,13 @@ class EventLogJdbcRepositoryTest extends Specification with IOChecker with DBCom
       )
     )
   )
+  check(
+    EventLogJdbcRepository.getEventLogCountSQL(
+      Some(
+        defaultFilter.copy(id = Some(EventLogRequest.Id(value = 1)))
+      )
+    )
+  )
   check(EventLogJdbcRepository.getEventLogByCriteriaSQL(None))
   check(EventLogJdbcRepository.getEventLogByCriteriaSQL(Some(defaultFilter)))
 
@@ -175,6 +182,6 @@ class EventLogJdbcRepositoryTest extends Specification with IOChecker with DBCom
     )
   )
 
-  def defaultFilter = EventLogRequest(0, 10, None, None, None, None, None, None)
+  def defaultFilter = EventLogRequest(0, 10, None, None, None, None, None, None, None)
 
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
@@ -132,6 +132,7 @@ final case class RestEventLogFilter(
     draw:       Int,
     start:      Int,
     length:     Int,
+    id:         Option[EventLogRequest.Id],
     search:     Option[EventLogRequest.Search],
     startDate:  Option[LocalDateTime],
     endDate:    Option[LocalDateTime],
@@ -143,6 +144,7 @@ final case class RestEventLogFilter(
     EventLogRequest(
       start,
       length,
+      id,
       search,
       startDate.map(_.toInstant(ZoneOffset.UTC)),
       endDate.map(_.toInstant(ZoneOffset.UTC)),
@@ -159,6 +161,7 @@ object RestEventLogFilter  {
   implicit val eventLogTypeDecoder: JsonDecoder[EventLogType] =
     JsonDecoder[String].mapOrFail(t => EventTypeFactory.get(t).toRight(s"Type ${t} doesn't exist"))
 
+  implicit val idDecoder:                 JsonDecoder[Id]                        = DeriveJsonDecoder.gen[Id]
   implicit val searchDecoder:             JsonDecoder[Search]                    = DeriveJsonDecoder.gen[Search]
   implicit val columnDecoder:             JsonDecoder[Column]                    = JsonDecoder[Int].mapOrFail(Column.fromId)
   implicit val directionDecoder:          JsonDecoder[Direction]                 = JsonDecoder[String].mapOrFail(Direction.parse)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ActivityTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Activity/ActivityTable.elm
@@ -17,34 +17,30 @@ initTable (ContextPath contextPath) timezone =
     let
         {-
            Add a link on the id to navigate to the detail of this activity log on change log page.
-           Build the json parameters to query on this activity log with the directive id as search value and activity
-           date as start date:
+           Build the json parameters to query on this activity log with the log id.
            {
+             "id":{"value":1234,"regex":false,"fixed":[]},
+             "draw":1,
              "start":0,
-             "length":5,
-             "search":{"value":"123e4567-e89b-12d3-a456-426614174000","regex":false,"fixed":[]},
-             "startDate":"2026-07-29 10:49:48",
-             "draw":1
+             "length":5
            }
         -}
         idWithLink : Activity -> Html msg
         idWithLink activity =
             let
-                search =
+                id =
                     object
-                        [ ( "value", activity.id |> String.fromInt |> string )
+                        [ ( "value", activity.id |> int )
                         , ( "regex", bool False )
                         , ( "fixed", list bool [] )
                         ]
 
                 json =
                     object
-                        [ ( "search", search )
-                        , ( "startDate", string (posixToStringWithHoursMinutesAndSecondsTo0 timezone activity.date) )
-                        , ( "endDate", string (posixToStringWithoutTimeZoneOffset timezone activity.date) )
+                        [ ( "id", id )
                         , ( "draw", int 1 )
                         , ( "start", int 0 )
-                        , ( "length", int 10 )
+                        , ( "length", int 5 )
                         ]
                         |> encode 0
             in

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/changeLogs.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/changeLogs.js
@@ -58,7 +58,7 @@ function createEventLogTable(gridId, data, contextPath, refresh, serverTimezone)
      * change logs will be filled from the html form.
      *
      * If the change log page is accessed by the same url with # fragment :
-     * http://localhost:8081/rudder-web/secure/configurationManager/changeLogs#{"search":{"value":"3278","regex":false,"fixed":[]},"startDate":"2026-07-30 00:00:00","endDate":"2026-07-30 17:16:37","draw":1,"start":0,"length":10 }
+     * http://localhost:8081/rudder-web/secure/configurationManager/changeLogs#{"id":{"value":3278,"regex":false,"fixed":[]},"draw":1,"start":0,"length":10 }
      * then the filter criteria will be filled from this json fragment.
      * The use case is the recent activity table provide links for each activity to navigate to the details in the
      * change log page.
@@ -120,6 +120,9 @@ function createEventLogTable(gridId, data, contextPath, refresh, serverTimezone)
            d.endDate = $(".pickEndInput").val()
          } else {
            d.endDate = filterCriteria.endDate
+         }
+         if (filterCriteria.id !== undefined) {
+           d.id = filterCriteria.id
          }
          if (filterCriteria.search !== undefined) {
            d.search = filterCriteria.search

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
@@ -119,6 +119,7 @@ class EventListDisplayer(service: EventLogService, staticResourceRewrite: Static
                       0,
                       0,
                       None,
+                      None,
                       startStr.map(_.toInstant),
                       endStr.map(_.toInstant),
                       None,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ChangeLogsViewer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ChangeLogsViewer.scala
@@ -65,6 +65,7 @@ class ChangeLogsViewer extends SecureDispatchSnippet with Loggable {
       None,
       None,
       None,
+      None,
       Some(EventLogRequest.Order(ID, Direction.Desc)),
       None
     )


### PR DESCRIPTION
https://issues.rudder.io/issues/29648

Previously the query to get the event log from the Recent Activity was using the full text search feature with a small date range, which is flaky and sometimes caused some bugs, we could have more that one logs or event no logs at all.

Modifications to fix the issue:
- add an id field in the event request object
- modify the sql query to add a eventid=id if the event request id is filled
- change the link on Recent Activity id 
  - remove old full text criteria and date
  - pass the id 
- parse the id in the javascript code to call the endpoint with the id as criteria
