### PR TITLE
Fixes #28879: LastPass extension breaks node properties

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
@@ -67,7 +67,7 @@ view model =
                         [ label [ for "newPropName", class "fw-bold" ] [ text "Add a new property:" ]
                         , div [ class "input-group has-validation align-items-start" ]
                             [ input
-                                [ placeholder "Name"
+                                [ placeholder "Property name"
                                 , class
                                     ("form-control input-key"
                                         ++ (if (checkEmptyName && checkPristineName) || checkAlreadyUsedName then


### PR DESCRIPTION
https://issues.rudder.io/issues/28879

It seems like LastPass looks at the placeholders for the field to know whether the extension should be enabled on that field. In this instance, the placeholder "Name" seems to indicate that the field could be saved with LastPass, while the placeholder "Property name" disables LastPass on the field.

<img width="940" height="70" alt="image" src="https://github.com/user-attachments/assets/1f566cb7-4891-4139-b69f-23215d165e8b" />
