### PR TITLE
Fixes #29682: It is possible to override the rudder node property with a String property, which cannot be modified or deleted

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -1329,7 +1329,7 @@ object JsonResponseObjects {
             s.prop.prop.value,
             s.nonEmptyDescription,
             s.prop.prop.inheritMode,
-            s.prop.prop.provider,
+            s.provider,
             parents,
             Some(hierarchyStatus),
             Some(origval)
@@ -1603,8 +1603,12 @@ object JsonResponseObjects {
 
     def inheritMode: Option[InheritMode] = property.resolvedValue.inheritMode
 
-    def description:           String                   = property.resolvedValue.description
-    def provider:              Option[PropertyProvider] = property.resolvedValue.provider
+    def description: String = property.resolvedValue.description
+
+    /**
+     * It needs to be property's one to avoid https://issues.rudder.io/issues/26191
+     */
+    def provider:              Option[PropertyProvider] = property.value.provider
     def hasChildTypeConflicts: Boolean
 
     def nonEmptyDescription: Option[String] = Some(description).filter(_.nonEmpty)
@@ -1617,6 +1621,8 @@ object JsonResponseObjects {
 
     override def errorMessage:          Option[String] = None
     override def hasChildTypeConflicts: Boolean        = false
+
+    override def provider: Option[PropertyProvider] = prop.prop.provider
 
     /**
      * The hierarchy of the main property, not the one as seen by the descendants (parentsInheritedProps)
@@ -1650,7 +1656,10 @@ object JsonResponseObjects {
         prop.hierarchy,
         Some("Conflicting types in inherited node properties"),
         hasChildTypeConflicts = true
-      ) {}
+      ) {
+    // a type conflict does not change who owns the property: keep the inherited/overridden information
+    override def provider: Option[PropertyProvider] = prop.prop.provider
+  }
 
   object InheritedPropertyStatus {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -205,7 +205,7 @@ sealed trait GenericProperty[P <: GenericProperty[?]] {
   def config: Config
   def fromConfig(v: Config): P
 
-  final def name: String           = config.getString(NAME)
+  final def name: String           = GenericProperty.getName(config)
   final def rev:  Option[Revision] = {
     if (config.hasPath(REV_ID)) Some(Revision(config.getString(REV_ID)))
     else None
@@ -216,10 +216,7 @@ sealed trait GenericProperty[P <: GenericProperty[?]] {
     case Some(r)                             => s"${name}+${r.value}"
   }
 
-  final def value: ConfigValue = {
-    if (config.hasPath(VALUE)) config.getValue(VALUE)
-    else ConfigValueFactory.fromAnyRef("")
-  }
+  final def value: ConfigValue = GenericProperty.getValue(config)
 
   final def provider: Option[PropertyProvider] = {
     // optional, default "rudder"
@@ -227,10 +224,7 @@ sealed trait GenericProperty[P <: GenericProperty[?]] {
     else None
   }
 
-  final def description: String = {
-    if (config.hasPath(GenericProperty.DESCRIPTION)) config.getString(GenericProperty.DESCRIPTION)
-    else ""
-  }
+  final def description: String = GenericProperty.getDescription(config)
 
   final def inheritMode: Option[InheritMode] = {
     GenericProperty.getMode(config)
@@ -241,10 +235,7 @@ sealed trait GenericProperty[P <: GenericProperty[?]] {
     else None
   }
 
-  final def visibility: Visibility = {
-    if (config.hasPath(VISIBILITY)) Visibility.withNameOption(config.getString(VISIBILITY)).getOrElse(Visibility.default)
-    else Visibility.default
-  }
+  final def visibility: Visibility = GenericProperty.getVisibility(config)
 
   final def security: Option[SecurityTag] = {
     if (config.hasPath(SECURITY)) config.getString(SECURITY).fromJson[SecurityTag].toOption
@@ -301,6 +292,21 @@ object GenericProperty {
   val INHERIT_MODE = "inheritMode" // options: inheritance mode
   val VISIBILITY   = "visibility"  // optional, if missing Visibility.default
   val SECURITY     = "security"    // optional, if missing None
+
+  // readers of the parts of a property, shared by the properties themselves and their resolved value
+  def getName(config: Config): String = config.getString(NAME)
+  def getValue(config: Config):       ConfigValue = {
+    if (config.hasPath(VALUE)) config.getValue(VALUE)
+    else ConfigValueFactory.fromAnyRef("")
+  }
+  def getDescription(config: Config): String      = {
+    if (config.hasPath(DESCRIPTION)) config.getString(DESCRIPTION)
+    else ""
+  }
+  def getVisibility(config: Config):  Visibility  = {
+    if (config.hasPath(VISIBILITY)) Visibility.withNameOption(config.getString(VISIBILITY)).getOrElse(Visibility.default)
+    else Visibility.default
+  }
 
   def getMode(config: Config):                            Option[InheritMode] = {
     if (config.hasPath(INHERIT_MODE)) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
@@ -8,7 +8,9 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.properties.ParentProperty.VertexParentProperty
 import com.normation.rudder.properties.GroupProp
+import com.typesafe.config.Config
 import com.typesafe.config.ConfigRenderOptions
+import com.typesafe.config.ConfigValue
 import enumeratum.Enum
 import enumeratum.EnumEntry
 import org.apache.commons.text.StringEscapeUtils
@@ -28,6 +30,38 @@ object ParentPropertyKind extends Enum[ParentPropertyKind] with EnumCodec[Parent
   override def values: IndexedSeq[ParentPropertyKind] = findValues
 }
 
+/**
+ * The value of a property once resolved along its hierarchy, ie the composition of the values defined at each of
+ * its levels (see `ParentProperty#resolvedValue`).
+ *
+ * Contrary to the properties it is composed of, a resolved value belongs to nobody: composing values does not
+ * compose their providers (see https://issues.rudder.io/issues/29682).
+
+ * The other metadata (description, visibility, inherit mode, security tags) are inherited along the hierarchy:
+ * the most specific level defining one wins.
+ */
+final case class ResolvedProperty private (private[properties] val config: Config) {
+  def name:        String              = GenericProperty.getName(config)
+  def value:       ConfigValue         = GenericProperty.getValue(config)
+  def description: String              = GenericProperty.getDescription(config)
+  def visibility:  Visibility          = GenericProperty.getVisibility(config)
+  def inheritMode: Option[InheritMode] = GenericProperty.getMode(config)
+}
+
+object ResolvedProperty {
+
+  /** A property which does not override anything resolves to itself, minus its provider */
+  def from(property: GenericProperty[?]): ResolvedProperty = build(property.config)
+
+  /** Compose the value overriding a resolved one with it, according to the inherit mode of the overridden one */
+  def resolve(overridden: ResolvedProperty, overriding: GenericProperty[?]): ResolvedProperty = {
+    build(GenericProperty.mergeConfig(overridden.config, overriding.config)(using overridden.inheritMode))
+  }
+
+  // the only place where a resolved value is built: merging keeps everything but the value of the parents
+  private def build(config: Config): ResolvedProperty = ResolvedProperty(config.withoutPath(GenericProperty.PROVIDER))
+}
+
 /*
  * A property with its inheritance context as a parent of some other property:
  * - key / provider
@@ -41,7 +75,7 @@ sealed trait ParentProperty[P <: GenericProperty[?]] {
   def id:            String
   def name:          String
   def value:         GenericProperty[P]
-  def resolvedValue: GenericProperty[P]
+  def resolvedValue: ResolvedProperty
 }
 
 object ParentProperty {
@@ -53,12 +87,11 @@ object ParentProperty {
       override val value: NodeProperty,
       parentProperty:     Option[VertexParentProperty[?]]
   ) extends ParentProperty[NodeProperty] {
-    override val kind:          ParentPropertyKind            = ParentPropertyKind.Node
-    override def id:            String                        = nodeId.value
-    override val resolvedValue: GenericProperty[NodeProperty] = parentProperty match {
-      case None    => value
-      case Some(v) =>
-        NodeProperty(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(using v.resolvedValue.inheritMode))
+    override val kind:          ParentPropertyKind = ParentPropertyKind.Node
+    override def id:            String             = nodeId.value
+    override val resolvedValue: ResolvedProperty   = parentProperty match {
+      case None    => ResolvedProperty.from(value)
+      case Some(v) => ResolvedProperty.resolve(v.resolvedValue, value)
     }
 
   }
@@ -74,21 +107,20 @@ object ParentProperty {
       override val value: GroupProperty,
       parentProperty:     Option[VertexParentProperty[?]]
   ) extends VertexParentProperty[GroupProperty] {
-    override val kind:          ParentPropertyKind             = ParentPropertyKind.Group
-    override def id:            String                         = groupId.serialize
-    override val resolvedValue: GenericProperty[GroupProperty] = parentProperty match {
-      case None    => value
-      case Some(v) =>
-        GroupProperty(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(using v.resolvedValue.inheritMode))
+    override val kind:          ParentPropertyKind = ParentPropertyKind.Group
+    override def id:            String             = groupId.serialize
+    override val resolvedValue: ResolvedProperty   = parentProperty match {
+      case None    => ResolvedProperty.from(value)
+      case Some(v) => ResolvedProperty.resolve(v.resolvedValue, value)
     }
   }
 
   // a global parameter has the same name as property so no need to be specific for name
   final case class Global(override val value: GlobalParameter) extends VertexParentProperty[GlobalParameter] {
-    override val name:          String                           = value.name
-    override def id:            String                           = value.name
-    override val kind:          ParentPropertyKind               = ParentPropertyKind.Global
-    override val resolvedValue: GenericProperty[GlobalParameter] = value
+    override val name:          String             = value.name
+    override def id:            String             = value.name
+    override val kind:          ParentPropertyKind = ParentPropertyKind.Global
+    override val resolvedValue: ResolvedProperty   = ResolvedProperty.from(value)
   }
 }
 
@@ -103,9 +135,11 @@ sealed trait PropertyHierarchy {
 
 case class NodePropertyHierarchy(id: NodeId, override val hierarchy: ParentProperty[?])             extends PropertyHierarchy {
   override lazy val prop: GenericProperty[?] = hierarchy match {
-    case n: ParentProperty.Node =>
-      val prop = NodeProperty(hierarchy.resolvedValue.config)
-      if (n.parentProperty.isEmpty) prop else prop.withProvider(GroupProp.OVERRIDE_PROVIDER)
+    // the node defines that property and does not override anything: it is that property, provider included
+    case n: ParentProperty.Node if n.parentProperty.isEmpty =>
+      n.value
+    case _: ParentProperty.Node                             =>
+      NodeProperty(hierarchy.resolvedValue.config).withProvider(GroupProp.OVERRIDE_PROVIDER)
     case _ =>
       NodeProperty(hierarchy.resolvedValue.config)
         .withProvider(GroupProp.INHERITANCE_PROVIDER)
@@ -114,9 +148,11 @@ case class NodePropertyHierarchy(id: NodeId, override val hierarchy: ParentPrope
 }
 case class GroupPropertyHierarchy(id: NodeGroupId, override val hierarchy: VertexParentProperty[?]) extends PropertyHierarchy {
   override lazy val prop: GenericProperty[?] = hierarchy match {
-    case g: ParentProperty.Group if g.groupId == id =>
-      val prop = GroupProperty(hierarchy.resolvedValue.config)
-      if (g.parentProperty.isEmpty) prop else prop.withProvider(GroupProp.OVERRIDE_PROVIDER)
+    // the group defines that property and does not override anything: it is that property, provider included
+    case g: ParentProperty.Group if g.groupId == id && g.parentProperty.isEmpty =>
+      g.value
+    case g: ParentProperty.Group if g.groupId == id                             =>
+      GroupProperty(hierarchy.resolvedValue.config).withProvider(GroupProp.OVERRIDE_PROVIDER)
     case _ =>
       GroupProperty(hierarchy.resolvedValue.config)
         .withProvider(GroupProp.INHERITANCE_PROVIDER)
@@ -143,7 +179,7 @@ sealed trait PropertyHierarchySpecificError extends PropertyHierarchyError {
    * a hierarchy of inherited properties from parents that lead to the error,
    * and an error message
    */
-  def propertiesErrors: Map[String, (GenericProperty[?], NonEmptyChunk[ParentProperty[?]], String)]
+  def propertiesErrors: Map[String, (ResolvedProperty, NonEmptyChunk[ParentProperty[?]], String)]
 }
 
 object PropertyHierarchyError {
@@ -167,7 +203,7 @@ object PropertyHierarchyError {
 
   // There are conflicts by node property
   case class PropertyHierarchySpecificInheritanceConflicts(
-      conflicts: Map[GenericProperty[?], NonEmptyChunk[VertexParentProperty[?]]]
+      conflicts: Map[ResolvedProperty, NonEmptyChunk[VertexParentProperty[?]]]
   ) extends PropertyHierarchySpecificError {
     override def toString(): String = debugString
 
@@ -199,7 +235,7 @@ object PropertyHierarchyError {
     }
 
     // the map needs to be evaluated eagerly to get all property errors at once and atomic checks
-    override val propertiesErrors: Map[String, (GenericProperty[?], NonEmptyChunk[ParentProperty[?]], String)] = {
+    override val propertiesErrors: Map[String, (ResolvedProperty, NonEmptyChunk[ParentProperty[?]], String)] = {
       conflicts.map {
         case (k, props) =>
           (
@@ -209,7 +245,7 @@ object PropertyHierarchyError {
       }
     }
 
-    private def conflictMessage(prop: GenericProperty[?], conflicts: NonEmptyChunk[ParentProperty[?]]): String = {
+    private def conflictMessage(prop: ResolvedProperty, conflicts: NonEmptyChunk[ParentProperty[?]]): String = {
       def inheritanceName(p: ParentProperty[?]): String = {
         p match {
           case n: ParentProperty.Node =>
@@ -239,7 +275,7 @@ object PropertyHierarchyError {
      * Represent a single failure from a property and the conflicting inheritance lines
      */
     def one(
-        prop:    GenericProperty[?],
+        prop:    ResolvedProperty,
         parents: NonEmptyChunk[VertexParentProperty[?]]
     ): PropertyHierarchySpecificInheritanceConflicts = {
       PropertyHierarchySpecificInheritanceConflicts(

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api_inherited_prop/global_group_param.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api_inherited_prop/global_group_param.yml
@@ -106,7 +106,8 @@ response:
             "properties":[
               {"name":"stringParam","value":"string","inheritMode":"map","provider":"datasources"},
               {"name":"jsonParam","value":{"array":[5,6],"group":"string","json":{"g1":"g1"}}},
-              {"name":"badOverrideType","value" : {"now" :"a json"}}
+              {"name":"badOverrideType","value" : {"now" :"a json"}},
+              {"name":"rudder","value":"a string"}
             ],
             "target":"group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
             "system":false
@@ -136,6 +137,7 @@ response:
                   "now" : "a json"
                 },
                 "description" : "a string at first",
+                "provider" : "overridden",
                 "hierarchy" : {
                   "kind" : "group",
                   "name" : "Real nodes",
@@ -222,18 +224,32 @@ response:
               },
               {
                 "name":"rudder",
-                "value":{ "compliance_expiration_policy":{"mode":"expire_immediately"} },
+                "value":"a string",
                 "description":"rudder system config",
-                "provider":"inherited",
+                "provider":"overridden",
                 "hierarchy":{
-                  "kind":"global",
-                  "value":{ "compliance_expiration_policy":{"mode":"expire_immediately"} }
+                  "kind":"group",
+                  "name":"Real nodes",
+                  "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "value":"a string",
+                  "resolvedValue":"a string",
+                  "parent":{
+                    "kind":"global",
+                    "value":{ "compliance_expiration_policy":{"mode":"expire_immediately"} }
+                  }
                 },
                 "hierarchyStatus":{
-                  "hasChildTypeConflicts":false,
-                  "fullHierarchy":{"kind":"global","valueType":"Object"}
+                  "hasChildTypeConflicts":true,
+                  "fullHierarchy":{
+                    "kind":"group",
+                    "name":"Real nodes",
+                    "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                    "valueType":"String",
+                    "parent":{"kind":"global","valueType":"Object"}
+                  },
+                  "errorMessage":"Conflicting types in inherited node properties"
                 },
-                "origval":{ "compliance_expiration_policy":{"mode":"expire_immediately"} }
+                "origval":"a string"
               },
               {
                 "name":"stringParam",
@@ -301,6 +317,7 @@ response:
                   "now":"a json"
                 },
                "description":"a string at first",
+               "provider":"overridden",
                "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"a string\"</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"now\" : \"a json\"\n}\n</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : true,
@@ -380,26 +397,25 @@ response:
               },
               {
                 "name":"rudder",
-                "value" : {
-                  "compliance_expiration_policy" : {
-                    "mode":"expire_immediately"
-                  }
-                },
+                "value":"a string",
                "description":"rudder system config",
-                "provider":"inherited",
-               "hierarchy":"<p>from <b>Global parameter </b>:<pre>{\n    \"compliance_expiration_policy\" : {\n        \"mode\" : \"expire_immediately\"\n    }\n}\n</pre></p>",
+                "provider":"overridden",
+               "hierarchy":"<p>from <b>Global parameter </b>:<pre>{\n    \"compliance_expiration_policy\" : {\n        \"mode\" : \"expire_immediately\"\n    }\n}\n</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>\"a string\"</pre></p>",
                 "hierarchyStatus" : {
-                  "hasChildTypeConflicts" : false,
+                  "hasChildTypeConflicts" : true,
                  "fullHierarchy" : {
-                   "kind":"global",
-                   "valueType":"Object"
-                 }
+                   "kind":"group",
+                   "name":"Real nodes",
+                   "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                   "valueType":"String",
+                   "parent" : {
+                      "kind":"global",
+                      "valueType":"Object"
+                    }
+                 },
+                  "errorMessage":"Conflicting types in inherited node properties"
                 },
-                "origval" : {
-                  "compliance_expiration_policy" : {
-                    "mode":"expire_immediately"
-                  }
-                }
+                "origval":"a string"
               },
               {
                 "name":"stringParam",
@@ -494,7 +510,8 @@ response:
             "properties":[
               {"name":"stringParam","value":"string","inheritMode":"map","provider":"datasources"},
               {"name":"jsonParam","value":{"array":[5,6],"group":"string","json":{"g1":"g1"}}},
-              {"name":"badOverrideType","value" : {"now" :"a json"}}
+              {"name":"badOverrideType","value" : {"now" :"a json"}},
+              {"name":"rudder","value":"a string"}
             ],
             "target":"group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
             "system":false
@@ -662,6 +679,7 @@ response:
                 "now":"a json"
               },
              "description":"a string at first",
+              "provider":"inherited",
              "hierarchy" : {
                "kind":"group",
                "name":"Real nodes",
@@ -800,33 +818,39 @@ response:
             },
             {
               "name":"rudder",
-              "value" : {
-                "compliance_expiration_policy" : {
-                  "mode":"expire_immediately"
-                }
-              },
+              "value":"a string",
              "description":"rudder system config",
               "provider":"inherited",
              "hierarchy" : {
-               "kind":"global",
-               "value" : {
-                 "compliance_expiration_policy" : {
-                   "mode":"expire_immediately"
+               "kind":"group",
+               "name":"Real nodes",
+               "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+               "value":"a string",
+               "resolvedValue":"a string",
+               "parent" : {
+                 "kind":"global",
+                 "value" : {
+                   "compliance_expiration_policy" : {
+                     "mode":"expire_immediately"
+                    }
                   }
                 }
              },
               "hierarchyStatus" : {
-                "hasChildTypeConflicts" : false,
+                "hasChildTypeConflicts" : true,
                "fullHierarchy" : {
-                 "kind":"global",
-                 "valueType":"Object"
-               }
+                 "kind":"group",
+                 "name":"Real nodes",
+                 "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                 "valueType":"String",
+                 "parent" : {
+                   "kind":"global",
+                   "valueType":"Object"
+                 }
+               },
+                "errorMessage":"Conflicting types in inherited node properties"
               },
-              "origval" : {
-                "compliance_expiration_policy" : {
-                  "mode":"expire_immediately"
-                }
-              }
+              "origval":"a string"
             },
             {
               "name":"stringParam",

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
@@ -95,6 +95,11 @@ class TestInheritedProperties extends ZIOSpecDefault {
     )
     .getOrElse(null) // for test
 
+  // a string overriding the object value of the `rudder` global parameter, which is owned by the `system` provider:
+  // an inconsistent hierarchy that must nonetheless be reported as `overridden`, else it can not be corrected
+  // anymore. See https://issues.rudder.io/issues/29682
+  val gRudderProp: GroupProperty = GroupProperty("rudder", GitVersion.DEFAULT_REV, "a string".toConfigValue, None, None)
+
   import com.softwaremill.quicklens.*
 
   implicit val qc: QueryContext  = QueryContext.testQC
@@ -103,7 +108,7 @@ class TestInheritedProperties extends ZIOSpecDefault {
   val g0Id: NodeGroupId = restTestSetUp.mockNodeGroups.g0.id
   (for {
     g <- restTestSetUp.mockNodeGroups.groupsRepo.getNodeGroupOpt(g0Id).notOptional("test")
-    up = g._1.modify(_.properties).using(_.appended(gProp))
+    up = g._1.modify(_.properties).using(_.appendedAll(List(gProp, gRudderProp)))
     _ <- restTestSetUp.mockNodeGroups.groupsRepo.update(up)
     _ <- restTestSetUp.mockNodeGroups.propService.updateAll() // the properties also need to be recomputed after group is updated
   } yield ()).runNow

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
@@ -270,3 +270,38 @@ getPossibleFormatsFromPropertyName model propertyName =
     in
     mergedValueTypes
         |> Maybe.withDefault []
+
+
+{-| Check if a property has a value defined at the leaf-node place ("own" value)
+-}
+hasOwnValue : Model -> Property -> Bool
+hasOwnValue model property =
+    case property.hierarchyStatus of
+        Just hierarchyStatus ->
+            case hierarchyStatus.fullHierarchy of
+                ParentGlobal _ ->
+                    False
+
+                ParentGroup prop ->
+                    prop.id == model.nodeId
+
+                ParentNode prop ->
+                    prop.id == model.nodeId
+
+        Nothing ->
+            -- without any inheritance information, the only possible value is the one of the object itself
+            True
+
+
+{-| A property managed by a provider (the inventory, a plugin like datasources, Rudder itself, ...) can only be
+changed by it. `inherited` and `overridden` are not real providers, they only tell how the displayed value is
+built along the hierarchy.
+-}
+isManagedByProvider : Property -> Bool
+isManagedByProvider property =
+    case property.provider of
+        Just provider ->
+            provider /= "inherited" && provider /= "overridden"
+
+        Nothing ->
+            False

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
@@ -357,7 +357,7 @@ displayNodePropertyRow model =
                 editedProperty =
                     Dict.get p.name model.ui.editedProperties
 
-                ( providerBadge, editRight, deleteRight ) =
+                providerBadge =
                     case p.provider of
                         Just pr ->
                             let
@@ -372,7 +372,7 @@ displayNodePropertyRow model =
                                         _ ->
                                             "<h4 class='tags-tooltip-title'>" ++ pr ++ "</h4> <div class='tooltip-inner-content'>This property is managed by its provider ‘<b>" ++ pr ++ "</b>’ and can not be modified manually. Check Rudder’s settings to adjust this provider’s configuration.</div>"
                             in
-                            ( span
+                            span
                                 [ class "rudder-label label-provider label-sm bs-tooltip ms-1"
                                 , attribute "data-bs-toggle" "tooltip"
                                 , attribute "data-bs-placement" "right"
@@ -380,12 +380,19 @@ displayNodePropertyRow model =
                                 , title pTitle
                                 ]
                                 [ text pr ]
-                            , pr == "overridden" || pr == "inherited"
-                            , pr == "overridden"
-                            )
 
                         Nothing ->
-                            ( text "", True, True )
+                            text ""
+
+                -- only the provider owning a property can change it. Everything else can be edited: either the
+                -- property has a value on that object, or we can add one that overrides its inherited value.
+                editRight =
+                    not (isManagedByProvider p)
+
+                -- a value set on that object can always be removed there, whatever the hierarchy it overrides:
+                -- see https://issues.rudder.io/issues/26191
+                deleteRight =
+                    editRight && hasOwnValue model p
 
                 isTooLong : Value -> Bool
                 isTooLong value =


### PR DESCRIPTION
https://issues.rudder.io/issues/29682

So, two main problems: 
- 1/ we should never be blocked to edit/delete a self-value we set ourselves in a node. That blocked the possibility to reverse the error once the Bad Thing Happened, 
- 2/ `provider` is not inherited like other things, it doesn't make sens on resolved value, only on the real node/group/global properties. 


1/ was only an UI level (that's why we could workaround via REST API), an so it's corrected their by checking the "own value". 

2/ could have been corrected by "ignoring" the inherithed provider, but I prefered to materialize the fact that a resolve property is something else in a dedicated type without that attribute. It seems to be self-contained to inherited property (and not even in plugins) so it looks ok. 