### PR TITLE
Fixes #29696: Reading nodes at startup must be done in a bulk request

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -366,12 +366,10 @@ object CoreNodeFactRepository {
       callbacks:     Chunk[NodeFactChangeEventCallback],
       savePreChecks: Chunk[NodeFact => IOResult[Unit]] = defaultSavePreChecks // that should really be used apart in some tests
   ): IOResult[CoreNodeFactRepository] = for {
-    _        <- InventoryDataLogger.debug("Getting pending node info for node fact repos")
-    pending  <- storage.getAllPending()(using SelectFacts.none).map(f => (f.id, f.toCore)).runCollect.map(_.toMap)
-    _        <- InventoryDataLogger.debug("Getting accepted node info for node fact repos")
-    accepted <- storage.getAllAccepted()(using SelectFacts.none).map(f => (f.id, f.toCore)).runCollect.map(_.toMap)
-    _        <- InventoryDataLogger.debug("Creating node fact repos")
-    repo     <- make(storage, softByName, tenantRepos, tenantService, pending, accepted, callbacks, savePreChecks)
+    _    <- InventoryDataLogger.debug("Getting node info for node fact repos")
+    all  <- storage.loadAllCoreNodeFacts()
+    _    <- InventoryDataLogger.debug("Creating node fact repos")
+    repo <- make(storage, softByName, tenantRepos, tenantService, all.pending, all.accepted, callbacks, savePreChecks)
   } yield {
     repo
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
@@ -53,6 +53,7 @@ import com.normation.ldap.sdk.LDAPConnectionProvider
 import com.normation.ldap.sdk.LDAPEntry
 import com.normation.ldap.sdk.One
 import com.normation.ldap.sdk.RwLDAPConnection
+import com.normation.ldap.sdk.StreamedSearchResult
 import com.normation.rudder.domain.NodeDit
 import com.normation.rudder.domain.logger.NodeLogger
 import com.normation.rudder.domain.logger.NodeLoggerPure
@@ -283,6 +284,16 @@ object StorageChangeEventDelete {
   }
 }
 
+// make the semantic of the return of loadAllCoreNodeFacts clearer:
+case class AllCoreNodeFacts(
+    pending:  Map[NodeId, CoreNodeFact],
+    accepted: Map[NodeId, CoreNodeFact]
+)
+
+object AllCoreNodeFacts {
+  def empty = AllCoreNodeFacts(Map(), Map())
+}
+
 trait NodeFactStorage {
 
   /*
@@ -310,6 +321,21 @@ trait NodeFactStorage {
 
   def getAllPending()(implicit attrs:  SelectFacts = SelectFacts.default): IOStream[NodeFact]
   def getAllAccepted()(implicit attrs: SelectFacts = SelectFacts.default): IOStream[NodeFact]
+
+  /*
+   * Load every pending/accepted nodes in one go. Used to CodeNodeFactRepository cache initialization.
+   * This method imposes SelectFacts = SelectFacts.none given we want to optimize for the startup scenario.
+   */
+  def loadAllCoreNodeFacts(): IOResult[AllCoreNodeFacts] = {
+    // give a default implementation that matched node-by-node pre-9.1.5 behavior, so that all
+    // mock and testing implementation have at least that behavior.
+    implicit val attrs: SelectFacts = SelectFacts.none
+    for {
+      pending  <- getAllPending().map(f => (f.id, f.toCore)).runCollect.map(_.toMap)
+      accepted <- getAllAccepted().map(f => (f.id, f.toCore)).runCollect.map(_.toMap)
+    } yield AllCoreNodeFacts(pending, accepted)
+
+  }
 }
 
 /*
@@ -327,6 +353,7 @@ object NoopFactStorage extends NodeFactStorage {
   override def getAllAccepted()(implicit @unused attrs: SelectFacts = SelectFacts.default): IOStream[NodeFact] = ZStream.empty
   override def getPending(nodeId:                       NodeId)(implicit attrs: SelectFacts): IOResult[Option[NodeFact]] = None.succeed
   override def getAccepted(nodeId:                      NodeId)(implicit attrs: SelectFacts): IOResult[Option[NodeFact]] = None.succeed
+  override def loadAllCoreNodeFacts(): IOResult[AllCoreNodeFacts] = AllCoreNodeFacts.empty.succeed
 }
 
 /*
@@ -471,7 +498,7 @@ class GitNodeFactStorageImpl(
     gitRepo.rootDirectory / relativePath / AcceptedInventory.name
   )
 
-  // We saving, we must ignore attrs that are "ignored" - ie in that case, if the source list is empty, we take the existing one
+  // When saving, we must ignore attrs that are "ignored" - ie in that case, if the source list is empty, we take the existing one
   // Save does not know about status change. If it's called with a status change, this leads to duplicated data.
   override def save(nodeFact: NodeFact)(implicit attrs: SelectFacts): IOResult[StorageChangeEventSave] = {
     if (nodeFact.rudderSettings.status == RemovedInventory) {
@@ -619,6 +646,9 @@ class GitNodeFactStorageImpl(
 
 object LdapNodeFactStorage {
 
+  // name of the property that turns the bulk loading for cold start off
+  val bulkLoadAtBootProperty = "rudder.facts.bulkLoadAtBoot"
+
   /*
    * We have 3 main places where facts can be stored:
    * - in ou=Nodes,cn=rudder-configuration
@@ -678,7 +708,10 @@ class LdapNodeFactStorage(
     fullInventoryRepository: FullInventoryRepositoryImpl,
     softwareGet:             ReadOnlySoftwareDAO,
     softwareSave:            SoftwareDNFinderAction,
-    uuidGen:                 StringUuidGenerator
+    uuidGen:                 StringUuidGenerator,
+    // whether the node fact cache is filled at boot with a handful of searches instead of node by node
+    // See: https://issues.rudder.io/issues/29696
+    bulkLoadAtBoot:          Boolean = true
 ) extends NodeFactStorage {
 
   // for save, we always store the full node. Since we don't know how to restrict attributes to save
@@ -968,5 +1001,138 @@ class LdapNodeFactStorage(
 
   override def getAllAccepted()(implicit attrs: SelectFacts): IOStream[NodeFact] = {
     getAllNodeFacts(nodeDit.NODES.dn, getAccepted)
+  }
+
+  /*
+   * Bulk load with streaming ldap search.
+   * It can be disabled with `bulkLoadAtBootProperty` set to false.
+   * We only do 3 search (nodes and pending/accepted inventories) and create map of NodeId -> Entry, then
+   * merge them as usual.
+   */
+  override def loadAllCoreNodeFacts(): IOResult[AllCoreNodeFacts] = {
+    if (bulkLoadAtBoot) {
+      // take the read lock since inventories can come, and we want to keep consistency and only proceed them after
+      // initial cache init step
+      NodeLoggerPure.debug(s"Bulk load of node facts ('${LdapNodeFactStorage.bulkLoadAtBootProperty}=true' )") *>
+      nodeLibMutex.readLock(bulkLoadAllCoreNodeFacts())
+    } else {
+      // pre-9.1.5 way of loading all nodes
+      NodeLoggerPure.info(s"Loading node facts node by node ('${LdapNodeFactStorage.bulkLoadAtBootProperty}=false')")
+      *> super.loadAllCoreNodeFacts()
+    }
+  }
+
+  private def bulkLoadAllCoreNodeFacts(): IOResult[AllCoreNodeFacts] = {
+    val nodeAttrs      = NodeInfoService.nodeInfoAttributes
+    // software update needed in addition, see `getFromLdapInfo`
+    val inventoryAttrs = NodeInfoService.nodeInfoAttributes :+ LDAPConstants.A_SOFTWARE_UPDATE
+
+    def searchSubtree[A](con: RwLDAPConnection, baseDN: DN, attrs: Seq[String])(
+        map: LDAPEntry => Either[String, A]
+    ): IOResult[StreamedSearchResult[A]] = {
+      // only search ONE (level) scope: here, we don't need machine or node inventory subtrees like CPU, FS, etc.
+      con.searchStreamed(baseDN, One, ALL, attrs*)(map)
+    }
+
+    def mapWithId(e: LDAPEntry): Either[String, (NodeId, LDAPEntry)] = {
+      e(A_NODE_UUID) match {
+        // it should never happen, but still
+        case None    => Left("") // we actually don't care of special message here
+        case Some(x) => Right((NodeId(x), e))
+      }
+    }
+
+    for {
+      con <- ldap
+
+      // the rudder node entries are not partitioned by status, so one search covers both
+      rudderEntries <- searchSubtree(con, nodeDit.NODES.dn, nodeAttrs)(mapWithId)
+      // log mapping errors
+      _             <- ZIO.when(!rudderEntries.mappingErrors.isEmpty) {
+                         NodeLoggerPure.warn(
+                           s"${rudderEntries.mappingErrors.size} entries have no '${A_NODE_UUID}' attribute and are ignored: ${rudderEntries.mappingErrors
+                               .map(_._1.toString)
+                               .mkString(", ")}"
+                         )
+                       }
+      rudderNodes    = rudderEntries.results.toMap
+
+      accepted <- loadInventories(con, AcceptedInventory, rudderNodes, inventoryAttrs)
+      pending  <- loadInventories(con, PendingInventory, rudderNodes, inventoryAttrs)
+    } yield AllCoreNodeFacts(pending, accepted)
+  }
+
+  /*
+   * Load the inventory part of fact: one search for the inventory node entries
+   * If some machine are not in the correct branch, we get them one by one.
+   */
+  private def loadInventories(
+      con:            RwLDAPConnection,
+      status:         InventoryStatus,
+      rudderNodes:    Map[NodeId, LDAPEntry],
+      inventoryAttrs: Seq[String]
+  ): IOResult[Map[NodeId, CoreNodeFact]] = {
+    val dit = inventoryDitService.getDit(status)
+
+    def machineKey(dn: DN): String = dn.toNormalizedString // more efficient comparison key
+
+    for {
+      t0 <- currentTimeMillis
+
+      inventoryEntries <- con.searchStreamed(dit.NODES.dn, One, ALL, inventoryAttrs*)(Right.apply)
+      machineEntries   <- con.searchStreamed(dit.MACHINES.dn, One, ALL, inventoryAttrs*)(e => Right((machineKey(e.dn), e)))
+      machines          = machineEntries.results.toMap
+
+      // a node can point to a machine that is not in its own status subtree (it happens when an
+      // acceptation only moved part of the entries). Those are fetched one by one
+      strayMachineDns = inventoryEntries.results
+                          .flatMap(_(A_CONTAINER_DN))
+                          .distinct
+                          .filterNot(dn => machines.contains(machineKey(new DN(dn))))
+      _              <- ZIO.when(strayMachineDns.nonEmpty)(
+                          NodeLoggerPure.debug(
+                            s"${strayMachineDns.size} ${status.name} nodes reference a machine that is not in " +
+                            s"'${dit.MACHINES.dn}', fetching them individually"
+                          )
+                        )
+      strayMachines  <-
+        ZIO
+          .foreach(strayMachineDns)(dn => con.get(new DN(dn), inventoryAttrs*).map(_.map((machineKey(new DN(dn)), _))))
+          .map(_.flatten.toMap)
+      allMachines     = machines ++ strayMachines
+
+      facts <- ZIO.foreach(inventoryEntries.results) { inventoryEntry =>
+                 val optFact = for {
+                   id         <- inventoryEntry(A_NODE_UUID).map(NodeId(_))
+                   rudderNode <- rudderNodes.get(id)
+                 } yield (id, rudderNode)
+
+                 optFact match {
+                   // no rudder entry for that inventory, or no id at all: skip
+                   case None                  => None.succeed
+                   case Some((id, nodeEntry)) =>
+                     val machineEntry = inventoryEntry(A_CONTAINER_DN).flatMap(m => allMachines.get(machineKey(new DN(m))))
+                     (for {
+                       info <- nodeMapper.convertEntriesToNodeInfos(nodeEntry, inventoryEntry, machineEntry)
+                       up   <- InventoryMapper.getSoftwareUpdate(inventoryEntry)
+                     } yield {
+                       Some((id, NodeFact.fromCompat(info, Left(status), Seq(), Some(up)).toCore))
+                     }).catchAll { err =>
+                       // continue but warn on log
+                       NodeLoggerPure.warn(
+                         s"Unable to retrieve node with id '${id.value}' from LDAP storage. It will be ignored: ${err.fullMsg}"
+                       ) *> None.succeed
+                     }
+                 }
+               }
+
+      result = facts.flatten.toMap
+      t2    <- currentTimeMillis
+      _     <- NodeLoggerPure.Metrics.info(
+                 s"Loaded ${result.size} ${status.name} node facts in ${t2 - t0} ms " +
+                 s"(${inventoryEntries.results.size} inventory entries, ${allMachines.size} machine entries, " +
+                 s"${inventoryEntries.results.size - result.size} skipped)"
+               )
+    } yield result
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/MockLdapFactStorage.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/MockLdapFactStorage.scala
@@ -138,6 +138,7 @@ class MockLdapFactStorage {
   val softwareGet                 = new ReadOnlySoftwareDAOImpl(inventoryDitService, ldapRo, inventoryMapper)
   val softwareSave                = new NameAndVersionIdFinder("check_name_and_version", ldapRo, inventoryMapper, acceptedDIT)
 
+  // bulk version
   val nodeFactStorage = new LdapNodeFactStorage(
     ldap,
     nodeDit,
@@ -149,6 +150,21 @@ class MockLdapFactStorage {
     softwareGet,
     softwareSave,
     new StringUuidGeneratorImpl()
+  )
+
+  // old node by node version
+  val nodeFactStorageNodeByNode = new LdapNodeFactStorage(
+    ldap,
+    nodeDit,
+    inventoryDitService,
+    ldapMapper,
+    inventoryMapper,
+    new ZioTReentrantLock("node-lock"),
+    ldapFullInventoryRepository,
+    softwareGet,
+    softwareSave,
+    new StringUuidGeneratorImpl(),
+    bulkLoadAtBoot = false
   )
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestLdapNodeFactLoadAll.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestLdapNodeFactLoadAll.scala
@@ -1,0 +1,258 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.facts.nodes
+
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.ldap.core.LDAPConstants
+import com.normation.ldap.sdk.BuildFilter.ALL
+import com.normation.ldap.sdk.One
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.zio.*
+import com.unboundid.ldap.sdk.SearchRequest
+import com.unboundid.ldap.sdk.SearchScope as UnboundidSearchScope
+import java.security.Security
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.runner.*
+import org.specs2.mutable.*
+import org.specs2.runner.*
+import zio.*
+
+/*
+ * Check that both the old pre-9.1.5
+ */
+@RunWith(classOf[JUnitRunner])
+class TestLdapNodeFactLoadAll extends Specification {
+  sequential
+
+  Security.addProvider(new BouncyCastleProvider())
+
+  val mock = new MockLdapFactStorage()
+
+  val bulk:       LdapNodeFactStorage = mock.nodeFactStorage
+  val nodeByNode: LdapNodeFactStorage = mock.nodeFactStorageNodeByNode
+
+  def addEntry(lines: String*): Unit = mock.testServer.add(lines*)
+
+  def rudderNodeEntry(id: String): Seq[String] = Seq(
+    s"dn: nodeId=${id},ou=Nodes,cn=rudder-configuration",
+    "objectClass: top",
+    "objectClass: rudderNode",
+    s"nodeId: ${id}",
+    s"cn: ${id}",
+    "isSystem: false",
+    "isBroken: false",
+    "createTimestamp: 20070101000000Z"
+  )
+
+  def inventoryNodeEntry(id: String, status: String, machineDn: Option[String]): Seq[String] = Seq(
+    s"dn: nodeId=${id},ou=Nodes,ou=${status} Inventories,ou=Inventories,cn=rudder-configuration",
+    "objectClass: top",
+    "objectClass: node",
+    "objectClass: unixNode",
+    "objectClass: linuxNode",
+    "osVersion: 12",
+    "osName: Debian",
+    "osKernelVersion: 6.1.0",
+    s"nodeId: ${id}",
+    s"cn: ${id}",
+    s"nodeHostname: ${id}.normation.com",
+    "inventoryDate: 20260101123456.948Z",
+    "localAdministratorAccountName: root",
+    "policyServerId: root",
+    """agentName: {"agentType":"cfengine-community","version":"9.1.0","securityToken":{"value":"-----BEGIN CERTIFICATE-----\nMIIFSzCCAzOgAwIBAgIUUiS87+meuwydJeAcCKI35Ko7kmowDQYJKoZIhvcNAQEL\n-----END CERTIFICATE-----\n","type":"certificate"},"capabilities":[]}"""
+  ) ++ machineDn.map(dn => s"container: ${dn}").toSeq
+
+  def machineEntry(id: String, status: String): Seq[String] = Seq(
+    s"dn: machineId=${id},ou=Machines,ou=${status} Inventories,ou=Inventories,cn=rudder-configuration",
+    "objectClass: top",
+    "objectClass: device",
+    "objectClass: machine",
+    s"machineId: ${id}",
+    s"cn: ${id}"
+  )
+
+  def loadBoth(): (AllCoreNodeFacts, AllCoreNodeFacts) = {
+    (bulk.loadAllCoreNodeFacts().runNow, nodeByNode.loadAllCoreNodeFacts().runNow)
+  }
+
+  "loading all node facts" should {
+
+    "give the same facts in bulk and node by node, on the sample directory" in {
+      val (AllCoreNodeFacts(bulkPending, bulkAccepted), AllCoreNodeFacts(oneByOnePending, oneByOneAccepted)) = loadBoth()
+
+      // the sample data has more inventory entries than rudder node entries: only the nodes that
+      // have both are facts, and that is what both paths must agree on
+      (bulkAccepted must not be empty) and
+      (bulkAccepted must beEqualTo(oneByOneAccepted)) and
+      (bulkPending must beEqualTo(oneByOnePending))
+    }
+
+    "not invent a fact for an inventory entry that has no rudder node entry" in {
+      addEntry(inventoryNodeEntry("lonely-inventory", "Accepted", None)*)
+
+      val (AllCoreNodeFacts(_, bulkAccepted), AllCoreNodeFacts(_, oneByOneAccepted)) = loadBoth()
+
+      (bulkAccepted.get(NodeId("lonely-inventory")) must beNone) and
+      (bulkAccepted must beEqualTo(oneByOneAccepted))
+    }
+
+    "not invent a fact for a rudder node entry that has no inventory entry" in {
+      addEntry(rudderNodeEntry("lonely-rudder")*)
+
+      val (AllCoreNodeFacts(bulkPending, bulkAccepted), AllCoreNodeFacts(_, oneByOneAccepted)) = loadBoth()
+
+      (bulkAccepted.get(NodeId("lonely-rudder")) must beNone) and
+      (bulkPending.get(NodeId("lonely-rudder")) must beNone) and
+      (bulkAccepted must beEqualTo(oneByOneAccepted))
+    }
+
+    "load pending nodes, which are keyed on the pending inventory subtree" in {
+      addEntry(rudderNodeEntry("pending1")*)
+      addEntry(machineEntry("machine-pending1", "Pending")*)
+      addEntry(
+        inventoryNodeEntry(
+          "pending1",
+          "Pending",
+          Some("machineId=machine-pending1,ou=Machines,ou=Pending Inventories,ou=Inventories,cn=rudder-configuration")
+        )*
+      )
+
+      val (AllCoreNodeFacts(bulkPending, bulkAccepted), AllCoreNodeFacts(oneByOnePending, _)) = loadBoth()
+
+      (bulkPending.get(NodeId("pending1")) must beSome) and
+      // a pending node is not an accepted one
+      (bulkAccepted.get(NodeId("pending1")) must beNone) and
+      (bulkPending must beEqualTo(oneByOnePending))
+    }
+
+    "resolve the machine of a node whose machine entry is not in its own status subtree" in {
+      // that (used to) happen on servers where an acceptation only moved part of the entries: the node is
+      // accepted but its machine stayed in the pending subtree. We should still get it. It will corrected on a
+      // following storage save.
+      addEntry(rudderNodeEntry("stray-machine-node")*)
+      addEntry(machineEntry("machine-stray", "Pending")*)
+      addEntry(
+        inventoryNodeEntry(
+          "stray-machine-node",
+          "Accepted",
+          Some("machineId=machine-stray,ou=Machines,ou=Pending Inventories,ou=Inventories,cn=rudder-configuration")
+        )*
+      )
+
+      val (AllCoreNodeFacts(_, bulkAccepted), AllCoreNodeFacts(_, oneByOneAccepted)) = loadBoth()
+
+      val fact = bulkAccepted.get(NodeId("stray-machine-node"))
+
+      (fact must beSome) and
+      // the machine was found, so its id is the one of the stray entry and not a placeholder
+      (fact.map(_.machine.id.value) must beSome("machine-stray")) and
+      (bulkAccepted must beEqualTo(oneByOneAccepted))
+    }
+
+    "ignore the child entries of a machine" in {
+      // machine entries have children (bios, cpu, memory slots...). The searches are `One` scoped
+      // so those must never be taken for machines, whatever their number.
+      addEntry(rudderNodeEntry("machine-with-elements")*)
+      addEntry(machineEntry("machine-elts", "Accepted")*)
+      addEntry(
+        "dn: biosName=bios1,machineId=machine-elts,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration",
+        "objectClass: top",
+        "objectClass: physicalElement",
+        "objectClass: biosPhysicalElement",
+        "biosName: bios1",
+        "editor: Phoenix Technologies LTD"
+      )
+      addEntry(
+        inventoryNodeEntry(
+          "machine-with-elements",
+          "Accepted",
+          Some("machineId=machine-elts,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration")
+        )*
+      )
+
+      val (AllCoreNodeFacts(_, bulkAccepted), AllCoreNodeFacts(_, oneByOneAccepted)) = loadBoth()
+
+      (bulkAccepted.get(NodeId("machine-with-elements")).map(_.machine.id.value) must beSome("machine-elts")) and
+      (bulkAccepted must beEqualTo(oneByOneAccepted))
+    }
+
+    "never ask the directory for the software of a node" in {
+      val attrs = NodeInfoService.nodeInfoAttributes :+ LDAPConstants.A_SOFTWARE_UPDATE
+
+      val withSoftwareAttribute = (for {
+        con     <- mock.ldap
+        entries <- con.searchStreamed(
+                     mock.acceptedDIT.NODES.dn,
+                     One,
+                     ALL,
+                     attrs*
+                   )(Right.apply)
+      } yield entries.results.filter(_(LDAPConstants.A_SOFTWARE_DN).isDefined)).runNow
+
+      (NodeInfoService.nodeInfoAttributes.contains(LDAPConstants.A_SOFTWARE_DN) must beFalse) and
+      (withSoftwareAttribute must beEmpty)
+    }
+  }
+
+  "a streamed search" should {
+
+    "fail when the directory truncates the result, where a plain search reports and truncates" in {
+      // check that error on SIZE_LIMIT_EXCEEDED are real errors
+      val limited = new SearchRequest(
+        mock.acceptedDIT.NODES.dn.toString,
+        UnboundidSearchScope.ONE,
+        ALL,
+        NodeInfoService.nodeInfoAttributes*
+      )
+      limited.setSizeLimit(1)
+
+      val streamed = (for {
+        con <- mock.ldap
+        res <- con.searchStreamed(limited)(Right.apply).either
+      } yield res).runNow
+
+      val plain = (for {
+        con <- mock.ldap
+        res <- con.search(limited).either
+      } yield res).runNow
+
+      (streamed must beLeft) and
+      (plain must beRight)
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -473,6 +473,12 @@ rudder.facts.repo.writeNodeState=false
 # property to true:
 rudder.facts.repo.historizeNodeChange=false
 
+# At boot, Rudder loads all node facts from LDAP to fill its cache.
+# Set this to 'false' to get back to the node-by-node loading, which is what Rudder did up to 9.1.4.
+# It is only useful if there's warning in the boot sequence related to loading nodes
+# or if you notice missing nodes on restart.
+rudder.facts.bulkLoadAtBoot=true
+
 ###############################
 # Dynamic group configuration  ######################################################
 ###############################

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -743,6 +743,16 @@ object RudderParsedProperties {
     }
   }
 
+  // control the bulk load of node facts from LDAP. Default to true; fasle revert to the
+  // pre-9.1.5 behavior.
+  val RUDDER_NODEFACTS_BULK_LOAD_AT_BOOT: Boolean = {
+    try {
+      config.getBoolean(LdapNodeFactStorage.bulkLoadAtBootProperty)
+    } catch {
+      case ex: Exception => true
+    }
+  }
+
   val RUDDER_DIR_TECHNIQUES:                        String = RUDDER_GIT_ROOT_CONFIG_REPO + "/techniques"
   val RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL:         Int    = config.getInt("rudder.batch.dyngroup.updateInterval") // in minutes
   val RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL: Int    =
@@ -1991,7 +2001,8 @@ object RudderConfigInit {
       deprecated.ldapFullInventoryRepository,
       deprecated.softwareInventoryDAO,
       deprecated.ldapSoftwareSave,
-      stringUuidGenerator
+      stringUuidGenerator,
+      RUDDER_NODEFACTS_BULK_LOAD_AT_BOOT
     )
 
     lazy val getNodeBySoftwareName = new SoftDaoGetNodesBySoftwareName(deprecated.softwareInventoryDAO)

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
@@ -40,6 +40,9 @@ import com.unboundid.ldap.sdk.ReadOnlyLDAPRequest
 import com.unboundid.ldap.sdk.ResultCode
 import com.unboundid.ldap.sdk.ResultCode.*
 import com.unboundid.ldap.sdk.SearchRequest
+import com.unboundid.ldap.sdk.SearchResultEntry
+import com.unboundid.ldap.sdk.SearchResultListener
+import com.unboundid.ldap.sdk.SearchResultReference
 import com.unboundid.ldif.LDIFChangeRecord
 import scala.jdk.CollectionConverters.*
 import zio.*
@@ -49,6 +52,16 @@ import zio.syntax.*
  * Logger for LDAP connection related information.
  */
 object LDAPConnectionLogger extends NamedZioLogger() { def loggerName = "ldap-connection" }
+
+/*
+ * A dedicated type to accumulate.
+ * Since we map along the way to release entries asap, we need a way to also accumulate entry that
+ * where found but for which mapping failed.
+ */
+case class StreamedSearchResult[+A](
+    results:       Chunk[A],
+    mappingErrors: Chunk[(DN, String)]
+)
 
 trait ReadOnlyEntryLDAPConnection {
 
@@ -174,6 +187,40 @@ trait ReadOnlyEntryLDAPConnection {
    */
   def searchSub(baseDn: DN, filter: Filter, attributes: String*): LDAPIOResult[Seq[LDAPEntry]] =
     search(baseDn, Sub, filter, attributes*)
+
+  /**
+   * Like `search`, but entries are mapped as they arrive from the directory instead of being
+   * all accumulated first. For the cases where the result set is big and each entry can be
+   * processed then dropped, so that neither this process nor the directory has to hold the
+   * whole result set.
+   *
+   * Two differences with `search`:
+   * - `onEntry` is called from the connection reader thread, one entry at a time. It must be
+   *   cheap and pure (and so not block on anything, esp. that could wait for this same connection)
+   * - a server side size or time limit makes this fail. `search` reports it and returns the
+   *   truncated result, which is a real error in that case.
+   *
+   * @param sr
+   *   SearchRequest object which define the search operation to send to LDAP directory.
+   *   It must not carry a SearchResultListener, this method sets its own.
+   * @param onEntry
+   *   Mapping applied to each entry as it arrives. If Left, the entry is dropped from `results` and message is
+   *   added to mappingErrors.
+   * @return
+   *   The mapped entries, in the order the directory returned them, and the mapping errors.
+   */
+  def searchStreamed[A](sr: SearchRequest)(onEntry: LDAPEntry => Either[String, A]): LDAPIOResult[StreamedSearchResult[A]]
+
+  /**
+   * `searchStreamed` with the commonly used parameters.
+   * @see searchStreamed
+   * @see search
+   */
+  def searchStreamed[A](baseDn: DN, scope: SearchScope, filter: Filter, attributes: String*)(
+      onEntry: LDAPEntry => Either[String, A]
+  ): LDAPIOResult[StreamedSearchResult[A]] = {
+    searchStreamed(new SearchRequest(baseDn.toString, scope.toUnboundid, filter, attributes*))(onEntry)
+  }
 }
 
 trait WriteOnlyEntryLDAPConnection {
@@ -335,6 +382,52 @@ sealed class RoLDAPConnection(
       case ex: LDAPException                                                =>
         LDAPRudderError
           .BackendException(s"Error during search ${sr.getBaseDN} ${sr.getScope.getName}: ${ex.getDiagnosticMessage}", ex)
+          .fail
+      // catchAll is a lie, but if other kind of exception happens, we want to crash
+      case ex => throw ex
+    }
+  }
+
+  override def searchStreamed[A](
+      sr: SearchRequest
+  )(onEntry: LDAPEntry => Either[String, A]): LDAPIOResult[StreamedSearchResult[A]] = {
+    blocking {
+      // none of these variables escape the scope of that method. They are mutable for memory efficiency.
+      val mapped   = Chunk.newBuilder[A]
+      val errors   = Chunk.newBuilder[(DN, String)]
+      val listener = new SearchResultListener {
+        override def searchEntryReturned(entry: SearchResultEntry): Unit = {
+          val e = LDAPEntry(entry)
+          onEntry(e) match {
+            case Left(err) => errors += ((e.dn, err))
+            case Right(x)  => mapped += x
+          }
+        }
+        override def searchReferenceReturned(reference: SearchResultReference): Unit = ()
+      }
+      val streamed = new SearchRequest(
+        listener,
+        sr.getBaseDN,
+        sr.getScope,
+        sr.getDereferencePolicy,
+        sr.getSizeLimit,
+        sr.getTimeLimitSeconds,
+        sr.typesOnly(),
+        sr.getFilter,
+        sr.getAttributes.toSeq*
+      )
+      sr.getControlList.asScala.foreach(streamed.addControl)
+      backed.search(streamed)
+      StreamedSearchResult(mapped.result(), errors.result())
+    } catchAll {
+      // no `onlyReportOnSearch` here on purpose: a truncated result would silently mean
+      // "these objects do not exist" to whoever asked for the whole set
+      case ex: LDAPException =>
+        LDAPRudderError
+          .BackendException(
+            s"Error during streamed search ${sr.getBaseDN} ${sr.getScope.getName}: ${ex.getDiagnosticMessage}",
+            ex
+          )
           .fail
       // catchAll is a lie, but if other kind of exception happens, we want to crash
       case ex => throw ex


### PR DESCRIPTION
https://issues.rudder.io/issues/29696

The whole idea is to switch from a node-by-node retrieval to a "get all nodes" one. 
It avoid a *lot* of queries (one to get all ids, then 3 per nodes) to only keep 3 (one on nodes branch, and one for pending (resp. accepted) inventories. 

That PR also add a streaming query for LDAP, which should allow to consume less resources during the process. 

We can switch back to previous behavior with a new parameter in rudder-web.properties: `rudder.facts.bulkLoadAtBoot`, true by default. 

Measures on my little instance give ~25% speed up of boot sequence (so certainly a big enhancement for the LDAP loading). 